### PR TITLE
Merge candidate with fixes for various issues

### DIFF
--- a/fanuc_driver/KAREL/libind_log.kl
+++ b/fanuc_driver/KAREL/libind_log.kl
@@ -45,7 +45,7 @@ PROGRAM libind_log
 --------------------------------------------------------------------------------
 %NOLOCKGROUP
 %NOPAUSE= COMMAND + TPENABLE + ERROR
-%COMMENT = 'r1'
+%COMMENT = 'r2'
 
 
 
@@ -130,8 +130,21 @@ END prnt_time
 ROUTINE log_clear
 BEGIN
 	WRITE(CHR(128), CR)
-	FORCE_SPMENU(TP_PANEL, SPI_TPUSER, 1)
+	log_force
 END log_clear
+
+
+
+
+--------------------------------------------------------------------------------
+-- 
+-- Force the USER menu screen
+-- 
+--------------------------------------------------------------------------------
+ROUTINE log_force
+BEGIN
+	FORCE_SPMENU(TP_PANEL, SPI_TPUSER, 1)
+END log_force
 
 
 

--- a/fanuc_driver/KAREL/libind_log_h.kl
+++ b/fanuc_driver/KAREL/libind_log_h.kl
@@ -42,6 +42,7 @@
 --------------------------------------------------------------------------------
 
 ROUTINE log_clear FROM libind_log
+ROUTINE log_force FROM libind_log
 ROUTINE log_info(s : STRING) FROM libind_log
 ROUTINE log_info_a(s : STRING; a : INTEGER) FROM libind_log
 ROUTINE log_warn(s : STRING) FROM libind_log

--- a/fanuc_driver/KAREL/ros_relay.kl
+++ b/fanuc_driver/KAREL/ros_relay.kl
@@ -120,10 +120,11 @@ CONST
 	CFG_OK       =    0  -- config ok
 	CFG_NOTDONE  =   -1  -- configuration not checked: user action required
 
-	MOVERR_OOR   =   -1  -- Requested JPOS is out-of-range
-
+	FILE_ILL_PRM =  2032 -- FILE-032 Illegal parameter
 	HOST_CTAG_ER = 67144 -- HOST-144 Comm Tag error
 	SEV_ABORT    =    2  -- ABORT severity
+
+	MOVERR_OOR   =   -1  -- Requested JPOS is out-of-range
 
 	-- Configuration defaults
 	MOTION_TAG   =    4  -- Server tag
@@ -182,7 +183,9 @@ BEGIN
 	IF (stat_ <> CFG_OK) THEN
 		log_error_a(LOG_PFIX + 'cfg error:', stat_)
 		log_error(LOG_PFIX + 'check cfg')
+		-- errors with config always force user to log window
 		log_force
+		POST_ERR(FILE_ILL_PRM, '', 0, SEV_ABORT)
 		RETURN
 	ENDIF
 

--- a/fanuc_driver/KAREL/ros_relay.kl
+++ b/fanuc_driver/KAREL/ros_relay.kl
@@ -60,7 +60,7 @@ PROGRAM ros_relay
 -- 
 --------------------------------------------------------------------------------
 %ALPHABETIZE
-%COMMENT = 'r20'
+%COMMENT = 'r22'
 %NOBUSYLAMP
 %NOLOCKGROUP
 %NOPAUSE = COMMAND + TPENABLE + ERROR

--- a/fanuc_driver/KAREL/ros_relay.kl
+++ b/fanuc_driver/KAREL/ros_relay.kl
@@ -165,8 +165,8 @@ CONST
 --------------------------------------------------------------------------------
 ROUTINE check_cfg_(cfg : rrelay_cfg_t) : INTEGER FROM ros_relay
 ROUTINE exec_move_(pkt : ind_pkt_t; cfg : rrelay_cfg_t) : INTEGER FROM ros_relay
-ROUTINE req_next_(pkt : ind_pkt_t; sock_fd : FILE) : INTEGER FROM ros_relay
-ROUTINE send_err_(pkt : ind_pkt_t; sock_fd : FILE) : INTEGER FROM ros_relay
+ROUTINE req_next_(pkt_in : ind_pkt_t; pkt_out : ind_pkt_t; sock_fd : FILE) : INTEGER FROM ros_relay
+ROUTINE send_err_(pkt_in : ind_pkt_t; pkt_out : ind_pkt_t; sock_fd : FILE) : INTEGER FROM ros_relay
 
 
 
@@ -294,7 +294,7 @@ BEGIN
 							log_info(LOG_PFIX + 'Trajectory stop')
 							-- cancel motion (if any)
 							CANCEL
-							stat_ = req_next_(pkt_in_, sock_fd_)
+							stat_ = req_next_(pkt_in_, pkt_out_, sock_fd_)
 							IF stat_ <> 0 THEN
 								-- can't continue
 								log_error_a(LOG_PFIX + 'Failed to ack stop, err:', stat_)
@@ -312,7 +312,7 @@ BEGIN
 				ELSE
 
 					-- notify ROS node we want a new trajectory node
-					stat_ = req_next_(pkt_in_, sock_fd_)
+					stat_ = req_next_(pkt_in_, pkt_out_, sock_fd_)
 					IF (stat_ <> 0) THEN
 						-- can't continue
 						log_error_a(LOG_PFIX + 'req_next err:', stat_)
@@ -325,7 +325,7 @@ BEGIN
 						-- 
 						log_error_a(LOG_PFIX + 'exec_move err:', stat_)
 						-- can't continue, send error
-						stat_ = send_err_(pkt_in_, sock_fd_)
+						stat_ = send_err_(pkt_in_, pkt_out_, sock_fd_)
 						-- disconnect if anything else than OOR error
 						IF (stat_ <> MOVERR_OOR) THEN
 							-- 
@@ -452,7 +452,8 @@ END exec_move_
 -- 
 -- Request next trajectory point from ROS node. Also sort of 'Send ACK'.
 --
--- [in    ]  pkt     : the packet to send
+-- [in    ]  pkt_in  : the packet received
+-- [in    ]  pkt_out : the packet to send
 -- [in    ]  sock_fd : file descriptor on the open socket
 -- [out   ]          : 0 IFF no error
 -- 
@@ -464,13 +465,12 @@ BEGIN
 	-- 
 	stat__ = 0
 
-	-- copy seq_nr from packet we ack
-	-- this is NOT done by the sedwards protocol implementations (debugging aid)
-	pkt_out_.seq_nr_ = pkt.seq_nr_
-	pkt_out_.reply_type_ = RI_RT_SUCC
+	-- copy seq_nr from packet we ack (done as a debugging aid)
+	pkt_out.seq_nr_ = pkt_in.seq_nr_
+	pkt_out.reply_type_ = RI_RT_SUCC
 
 	-- send ROS node request for next point
-	stat__ = ipkt_srlise(pkt_out_, sock_fd_)
+	stat__ = ipkt_srlise(pkt_out, sock_fd)
 
 	-- done
 	RETURN (-ABS(stat__))
@@ -483,7 +483,8 @@ END req_next_
 -- 
 -- Send NACK to ROS node. Something erred
 --
--- [in    ]  pkt     : the packet to send
+-- [in    ]  pkt_in  : the packet received
+-- [in    ]  pkt_out : the packet to send
 -- [in    ]  sock_fd : file descriptor on the open socket
 -- [out   ]          : 0 IFF no error
 -- 
@@ -495,13 +496,12 @@ BEGIN
 	-- 
 	stat__ = 0
 
-	-- copy seq_nr from the packet we NACK
-	-- this is NOT done by the sedwards protocol implementations (debugging aid)
-	pkt_out_.seq_nr_     = pkt.seq_nr_
-	pkt_out_.reply_type_ = RI_RT_FAIL
+	-- copy seq_nr from the packet we NACK (done as a debugging aid)
+	pkt_out.seq_nr_     = pkt_in.seq_nr_
+	pkt_out.reply_type_ = RI_RT_FAIL
 
-	-- send ROS node request for next point
-	stat__ = ipkt_srlise(pkt_out_, sock_fd_)
+	-- send nack to ROS node
+	stat__ = ipkt_srlise(pkt_out, sock_fd)
 
 	-- done
 	RETURN (-ABS(stat__))

--- a/fanuc_driver/KAREL/ros_relay.kl
+++ b/fanuc_driver/KAREL/ros_relay.kl
@@ -1,6 +1,6 @@
 -- Software License Agreement (BSD License)
 --
--- Copyright (c) 2012, 2013, TU Delft Robotics Institute
+-- Copyright (c) 2012-2014, TU Delft Robotics Institute
 -- All rights reserved.
 --
 -- Redistribution and use in source and binary forms, with or without
@@ -39,24 +39,28 @@ PROGRAM ros_relay
 -- 
 -- Currently only supports joint trajectory point streaming.
 -- 
--- Joint motion speed is limited (hard coded) to 20%. Termination is hard 
--- coded at CNT 50%.
--- 
 -- 
 -- Assumptions:
 --   - User Socket Messaging (USM) is supported by robot
---   - TAG 'S4' used for USM
 --   - There is only 1 motion group
 --   - The TP program 'ros_movesm' exists on the robot
+-- 
+-- 
+-- Configuration defaults:
+--   - TAG 'S4' used for USM
+--   - Relay TCP port ROS-I default (11000)
 --   - Position register 1 is available
 --   - Integer registers 1 & 2 are available
+--   - Flags 1 & 2 are available
+--   - Joint motion speed is limited to 20%
+--   - Motion termination is at CNT 50%
 -- 
 -- 
 -- author: G.A. vd. Hoorn (TU Delft Robotics Institute)
 -- 
 --------------------------------------------------------------------------------
 %ALPHABETIZE
-%COMMENT = 'r19'
+%COMMENT = 'r20'
 %NOBUSYLAMP
 %NOLOCKGROUP
 %NOPAUSE = COMMAND + TPENABLE + ERROR
@@ -80,39 +84,63 @@ PROGRAM ros_relay
 -- local types & constants
 -- 
 --------------------------------------------------------------------------------
-VAR
-	sock_        : ssock_t
-	sock_fd_     : FILE       -- file descriptor has to be declared here
-	pkt_in       : ind_pkt_t  -- incoming joint commands
-	pkt_out      : ind_pkt_t  -- outgoing reply msgs
-	new_j_pos    : JOINTPOS
-	stat_        : INTEGER
-	sleep_time   : INTEGER
-	do_it        : BOOLEAN
+TYPE
+	rrelay_cfg_t = STRUCTURE
+		checked      : BOOLEAN  -- user flagged: config checked
+		f_msm_rdy    : INTEGER  -- flag used for 'motion sm ready' signal
+		f_msm_drdy   : INTEGER  -- flag used for 'motion sm data ready' signal
+		loop_hz      : INTEGER  -- main loop update rate (in Hz)
+		move_cnt     : INTEGER  -- CNT to use for each motion instruction
+		move_speed   : INTEGER  -- speed to use for each motion instruction
+		pr_move      : INTEGER  -- pos reg to use for next traj pt
+		r_move_spd   : INTEGER  -- int reg to store motion speed in
+		r_move_cnt   : INTEGER  -- int reg to store motion CNT in
+		s_tcp_nr     : INTEGER  -- TCP port to listen on
+		s_tag_nr     : INTEGER  -- server TAG number to use
+		um_clear     : BOOLEAN  -- clear user menu on start
+	ENDSTRUCTURE
 
+
+VAR
+	cfg_         IN SHADOW : rrelay_cfg_t   -- configuration
+
+	sock_                  : ssock_t
+	sock_fd_               : FILE           -- file descriptor has to be declared here
+	pkt_in_                : ind_pkt_t      -- incoming joint commands
+	pkt_out_               : ind_pkt_t      -- outgoing reply msgs
+	new_j_pos_             : JOINTPOS
+	stat_                  : INTEGER
+	sleep_time_            : INTEGER
+	do_it_                 : BOOLEAN
 
 
 CONST
-	LOG_PFIX     = 'RREL '  -- 
+	LOG_PFIX     = 'RREL '
 
-	MOTION_TAG   =  4       -- which server tag to use
+	CFG_OK       =    0  -- config ok
+	CFG_NOTDONE  =   -1  -- configuration not checked: user action required
 
-	MOVE_PREG    =  1       -- position register to use with ros_movesm
-	MOVE_SPD_REG =  1       -- integer registers to use with ros_movesm
-	MOVE_CNT_REG =  2       -- 
+	MOVERR_OOR   =   -1  -- Requested JPOS is out-of-range
 
-	MOVE_SPEED   = 20       -- speed to use with ros_movesm (percentage of maximum)
-	MOVE_CNT     = 50       -- CNT value to use with ros_movesm
+	HOST_CTAG_ER = 67144 -- HOST-144 Comm Tag error
+	SEV_ABORT    =    2  -- ABORT severity
 
-	LOOP_HZ      = 40       -- Hz
+	-- Configuration defaults
+	MOTION_TAG   =    4  -- Server tag
+	MOTION_TCP_P = RI_TCP_TRAJR
 
-	RI_MSM_RDY   =  1       -- ros_movesm ready signal flag (waits for new point)
-	RI_MSM_DRDY  =  2       -- relay data ready signal flag (reset by ros_movesm)
+	MOVE_SPEED   =   20  -- speed to use with ros_movesm (percentage of maximum)
+	MOVE_CNT     =   50  -- CNT value to use with ros_movesm
 
-	MOVERR_OOR   = -1       -- Requested JPOS is out-of-range
+	LOOP_HZ      =   40  -- Hz
 
-	HOST_CTAG_ER = 67144    -- HOST-144 Comm Tag error
-	SEV_ABORT    =  2       -- ABORT severity
+	-- ros_movesm interface defaults:
+	MOVE_PREG    =    1  -- position register for current point
+	MOVE_SPD_REG =    1  -- integer register: motion speed (in %)
+	MOVE_CNT_REG =    2  -- integer register: motion termination (in %)
+
+	RI_MSM_RDY   =    1  -- ready signal flag
+	RI_MSM_DRDY  =    2  -- data ready signal flag
 
 
 
@@ -132,12 +160,13 @@ CONST
 
 --------------------------------------------------------------------------------
 -- 
--- Lokale routines
+-- local routine prototypes
 -- 
 --------------------------------------------------------------------------------
-ROUTINE exec_move(pkt : ind_pkt_t) : INTEGER FROM ros_relay
-ROUTINE req_next(pkt : ind_pkt_t; sock_fd : FILE) : INTEGER FROM ros_relay
-ROUTINE send_err(pkt : ind_pkt_t; sock_fd : FILE) : INTEGER FROM ros_relay
+ROUTINE check_cfg_(cfg : rrelay_cfg_t) : INTEGER FROM ros_relay
+ROUTINE exec_move_(pkt : ind_pkt_t; cfg : rrelay_cfg_t) : INTEGER FROM ros_relay
+ROUTINE req_next_(pkt : ind_pkt_t; sock_fd : FILE) : INTEGER FROM ros_relay
+ROUTINE send_err_(pkt : ind_pkt_t; sock_fd : FILE) : INTEGER FROM ros_relay
 
 
 
@@ -148,21 +177,31 @@ ROUTINE send_err(pkt : ind_pkt_t; sock_fd : FILE) : INTEGER FROM ros_relay
 -- 
 --------------------------------------------------------------------------------
 BEGIN
+	-- check config
+	stat_ = check_cfg_(cfg_)
+	IF (stat_ <> CFG_OK) THEN
+		log_error_a(LOG_PFIX + 'cfg error:', stat_)
+		log_error(LOG_PFIX + 'check cfg')
+		log_force
+		RETURN
+	ENDIF
+
+
 	-- init
-	stat_      = 0
-	sleep_time = ROUND(1000.0 / LOOP_HZ)
-	do_it      = TRUE
+	stat_       = 0
+	sleep_time_ = ROUND(1000.0 / cfg_.loop_hz)
+	do_it_      = TRUE
 
 
 	-- enable log output
-	log_clear
+	IF (cfg_.um_clear) THEN log_clear; ENDIF
 
 
 	-- init server socket
-	stat_ = ssock_ctor(sock_, RI_TCP_TRAJR, MOTION_TAG)
+	stat_ = ssock_ctor(sock_, cfg_.s_tcp_nr , cfg_.s_tag_nr)
 	IF (stat_ <> 0) THEN
 		IF (stat_ = TAG_CONF_ERR) THEN
-			log_error_a(LOG_PFIX + 'cfg err, TAG idx:', MOTION_TAG)
+			log_error_a(LOG_PFIX + 'cfg err, TAG idx:', cfg_.s_tag_nr)
 		ELSE
 			log_error_a(LOG_PFIX + 'ssock_ctor err:', stat_)
 		ENDIF
@@ -172,14 +211,14 @@ BEGIN
 
 
 	-- init incoming packet
-	stat_ = ipkt_ctor(pkt_in)
+	stat_ = ipkt_ctor(pkt_in_)
 
 
 	-- init reply packet
-	stat_ = ipkt_ctor(pkt_out)
+	stat_ = ipkt_ctor(pkt_out_)
 	-- setup fields: we reply with JOINT_POSITION packets
-	USING pkt_out DO
-		length_    = (RI_SZ_HDR + RI_SZB_JPOS)
+	USING pkt_out_ DO
+		length_     = (RI_SZ_HDR + RI_SZB_JPOS)
 		msg_type_   = RI_MT_JOINTP
 		comm_type_  = RI_CT_SVCRPL -- TODO: is this the correct reply type?
 		reply_type_ = RI_RT_SUCC
@@ -193,7 +232,7 @@ BEGIN
 
 
 	-- 
-	WHILE (do_it) DO
+	WHILE (do_it_) DO
 
 		-- inform user
 		log_info(LOG_PFIX + 'Waiting for ROS traj relay')
@@ -214,11 +253,11 @@ BEGIN
 		log_info(LOG_PFIX + 'Connected')
 
 		-- got client, start relay loop
-		WHILE (do_it) DO
+		WHILE (do_it_) DO
 
 			-- get new packet from the socket
 			-- TODO: this assumes 1 packet per iteration (ok for now)
-			stat_ = ipkt_checkfd(sock_fd_, pkt_in)
+			stat_ = ipkt_checkfd(sock_fd_, pkt_in_)
 			IF (stat_ < 0) THEN
 				log_error_a(LOG_PFIX + 'check_socket err:', stat_)
 
@@ -230,9 +269,9 @@ BEGIN
 			IF (stat_ > 0) THEN
 
 				-- check sequence number for special values
-				IF (pkt_in.seq_nr_ < 0) THEN
+				IF (pkt_in_.seq_nr_ < 0) THEN
 					-- 
-					SELECT (pkt_in.seq_nr_) OF
+					SELECT (pkt_in_.seq_nr_) OF
 						-- 
 						CASE (RI_SEQ_STRJD):
 							log_info(LOG_PFIX + 'Download start')
@@ -253,7 +292,7 @@ BEGIN
 							log_info(LOG_PFIX + 'Trajectory stop')
 							-- cancel motion (if any)
 							CANCEL
-							stat_ = req_next(pkt_in, sock_fd_)
+							stat_ = req_next_(pkt_in_, sock_fd_)
 							IF stat_ <> 0 THEN
 								-- can't continue
 								log_error_a(LOG_PFIX + 'Failed to ack stop, err:', stat_)
@@ -262,7 +301,7 @@ BEGIN
 
 						-- unknown special sequence nr
 						ELSE:
-							log_warn_a(LOG_PFIX + 'unknown seq nr:', pkt_in.seq_nr_)
+							log_warn_a(LOG_PFIX + 'unknown seq nr:', pkt_in_.seq_nr_)
 							log_warn(LOG_PFIX + 'please report')
 
 					ENDSELECT
@@ -271,7 +310,7 @@ BEGIN
 				ELSE
 
 					-- notify ROS node we want a new trajectory node
-					stat_ = req_next(pkt_in, sock_fd_)
+					stat_ = req_next_(pkt_in_, sock_fd_)
 					IF (stat_ <> 0) THEN
 						-- can't continue
 						log_error_a(LOG_PFIX + 'req_next err:', stat_)
@@ -279,12 +318,12 @@ BEGIN
 					ENDIF
 
 					-- 
-					stat_ = exec_move(pkt_in)
+					stat_ = exec_move_(pkt_in_, cfg_)
 					IF (stat_ <> 0) THEN
 						-- 
 						log_error_a(LOG_PFIX + 'exec_move err:', stat_)
 						-- can't continue, send error
-						stat_ = send_err(pkt_in, sock_fd_)
+						stat_ = send_err_(pkt_in_, sock_fd_)
 						-- disconnect if anything else than OOR error
 						IF (stat_ <> MOVERR_OOR) THEN
 							-- 
@@ -297,7 +336,7 @@ BEGIN
 			ELSE
 				-- no packets waiting; and no motion in progress,
 				-- sleep a little (1/T)
-				DELAY sleep_time
+				DELAY sleep_time_
 
 			ENDIF
 
@@ -320,6 +359,36 @@ END ros_relay
 
 
 
+ROUTINE check_cfg_
+VAR
+	a__ : BOOLEAN
+BEGIN
+	a__ = FALSE
+
+	-- set defaults for any uninitialised entries
+	IF (UNINIT(cfg.f_msm_rdy )) THEN cfg.f_msm_rdy  = RI_MSM_RDY  ; a__ = TRUE; ENDIF
+	IF (UNINIT(cfg.f_msm_drdy)) THEN cfg.f_msm_drdy = RI_MSM_DRDY ; a__ = TRUE; ENDIF
+	IF (UNINIT(cfg.loop_hz   )) THEN cfg.loop_hz    = LOOP_HZ     ; a__ = TRUE; ENDIF
+	IF (UNINIT(cfg.move_cnt  )) THEN cfg.move_cnt   = MOVE_CNT    ; a__ = TRUE; ENDIF
+	IF (UNINIT(cfg.move_speed)) THEN cfg.move_speed = MOVE_SPEED  ; a__ = TRUE; ENDIF
+	IF (UNINIT(cfg.pr_move   )) THEN cfg.pr_move    = MOVE_PREG   ; a__ = TRUE; ENDIF
+	IF (UNINIT(cfg.r_move_spd)) THEN cfg.r_move_spd = MOVE_SPD_REG; a__ = TRUE; ENDIF
+	IF (UNINIT(cfg.r_move_cnt)) THEN cfg.r_move_cnt = MOVE_CNT_REG; a__ = TRUE; ENDIF
+	IF (UNINIT(cfg.s_tcp_nr  )) THEN cfg.s_tcp_nr   = MOTION_TCP_P; a__ = TRUE; ENDIF
+	IF (UNINIT(cfg.s_tag_nr  )) THEN cfg.s_tag_nr   = MOTION_TAG  ; a__ = TRUE; ENDIF
+	IF (UNINIT(cfg.um_clear  )) THEN cfg.um_clear   = TRUE        ; a__ = TRUE; ENDIF
+	IF (UNINIT(cfg.checked   )) THEN cfg.checked    = FALSE       ; a__ = TRUE; ENDIF
+
+	-- make sure user has checked configuration
+	IF ((NOT cfg.checked) OR a__) THEN RETURN (CFG_NOTDONE); ENDIF
+
+	-- all ok
+	RETURN (CFG_OK)
+END check_cfg_
+
+
+
+
 --------------------------------------------------------------------------------
 -- 
 -- Update joint positions according to contents of ROS Industrial packet.
@@ -333,7 +402,7 @@ END ros_relay
 --                     < -1 on any other error
 -- 
 --------------------------------------------------------------------------------
-ROUTINE exec_move
+ROUTINE exec_move_
 VAR
 	stat__ : INTEGER
 BEGIN
@@ -341,37 +410,37 @@ BEGIN
 	arr_rad2deg(pkt.joint_data_)
 
 	-- convert reals to jointpos
-	CNV_REL_JPOS(pkt.joint_data_, new_j_pos, stat__)
+	CNV_REL_JPOS(pkt.joint_data_, new_j_pos_, stat__)
 	IF (stat__ <> 0) THEN RETURN (-stat__); ENDIF
 
 	-- check to make sure point can be reached before performing motion
-	IF (NOT J_IN_RANGE(new_j_pos)) THEN
+	IF (NOT J_IN_RANGE(new_j_pos_)) THEN
 		RETURN (MOVERR_OOR)
 	ENDIF
 
 	-- sync
-	WAIT FOR (FLG[RI_MSM_RDY] = ON)
+	WAIT FOR (FLG[cfg.f_msm_rdy] = ON)
 
 	-- setup registers
 	-- init position
-	SET_JPOS_REG(MOVE_PREG, new_j_pos, stat__)
+	SET_JPOS_REG(cfg.pr_move, new_j_pos_, stat__)
 	IF (stat__ <> 0) THEN RETURN (-stat__); ENDIF
 
-	-- init motion speed (constant for now)
-	SET_INT_REG(MOVE_SPD_REG, MOVE_SPEED, stat__)
+	-- init motion speed (from config)
+	SET_INT_REG(cfg.r_move_spd, cfg.move_speed, stat__)
 	IF (stat__ <> 0) THEN RETURN (-stat__); ENDIF
 
-	-- init motion termination (constant for now)
-	SET_INT_REG(MOVE_CNT_REG, MOVE_CNT, stat__)
+	-- init motion termination (from config)
+	SET_INT_REG(cfg.r_move_cnt, cfg.move_cnt, stat__)
 	IF (stat__ <> 0) THEN RETURN (-stat__); ENDIF
 
 	-- exec
-	FLG[RI_MSM_DRDY] = ON
-	WAIT FOR (FLG[RI_MSM_DRDY] = OFF)
+	FLG[cfg.f_msm_drdy] = ON
+	WAIT FOR (FLG[cfg.f_msm_drdy] = OFF)
 
 	-- done
 	RETURN (0)
-END exec_move
+END exec_move_
 
 
 
@@ -385,7 +454,7 @@ END exec_move
 -- [out   ]          : 0 IFF no error
 -- 
 --------------------------------------------------------------------------------
-ROUTINE req_next
+ROUTINE req_next_
 VAR
 	stat__ : INTEGER
 BEGIN
@@ -394,15 +463,15 @@ BEGIN
 
 	-- copy seq_nr from packet we ack
 	-- this is NOT done by the sedwards protocol implementations (debugging aid)
-	pkt_out.seq_nr_ = pkt.seq_nr_
-	pkt_out.reply_type_ = RI_RT_SUCC
+	pkt_out_.seq_nr_ = pkt.seq_nr_
+	pkt_out_.reply_type_ = RI_RT_SUCC
 
 	-- send ROS node request for next point
-	stat__ = ipkt_srlise(pkt_out, sock_fd_)
+	stat__ = ipkt_srlise(pkt_out_, sock_fd_)
 
 	-- done
 	RETURN (-ABS(stat__))
-END req_next
+END req_next_
 
 
 
@@ -416,7 +485,7 @@ END req_next
 -- [out   ]          : 0 IFF no error
 -- 
 --------------------------------------------------------------------------------
-ROUTINE send_err
+ROUTINE send_err_
 VAR
 	stat__ : INTEGER
 BEGIN
@@ -425,12 +494,12 @@ BEGIN
 
 	-- copy seq_nr from the packet we NACK
 	-- this is NOT done by the sedwards protocol implementations (debugging aid)
-	pkt_out.seq_nr_     = pkt.seq_nr_
-	pkt_out.reply_type_ = RI_RT_FAIL
+	pkt_out_.seq_nr_     = pkt.seq_nr_
+	pkt_out_.reply_type_ = RI_RT_FAIL
 
 	-- send ROS node request for next point
-	stat__ = ipkt_srlise(pkt_out, sock_fd_)
+	stat__ = ipkt_srlise(pkt_out_, sock_fd_)
 
 	-- done
 	RETURN (-ABS(stat__))
-END send_err
+END send_err_

--- a/fanuc_driver/KAREL/ros_relay.kl
+++ b/fanuc_driver/KAREL/ros_relay.kl
@@ -397,7 +397,7 @@ END check_cfg_
 -- Update joint positions according to contents of ROS Industrial packet.
 -- 
 -- This routine communicates the new joint positions to the 'Move SM' TPE 
--- program using the 'MOVE_PREG' position register.
+-- program using the configured flags, and position & integer registers.
 -- 
 -- [in    ]  pkt     : packet containing new joint positions
 -- [out   ]          :    0 IFF no error

--- a/fanuc_driver/KAREL/ros_relay.kl
+++ b/fanuc_driver/KAREL/ros_relay.kl
@@ -108,7 +108,6 @@ VAR
 	sock_fd_               : FILE           -- file descriptor has to be declared here
 	pkt_in_                : ind_pkt_t      -- incoming joint commands
 	pkt_out_               : ind_pkt_t      -- outgoing reply msgs
-	new_j_pos_             : JOINTPOS
 	stat_                  : INTEGER
 	sleep_time_            : INTEGER
 	do_it_                 : BOOLEAN
@@ -407,17 +406,18 @@ END check_cfg_
 --------------------------------------------------------------------------------
 ROUTINE exec_move_
 VAR
-	stat__ : INTEGER
+	stat__       : INTEGER
+	new_j_pos__  : JOINTPOS
 BEGIN
 	-- ROS sends radians, so convert
 	arr_rad2deg(pkt.joint_data_)
 
 	-- convert reals to jointpos
-	CNV_REL_JPOS(pkt.joint_data_, new_j_pos_, stat__)
+	CNV_REL_JPOS(pkt.joint_data_, new_j_pos__, stat__)
 	IF (stat__ <> 0) THEN RETURN (-stat__); ENDIF
 
 	-- check to make sure point can be reached before performing motion
-	IF (NOT J_IN_RANGE(new_j_pos_)) THEN
+	IF (NOT J_IN_RANGE(new_j_pos__)) THEN
 		RETURN (MOVERR_OOR)
 	ENDIF
 
@@ -426,7 +426,7 @@ BEGIN
 
 	-- setup registers
 	-- init position
-	SET_JPOS_REG(cfg.pr_move, new_j_pos_, stat__)
+	SET_JPOS_REG(cfg.pr_move, new_j_pos__, stat__)
 	IF (stat__ <> 0) THEN RETURN (-stat__); ENDIF
 
 	-- init motion speed (from config)

--- a/fanuc_driver/KAREL/ros_relay.kl
+++ b/fanuc_driver/KAREL/ros_relay.kl
@@ -111,6 +111,9 @@ CONST
 
 	MOVERR_OOR   = -1       -- Requested JPOS is out-of-range
 
+	HOST_CTAG_ER = 67144    -- HOST-144 Comm Tag error
+	SEV_ABORT    =  2       -- ABORT severity
+
 
 
 
@@ -164,7 +167,7 @@ BEGIN
 			log_error_a(LOG_PFIX + 'ssock_ctor err:', stat_)
 		ENDIF
 		-- nothing we can do, abort
-		GOTO exit_on_err
+		POST_ERR(HOST_CTAG_ER, '', 0, SEV_ABORT)
 	ENDIF
 
 

--- a/fanuc_driver/KAREL/ros_relay.kl
+++ b/fanuc_driver/KAREL/ros_relay.kl
@@ -56,7 +56,7 @@ PROGRAM ros_relay
 -- 
 --------------------------------------------------------------------------------
 %ALPHABETIZE
-%COMMENT = 'r18'
+%COMMENT = 'r19'
 %NOBUSYLAMP
 %NOLOCKGROUP
 %NOPAUSE = COMMAND + TPENABLE + ERROR
@@ -159,7 +159,7 @@ BEGIN
 	stat_ = ssock_ctor(sock_, RI_TCP_TRAJR, MOTION_TAG)
 	IF (stat_ <> 0) THEN
 		IF (stat_ = TAG_CONF_ERR) THEN
-			log_error_a(LOG_PFIX + 'TAG config error. TAG nr:', MOTION_TAG)
+			log_error_a(LOG_PFIX + 'cfg err, TAG idx:', MOTION_TAG)
 		ELSE
 			log_error_a(LOG_PFIX + 'ssock_ctor err:', stat_)
 		ENDIF

--- a/fanuc_driver/KAREL/ros_state.kl
+++ b/fanuc_driver/KAREL/ros_state.kl
@@ -48,7 +48,7 @@ PROGRAM ros_state
 -- 
 --------------------------------------------------------------------------------
 %ALPHABETIZE
-%COMMENT = 'r15'
+%COMMENT = 'r16'
 %NOBUSYLAMP
 %NOLOCKGROUP
 %NOPAUSE = COMMAND + TPENABLE + ERROR
@@ -142,7 +142,7 @@ BEGIN
 	stat_ = ssock_ctor(sock_, RI_TCP_STATE, STATE_TAG)
 	IF (stat_ <> 0) THEN
 		IF (stat_ = TAG_CONF_ERR) THEN
-			log_error_a(LOG_PFIX + 'TAG config error. TAG nr:', STATE_TAG)
+			log_error_a(LOG_PFIX + 'cfg err, TAG idx:', STATE_TAG)
 		ELSE
 			log_error_a(LOG_PFIX + 'ssock_ctor err:', stat_)
 		ENDIF

--- a/fanuc_driver/KAREL/ros_state.kl
+++ b/fanuc_driver/KAREL/ros_state.kl
@@ -93,6 +93,10 @@ CONST
 	LOOP_HZ = 40
 	-- Number of main loop iterations for each status message
 	STAT_LP_CNT = 10
+	-- HOST-144 Comm Tag error
+	HOST_CTAG_ER = 67144
+	-- ABORT severity
+	SEV_ABORT = 2
 
 
 
@@ -147,7 +151,7 @@ BEGIN
 			log_error_a(LOG_PFIX + 'ssock_ctor err:', stat_)
 		ENDIF
 		-- nothing we can do, abort
-		GOTO exit_on_err
+		POST_ERR(HOST_CTAG_ER, '', 0, SEV_ABORT)
 	ENDIF
 
 

--- a/fanuc_driver/KAREL/ros_state.kl
+++ b/fanuc_driver/KAREL/ros_state.kl
@@ -52,7 +52,7 @@ PROGRAM ros_state
 -- 
 --------------------------------------------------------------------------------
 %ALPHABETIZE
-%COMMENT = 'r20'
+%COMMENT = 'r22'
 %NOBUSYLAMP
 %NOLOCKGROUP
 %NOPAUSE = COMMAND + TPENABLE + ERROR

--- a/fanuc_driver/KAREL/ros_state.kl
+++ b/fanuc_driver/KAREL/ros_state.kl
@@ -1,6 +1,6 @@
 -- Software License Agreement (BSD License)
 --
--- Copyright (c) 2012, 2013, TU Delft Robotics Institute
+-- Copyright (c) 2012-2014, TU Delft Robotics Institute
 -- All rights reserved.
 --
 -- Redistribution and use in source and binary forms, with or without
@@ -35,20 +35,24 @@
 PROGRAM ros_state
 --------------------------------------------------------------------------------
 -- 
--- ROS Industrial state proxy
+-- ROS Industrial state proxy.
 -- 
 -- 
 -- Assumptions:
 --   - User Socket Messaging (USM) is supported by robot
---   - TAG 'S3' used for USM
 --   - There is only 1 motion group
+-- 
+-- 
+-- Configuration defaults:
+--   - TAG 'S3' used for USM
+--   - State TCP port ROS-I default (11002)
 -- 
 -- 
 -- author: G.A. vd. Hoorn (TU Delft Robotics Institute)
 -- 
 --------------------------------------------------------------------------------
 %ALPHABETIZE
-%COMMENT = 'r16'
+%COMMENT = 'r20'
 %NOBUSYLAMP
 %NOLOCKGROUP
 %NOPAUSE = COMMAND + TPENABLE + ERROR
@@ -73,30 +77,45 @@ PROGRAM ros_state
 -- local types & constants
 -- 
 --------------------------------------------------------------------------------
+TYPE
+	rstate_cfg_t = STRUCTURE
+		checked      : BOOLEAN  -- user flagged: config checked
+		loop_hz      : INTEGER  -- main loop update rate (in Hz)
+		sloop_div    : INTEGER  -- robot_status main loop divider
+		s_tcp_nr     : INTEGER  -- TCP port to listen on
+		s_tag_nr     : INTEGER  -- server TAG number to use
+		um_clear     : BOOLEAN  -- clear user menu on start
+	ENDSTRUCTURE
+
+
 VAR
-	jnt_pkt_out: ind_pkt_t   -- ROS industrial joint state packet
-	rs_pkt_out : ind_rs_t    -- ROS industrial robot status packet
-	sock_      : ssock_t     -- server socket instance
-	sock_fd_   : FILE        -- file descriptor associated with srvr socket
-	stat_      : INTEGER     -- status variable
-	stat_count_: INTEGER     -- status loop counter
-	cur_j_pos  : JOINTPOS    -- current position of robot joints
-	sleep_time : INTEGER
+	cfg_         IN SHADOW : rstate_cfg_t -- configuration
+
+	jnt_pkt_out_           : ind_pkt_t    -- ROS industrial joint state packet
+	rs_pkt_out_            : ind_rs_t     -- ROS industrial robot status packet
+	sock_                  : ssock_t      -- server socket instance
+	sock_fd_               : FILE         -- file descriptor associated with srvr socket
+	stat_                  : INTEGER      -- status variable
+	stat_count_            : INTEGER      -- status loop counter
+	cur_j_pos_             : JOINTPOS     -- current position of robot joints
+	sleep_time_            : INTEGER
 
 
 CONST
 	-- 
-	LOG_PFIX = 'RSTA '
-	-- which server tag to use
-	STATE_TAG = 3
-	-- Main loop freq (Hz)
-	LOOP_HZ = 40
-	-- Number of main loop iterations for each status message
-	STAT_LP_CNT = 10
-	-- HOST-144 Comm Tag error
-	HOST_CTAG_ER = 67144
-	-- ABORT severity
-	SEV_ABORT = 2
+	LOG_PFIX     = 'RSTA '
+
+	CFG_OK       =    0  -- config ok
+	CFG_NOTDONE  =   -1  -- configuration not checked: user action required
+
+	HOST_CTAG_ER = 67144 -- HOST-144 Comm Tag error
+	SEV_ABORT    =    2  -- ABORT severity
+
+	-- Configuration defaults
+	STATE_TAG    =    3  -- Server tag
+	STATE_TCP_P  = RI_TCP_STATE
+	LOOP_HZ      =   40  -- Main loop freq (Hz)
+	STAT_LP_CNT  =   10  -- Main loop divider for robot_status
 
 
 
@@ -118,23 +137,44 @@ CONST
 
 --------------------------------------------------------------------------------
 -- 
+-- local routine prototypes
+-- 
+--------------------------------------------------------------------------------
+ROUTINE check_cfg_(cfg : rstate_cfg_t) : INTEGER FROM ros_state
+
+
+
+
+--------------------------------------------------------------------------------
+-- 
 -- Main program
 -- 
 --------------------------------------------------------------------------------
 BEGIN
-	stat_       = 0
-	stat_count_ = 0
-	sleep_time  = ROUND(1000.0 / LOOP_HZ)
+	-- check config
+	stat_ = check_cfg_(cfg_)
+	IF (stat_ <> CFG_OK) THEN
+		log_error_a(LOG_PFIX + 'cfg error:', stat_)
+		log_error(LOG_PFIX + 'check cfg')
+		log_force
+		RETURN
+	ENDIF
+
+
+	-- 
+	stat_        = 0
+	stat_count_  = 0
+	sleep_time_  = ROUND(1000.0 / cfg_.loop_hz)
 
 
 	-- enable log output
-	log_clear
+	IF (cfg_.um_clear) THEN log_clear; ENDIF
 
 
 	-- init packet
-	stat_ = ipkt_ctor(jnt_pkt_out)
+	stat_ = ipkt_ctor(jnt_pkt_out_)
 	-- we reply with JOINT_POSITION packets
-	USING jnt_pkt_out DO
+	USING jnt_pkt_out_ DO
 		length_    = (RI_SZ_HDR + RI_SZB_JPOS)
 		msg_type_  = RI_MT_JOINTP
 		comm_type_ = RI_CT_TOPIC
@@ -143,10 +183,10 @@ BEGIN
 
 
 	-- init server socket
-	stat_ = ssock_ctor(sock_, RI_TCP_STATE, STATE_TAG)
+	stat_ = ssock_ctor(sock_, cfg_.s_tcp_nr,  cfg_.s_tag_nr)
 	IF (stat_ <> 0) THEN
 		IF (stat_ = TAG_CONF_ERR) THEN
-			log_error_a(LOG_PFIX + 'cfg err, TAG idx:', STATE_TAG)
+			log_error_a(LOG_PFIX + 'cfg err, TAG idx:', cfg_.s_tag_nr)
 		ELSE
 			log_error_a(LOG_PFIX + 'ssock_ctor err:', stat_)
 		ENDIF
@@ -184,16 +224,16 @@ BEGIN
 		WHILE (TRUE) DO
 
 			-- get current joint angles
-			cur_j_pos = CURJPOS(0, 0)
+			cur_j_pos_ = CURJPOS(0, 0)
 
 			-- convert to REAL array
-			CNV_JPOS_REL(cur_j_pos, jnt_pkt_out.joint_data_, stat_)
+			CNV_JPOS_REL(cur_j_pos_, jnt_pkt_out_.joint_data_, stat_)
 
 			-- ROS expects radians, so convert
-			arr_deg2rad(jnt_pkt_out.joint_data_)
+			arr_deg2rad(jnt_pkt_out_.joint_data_)
 
 			-- serialise packet, write to socket file descriptor
-			stat_ = ipkt_srlise(jnt_pkt_out, sock_fd_)
+			stat_ = ipkt_srlise(jnt_pkt_out_, sock_fd_)
 
 			-- check result
 			IF (stat_ <> 0) THEN
@@ -208,12 +248,12 @@ BEGIN
 			ENDIF
 
 			-- 
-			IF (stat_count_ >=  STAT_LP_CNT) THEN
+			IF (stat_count_ >= cfg_.sloop_div) THEN
 				--Build up robot status packer
-				irs_update(rs_pkt_out)
+				irs_update(rs_pkt_out_)
 
 				-- serialise packet, write to socket file descriptor
-				stat_ = irs_tpc_srl(rs_pkt_out, sock_fd_)
+				stat_ = irs_tpc_srl(rs_pkt_out_, sock_fd_)
 
 				-- check result
 				IF (stat_ <> 0) THEN
@@ -233,7 +273,7 @@ BEGIN
 			ENDIF
 
 			-- sleep a little (1/T)
-			DELAY sleep_time
+			DELAY sleep_time_
 
 		-- inner WHILE TRUE DO
 		ENDWHILE
@@ -254,3 +294,27 @@ exit_on_err::
 	-- nothing
 
 END ros_state
+
+
+
+
+ROUTINE check_cfg_
+VAR
+	a__ : BOOLEAN
+BEGIN
+	a__ = FALSE
+
+	-- set defaults for any uninitialised entries
+	IF (UNINIT(cfg.loop_hz  )) THEN cfg.loop_hz   = LOOP_HZ    ; a__ = TRUE; ENDIF
+	IF (UNINIT(cfg.sloop_div)) THEN cfg.sloop_div = STAT_LP_CNT; a__ = TRUE; ENDIF
+	IF (UNINIT(cfg.s_tcp_nr )) THEN cfg.s_tcp_nr  = STATE_TCP_P; a__ = TRUE; ENDIF
+	IF (UNINIT(cfg.s_tag_nr )) THEN cfg.s_tag_nr  = STATE_TAG  ; a__ = TRUE; ENDIF
+	IF (UNINIT(cfg.um_clear )) THEN cfg.um_clear  = TRUE       ; a__ = TRUE; ENDIF
+	IF (UNINIT(cfg.checked  )) THEN cfg.checked   = FALSE      ; a__ = TRUE; ENDIF
+
+	-- make sure user has checked configuration
+	IF ((NOT cfg.checked) OR a__) THEN RETURN (CFG_NOTDONE); ENDIF
+
+	-- all ok
+	RETURN (CFG_OK)
+END check_cfg_

--- a/fanuc_driver/KAREL/ros_state.kl
+++ b/fanuc_driver/KAREL/ros_state.kl
@@ -109,6 +109,7 @@ CONST
 	CFG_NOTDONE  =   -1  -- configuration not checked: user action required
 
 	HOST_CTAG_ER = 67144 -- HOST-144 Comm Tag error
+	FILE_ILL_PRM =  2032 -- FILE-032 Illegal parameter
 	SEV_ABORT    =    2  -- ABORT severity
 
 	-- Configuration defaults
@@ -156,7 +157,9 @@ BEGIN
 	IF (stat_ <> CFG_OK) THEN
 		log_error_a(LOG_PFIX + 'cfg error:', stat_)
 		log_error(LOG_PFIX + 'check cfg')
+		-- errors with config always force user to log window
 		log_force
+		POST_ERR(FILE_ILL_PRM, '', 0, SEV_ABORT)
 		RETURN
 	ENDIF
 

--- a/fanuc_driver/package.xml
+++ b/fanuc_driver/package.xml
@@ -21,9 +21,8 @@
 
   <buildtool_depend>catkin</buildtool_depend>
 
+  <build_depend>roslaunch</build_depend>
   <build_depend>industrial_robot_client</build_depend> 
 
   <run_depend>industrial_robot_client</run_depend>
-
-  <test_depend>roslaunch</test_depend>
 </package>

--- a/fanuc_m10ia_support/package.xml
+++ b/fanuc_m10ia_support/package.xml
@@ -33,14 +33,14 @@
 
   <buildtool_depend>catkin</buildtool_depend>
 
+  <build_depend>roslaunch</build_depend>
+
   <run_depend>robot_state_publisher</run_depend>
   <run_depend>joint_state_publisher</run_depend>
   <run_depend>rviz</run_depend>
   <run_depend>xacro</run_depend>
   <run_depend>fanuc_assets</run_depend>
   <run_depend>fanuc_driver</run_depend>
-
-  <test_depend>roslaunch</test_depend>
 
   <export>
     <architecture_independent />

--- a/fanuc_m16ib_support/package.xml
+++ b/fanuc_m16ib_support/package.xml
@@ -38,14 +38,14 @@
 
   <buildtool_depend>catkin</buildtool_depend>
 
+  <build_depend>roslaunch</build_depend>
+
   <run_depend>robot_state_publisher</run_depend>
   <run_depend>joint_state_publisher</run_depend>
   <run_depend>rviz</run_depend>
   <run_depend>xacro</run_depend>
   <run_depend>fanuc_assets</run_depend>
   <run_depend>fanuc_driver</run_depend>
-
-  <test_depend>roslaunch</test_depend>
 
   <export>
     <architecture_independent />

--- a/fanuc_m430ia_support/package.xml
+++ b/fanuc_m430ia_support/package.xml
@@ -37,14 +37,14 @@
 
   <buildtool_depend>catkin</buildtool_depend>
 
+  <build_depend>roslaunch</build_depend>
+
   <run_depend>robot_state_publisher</run_depend>
   <run_depend>joint_state_publisher</run_depend>
   <run_depend>rviz</run_depend>
   <run_depend>xacro</run_depend>
   <run_depend>fanuc_assets</run_depend>
   <run_depend>fanuc_driver</run_depend>
-
-  <test_depend>roslaunch</test_depend>
 
   <export>
     <architecture_independent />


### PR DESCRIPTION
Changes for various fixes, but most notably the introduction of a configuration struct that allows users to configure things like motion termination (CNT %) and speed, used server tags and TCP ports, flags and (position) registers. Settings default to the currently hard-coded values.

There is no validation of configuration entries yet. Will create an issue for that.

These changes also cause `ros_relay` and `ros_state` to use the central _Alarm Log_ on the controller.
