### PR TITLE
Fix issue #73: shorten Tag Cfg error msg on User Menu

### DIFF
--- a/fanuc_driver/KAREL/ros_relay.kl
+++ b/fanuc_driver/KAREL/ros_relay.kl
@@ -111,6 +111,9 @@ CONST
 
 	MOVERR_OOR   = -1       -- Requested JPOS is out-of-range
 
+	HOST_CTAG_ER = 67144    -- HOST-144 Comm Tag error
+	SEV_ABORT    =  2       -- ABORT severity
+
 
 
 
@@ -164,7 +167,7 @@ BEGIN
 			log_error_a(LOG_PFIX + 'ssock_ctor err:', stat_)
 		ENDIF
 		-- nothing we can do, abort
-		GOTO exit_on_err
+		POST_ERR(HOST_CTAG_ER, '', 0, SEV_ABORT)
 	ENDIF
 
 

--- a/fanuc_driver/KAREL/ros_relay.kl
+++ b/fanuc_driver/KAREL/ros_relay.kl
@@ -56,7 +56,7 @@ PROGRAM ros_relay
 -- 
 --------------------------------------------------------------------------------
 %ALPHABETIZE
-%COMMENT = 'r18'
+%COMMENT = 'r19'
 %NOBUSYLAMP
 %NOLOCKGROUP
 %NOPAUSE = COMMAND + TPENABLE + ERROR
@@ -159,7 +159,7 @@ BEGIN
 	stat_ = ssock_ctor(sock_, RI_TCP_TRAJR, MOTION_TAG)
 	IF (stat_ <> 0) THEN
 		IF (stat_ = TAG_CONF_ERR) THEN
-			log_error_a(LOG_PFIX + 'TAG config error. TAG nr:', MOTION_TAG)
+			log_error_a(LOG_PFIX + 'cfg err, TAG idx:', MOTION_TAG)
 		ELSE
 			log_error_a(LOG_PFIX + 'ssock_ctor err:', stat_)
 		ENDIF

--- a/fanuc_driver/KAREL/ros_state.kl
+++ b/fanuc_driver/KAREL/ros_state.kl
@@ -48,7 +48,7 @@ PROGRAM ros_state
 -- 
 --------------------------------------------------------------------------------
 %ALPHABETIZE
-%COMMENT = 'r15'
+%COMMENT = 'r16'
 %NOBUSYLAMP
 %NOLOCKGROUP
 %NOPAUSE = COMMAND + TPENABLE + ERROR
@@ -142,7 +142,7 @@ BEGIN
 	stat_ = ssock_ctor(sock_, RI_TCP_STATE, STATE_TAG)
 	IF (stat_ <> 0) THEN
 		IF (stat_ = TAG_CONF_ERR) THEN
-			log_error_a(LOG_PFIX + 'TAG config error. TAG nr:', STATE_TAG)
+			log_error_a(LOG_PFIX + 'cfg err, TAG idx:', STATE_TAG)
 		ELSE
 			log_error_a(LOG_PFIX + 'ssock_ctor err:', stat_)
 		ENDIF

--- a/fanuc_driver/KAREL/ros_state.kl
+++ b/fanuc_driver/KAREL/ros_state.kl
@@ -93,6 +93,10 @@ CONST
 	LOOP_HZ = 40
 	-- Number of main loop iterations for each status message
 	STAT_LP_CNT = 10
+	-- HOST-144 Comm Tag error
+	HOST_CTAG_ER = 67144
+	-- ABORT severity
+	SEV_ABORT = 2
 
 
 
@@ -147,7 +151,7 @@ BEGIN
 			log_error_a(LOG_PFIX + 'ssock_ctor err:', stat_)
 		ENDIF
 		-- nothing we can do, abort
-		GOTO exit_on_err
+		POST_ERR(HOST_CTAG_ER, '', 0, SEV_ABORT)
 	ENDIF
 
 


### PR DESCRIPTION
Also posts a (repurposed) error the global ALARM log, causing the program to `ABORT`.
