### PR TITLE
Fix issue #30: add roslaunch testing

### DIFF
--- a/fanuc_driver/CMakeLists.txt
+++ b/fanuc_driver/CMakeLists.txt
@@ -71,6 +71,12 @@ set_target_properties(${PROJECT_NAME}_motion_streaming_interface_bswap
     PREFIX "")
 
 
+if (CATKIN_ENABLE_TESTING)
+    find_package(roslaunch REQUIRED)
+    roslaunch_add_file_check(tests/roslaunch_test.xml)
+endif()
+
+
 install(TARGETS
     ${PROJECT_NAME}_robot_state
     ${PROJECT_NAME}_robot_state_bswap

--- a/fanuc_driver/package.xml
+++ b/fanuc_driver/package.xml
@@ -24,4 +24,6 @@
   <build_depend>industrial_robot_client</build_depend> 
 
   <run_depend>industrial_robot_client</run_depend>
+
+  <test_depend>roslaunch</test_depend>
 </package>

--- a/fanuc_driver/tests/roslaunch_test.xml
+++ b/fanuc_driver/tests/roslaunch_test.xml
@@ -1,0 +1,53 @@
+<launch>
+  <arg name="ip_str" value="127.0.0.1" />
+
+  <group ns="robot_state__">
+    <include file="$(find fanuc_driver)/launch/robot_state.launch">
+      <arg name="robot_ip" value="$(arg ip_str)" />
+      <arg name="use_bswap" value="true" />
+      <arg name="J23_factor" value="0" />
+    </include>
+  </group>
+
+  <group ns="robot_interface_streaming__">
+    <include file="$(find fanuc_driver)/launch/robot_interface_streaming.launch">
+      <arg name="robot_ip" value="$(arg ip_str)" />
+      <arg name="use_bswap" value="true" />
+      <arg name="J23_factor" value="0" />
+    </include>
+  </group>
+
+  <group ns="motion_streaming_interface__">
+    <include file="$(find fanuc_driver)/launch/motion_streaming_interface.launch">
+      <arg name="robot_ip" value="$(arg ip_str)" />
+      <arg name="use_bswap" value="true" />
+      <arg name="J23_factor" value="0" />
+    </include>
+  </group>
+
+
+  <!-- without bswap -->
+  <group ns="robot_state_f__">
+    <include file="$(find fanuc_driver)/launch/robot_state.launch">
+      <arg name="robot_ip" value="$(arg ip_str)" />
+      <arg name="use_bswap" value="false" />
+      <arg name="J23_factor" value="0" />
+    </include>
+  </group>
+
+  <group ns="robot_interface_streaming_f__">
+    <include file="$(find fanuc_driver)/launch/robot_interface_streaming.launch">
+      <arg name="robot_ip" value="$(arg ip_str)" />
+      <arg name="use_bswap" value="false" />
+      <arg name="J23_factor" value="0" />
+    </include>
+  </group>
+
+  <group ns="motion_streaming_interface_f__">
+    <include file="$(find fanuc_driver)/launch/motion_streaming_interface.launch">
+      <arg name="robot_ip" value="$(arg ip_str)" />
+      <arg name="use_bswap" value="false" />
+      <arg name="J23_factor" value="0" />
+    </include>
+  </group>
+</launch>

--- a/fanuc_m10ia_support/CMakeLists.txt
+++ b/fanuc_m10ia_support/CMakeLists.txt
@@ -6,6 +6,11 @@ find_package(catkin REQUIRED)
 
 catkin_package()
 
+if (CATKIN_ENABLE_TESTING)
+    find_package(roslaunch REQUIRED)
+    roslaunch_add_file_check(tests/roslaunch_test.xml)
+endif()
+
 foreach(dir config launch meshes urdf)
    install(DIRECTORY ${dir}/
       DESTINATION ${CATKIN_PACKAGE_SHARE_DESTINATION}/${dir})

--- a/fanuc_m10ia_support/package.xml
+++ b/fanuc_m10ia_support/package.xml
@@ -40,6 +40,8 @@
   <run_depend>fanuc_assets</run_depend>
   <run_depend>fanuc_driver</run_depend>
 
+  <test_depend>roslaunch</test_depend>
+
   <export>
     <architecture_independent />
   </export>

--- a/fanuc_m10ia_support/tests/roslaunch_test.xml
+++ b/fanuc_m10ia_support/tests/roslaunch_test.xml
@@ -1,0 +1,39 @@
+<launch>
+  <arg name="ip_str" value="127.0.0.1" />
+
+  <group ns="load_m10ia__">
+    <include file="$(find fanuc_m10ia_support)/launch/load_m10ia.launch"/>
+  </group>
+
+  <group ns="test_m10ia__">
+    <include file="$(find fanuc_m10ia_support)/launch/test_m10ia.launch"/>
+  </group>
+
+  <group ns="robot_interface_streaming_m10ia__">
+    <include file="$(find fanuc_m10ia_support)/launch/robot_interface_streaming_m10ia.launch">
+      <arg name="robot_ip" value="$(arg ip_str)" />
+    </include>
+  </group>
+
+  <group ns="robot_state_visualize_m10ia__">
+    <include file="$(find fanuc_m10ia_support)/launch/robot_state_visualize_m10ia.launch">
+      <arg name="robot_ip" value="$(arg ip_str)" />
+    </include>
+  </group>
+
+
+  <!-- without bswap -->
+  <group ns="robot_interface_streaming_m10ia_f__">
+    <include file="$(find fanuc_m10ia_support)/launch/robot_interface_streaming_m10ia.launch">
+      <arg name="robot_ip" value="$(arg ip_str)" />
+      <arg name="use_bswap" value="false" />
+    </include>
+  </group>
+
+  <group ns="robot_state_visualize_m10ia_f__">
+    <include file="$(find fanuc_m10ia_support)/launch/robot_state_visualize_m10ia.launch">
+      <arg name="robot_ip" value="$(arg ip_str)" />
+      <arg name="use_bswap" value="false" />
+    </include>
+  </group>
+</launch>

--- a/fanuc_m16ib_support/CMakeLists.txt
+++ b/fanuc_m16ib_support/CMakeLists.txt
@@ -6,6 +6,11 @@ find_package(catkin REQUIRED)
 
 catkin_package()
 
+if (CATKIN_ENABLE_TESTING)
+    find_package(roslaunch REQUIRED)
+    roslaunch_add_file_check(tests/roslaunch_test.xml)
+endif()
+
 foreach(dir config launch meshes urdf)
    install(DIRECTORY ${dir}/
       DESTINATION ${CATKIN_PACKAGE_SHARE_DESTINATION}/${dir})

--- a/fanuc_m16ib_support/package.xml
+++ b/fanuc_m16ib_support/package.xml
@@ -45,6 +45,8 @@
   <run_depend>fanuc_assets</run_depend>
   <run_depend>fanuc_driver</run_depend>
 
+  <test_depend>roslaunch</test_depend>
+
   <export>
     <architecture_independent />
   </export>

--- a/fanuc_m16ib_support/tests/roslaunch_test.xml
+++ b/fanuc_m16ib_support/tests/roslaunch_test.xml
@@ -1,0 +1,39 @@
+<launch>
+  <arg name="ip_str" value="127.0.0.1" />
+
+  <group ns="load_m16ib20__">
+    <include file="$(find fanuc_m16ib_support)/launch/load_m16ib20.launch"/>
+  </group>
+
+  <group ns="test_m16ib20__">
+    <include file="$(find fanuc_m16ib_support)/launch/test_m16ib20.launch"/>
+  </group>
+
+  <group ns="robot_interface_streaming_m16ib20__">
+    <include file="$(find fanuc_m16ib_support)/launch/robot_interface_streaming_m16ib20.launch">
+      <arg name="robot_ip" value="$(arg ip_str)" />
+    </include>
+  </group>
+
+  <group ns="robot_state_visualize_m16ib20__">
+    <include file="$(find fanuc_m16ib_support)/launch/robot_state_visualize_m16ib20.launch">
+      <arg name="robot_ip" value="$(arg ip_str)" />
+    </include>
+  </group>
+
+
+  <!-- without bswap -->
+  <group ns="robot_interface_streaming_m16ib20_f__">
+    <include file="$(find fanuc_m16ib_support)/launch/robot_interface_streaming_m16ib20.launch">
+      <arg name="robot_ip" value="$(arg ip_str)" />
+      <arg name="use_bswap" value="false" />
+    </include>
+  </group>
+
+  <group ns="robot_state_visualize_m16ib20_f__">
+    <include file="$(find fanuc_m16ib_support)/launch/robot_state_visualize_m16ib20.launch">
+      <arg name="robot_ip" value="$(arg ip_str)" />
+      <arg name="use_bswap" value="false" />
+    </include>
+  </group>
+</launch>

--- a/fanuc_m430ia_support/CMakeLists.txt
+++ b/fanuc_m430ia_support/CMakeLists.txt
@@ -6,6 +6,11 @@ find_package(catkin REQUIRED)
 
 catkin_package()
 
+if (CATKIN_ENABLE_TESTING)
+    find_package(roslaunch REQUIRED)
+    roslaunch_add_file_check(tests/roslaunch_test.xml)
+endif()
+
 foreach(dir config launch meshes urdf)
    install(DIRECTORY ${dir}/
       DESTINATION ${CATKIN_PACKAGE_SHARE_DESTINATION}/${dir})

--- a/fanuc_m430ia_support/package.xml
+++ b/fanuc_m430ia_support/package.xml
@@ -44,6 +44,8 @@
   <run_depend>fanuc_assets</run_depend>
   <run_depend>fanuc_driver</run_depend>
 
+  <test_depend>roslaunch</test_depend>
+
   <export>
     <architecture_independent />
   </export>

--- a/fanuc_m430ia_support/tests/roslaunch_test.xml
+++ b/fanuc_m430ia_support/tests/roslaunch_test.xml
@@ -1,0 +1,78 @@
+<launch>
+  <arg name="ip_str" value="127.0.0.1" />
+
+  <group ns="load_m430ia2f__">
+    <include file="$(find fanuc_m430ia_support)/launch/load_m430ia2f.launch"/>
+  </group>
+
+  <group ns="test_m430ia2f__">
+    <include file="$(find fanuc_m430ia_support)/launch/test_m430ia2f.launch"/>
+  </group>
+
+  <group ns="robot_interface_streaming_m430ia2f__">
+    <include file="$(find fanuc_m430ia_support)/launch/robot_interface_streaming_m430ia2f.launch">
+      <arg name="robot_ip" value="$(arg ip_str)" />
+    </include>
+  </group>
+
+  <group ns="robot_state_visualize_m430ia2f__">
+    <include file="$(find fanuc_m430ia_support)/launch/robot_state_visualize_m430ia2f.launch">
+      <arg name="robot_ip" value="$(arg ip_str)" />
+    </include>
+  </group>
+
+
+  <!-- without bswap -->
+  <group ns="robot_interface_streaming_m430ia2f_f__">
+    <include file="$(find fanuc_m430ia_support)/launch/robot_interface_streaming_m430ia2f.launch">
+      <arg name="robot_ip" value="$(arg ip_str)" />
+      <arg name="use_bswap" value="false" />
+    </include>
+  </group>
+
+  <group ns="robot_state_visualize_m430ia2f_f__">
+    <include file="$(find fanuc_m430ia_support)/launch/robot_state_visualize_m430ia2f.launch">
+      <arg name="robot_ip" value="$(arg ip_str)" />
+      <arg name="use_bswap" value="false" />
+    </include>
+  </group>
+
+
+
+
+  <group ns="load_m430ia2p__">
+    <include file="$(find fanuc_m430ia_support)/launch/load_m430ia2p.launch"/>
+  </group>
+
+  <group ns="test_m430ia2p__">
+    <include file="$(find fanuc_m430ia_support)/launch/test_m430ia2p.launch"/>
+  </group>
+
+  <group ns="robot_interface_streaming_m430ia2p__">
+    <include file="$(find fanuc_m430ia_support)/launch/robot_interface_streaming_m430ia2p.launch">
+      <arg name="robot_ip" value="$(arg ip_str)" />
+    </include>
+  </group>
+
+  <group ns="robot_state_visualize_m430ia2p__">
+    <include file="$(find fanuc_m430ia_support)/launch/robot_state_visualize_m430ia2p.launch">
+      <arg name="robot_ip" value="$(arg ip_str)" />
+    </include>
+  </group>
+
+
+  <!-- without bswap -->
+  <group ns="robot_state_visualize_m430ia2p_f__">
+    <include file="$(find fanuc_m430ia_support)/launch/robot_state_visualize_m430ia2p.launch">
+      <arg name="robot_ip" value="$(arg ip_str)" />
+      <arg name="use_bswap" value="false" />
+    </include>
+  </group>
+
+  <group ns="robot_interface_streaming_m430ia2p_f__">
+    <include file="$(find fanuc_m430ia_support)/launch/robot_interface_streaming_m430ia2p.launch">
+      <arg name="robot_ip" value="$(arg ip_str)" />
+      <arg name="use_bswap" value="false" />
+    </include>
+  </group>
+</launch>


### PR DESCRIPTION
This adds roslaunch testing to all pkgs with launchfiles.

All tests are wrapped in conditionals on `CATKIN_ENABLE_TESTING`.
