### PR TITLE
Math fixes (constants) for hydro-devel

### DIFF
--- a/fanuc_driver/karel/libind_log_h.kl
+++ b/fanuc_driver/karel/libind_log_h.kl
@@ -1,6 +1,6 @@
 -- Software License Agreement (BSD License)
 --
--- Copyright (c) 2012, 2013, TU Delft Robotics Institute
+-- Copyright (c) 2012-2014, TU Delft Robotics Institute
 -- All rights reserved.
 --
 -- Redistribution and use in source and binary forms, with or without

--- a/fanuc_driver/karel/libind_mth.kl
+++ b/fanuc_driver/karel/libind_mth.kl
@@ -54,11 +54,6 @@ PROGRAM libind_mth
 -- local types & constants
 -- 
 --------------------------------------------------------------------------------
-CONST
-	M_PI       =  3.14159265359
-	M_1_PI     =  0.31830988618
-	M_1RAD_DEG = 57.29577951318
-	M_1DEG_RAD =  0.01745329252
 
 
 
@@ -86,7 +81,7 @@ END libind_mth
 
 ROUTINE deg_to_rad
 BEGIN
-	RETURN (r_deg * M_1DEG_RAD)
+	RETURN (r_deg * DEG_2_RAD)
 END deg_to_rad
 
 
@@ -94,7 +89,7 @@ END deg_to_rad
 
 ROUTINE rad_to_deg
 BEGIN
-	RETURN (r_rad * M_1RAD_DEG)
+	RETURN (r_rad * RAD_2_DEG)
 END rad_to_deg
 
 

--- a/fanuc_driver/karel/libind_mth.kl
+++ b/fanuc_driver/karel/libind_mth.kl
@@ -40,9 +40,11 @@ PROGRAM libind_mth
 -- author: G.A. vd. Hoorn (TU Delft Robotics Institute)
 -- 
 --------------------------------------------------------------------------------
-%NOLOCKGROUP
-%NOPAUSE= COMMAND + TPENABLE + ERROR
+%ALPHABETIZE
 %COMMENT = 'r1'
+%NOBUSYLAMP
+%NOLOCKGROUP
+%NOPAUSE = COMMAND + TPENABLE + ERROR
 
 
 
@@ -52,7 +54,7 @@ PROGRAM libind_mth
 -- local types & constants
 -- 
 --------------------------------------------------------------------------------
-const
+CONST
 	M_PI       =  3.14159265359
 	M_1_PI     =  0.31830988618
 	M_1RAD_DEG = 57.29577951318

--- a/fanuc_driver/karel/libind_mth.kl
+++ b/fanuc_driver/karel/libind_mth.kl
@@ -1,6 +1,6 @@
 -- Software License Agreement (BSD License)
 --
--- Copyright (c) 2012, 2013, TU Delft Robotics Institute
+-- Copyright (c) 2012-2014, TU Delft Robotics Institute
 -- All rights reserved.
 --
 -- Redistribution and use in source and binary forms, with or without

--- a/fanuc_driver/karel/libind_mth.kl
+++ b/fanuc_driver/karel/libind_mth.kl
@@ -41,7 +41,7 @@ PROGRAM libind_mth
 -- 
 --------------------------------------------------------------------------------
 %ALPHABETIZE
-%COMMENT = 'r1'
+%COMMENT = 'r2'
 %NOBUSYLAMP
 %NOLOCKGROUP
 %NOPAUSE = COMMAND + TPENABLE + ERROR

--- a/fanuc_driver/karel/libind_mth_h.kl
+++ b/fanuc_driver/karel/libind_mth_h.kl
@@ -1,6 +1,6 @@
 -- Software License Agreement (BSD License)
 --
--- Copyright (c) 2012, 2013, TU Delft Robotics Institute
+-- Copyright (c) 2012-2014 TU Delft Robotics Institute
 -- All rights reserved.
 --
 -- Redistribution and use in source and binary forms, with or without
@@ -48,6 +48,9 @@
 -- 
 -- Convert given argument (in degrees) to radians
 -- 
+-- [in    ]  r_deg        : angle in degrees
+-- [return]               : same angle in radians
+-- 
 --------------------------------------------------------------------------------
 ROUTINE deg_to_rad(r_deg : REAL) : REAL FROM libind_mth
 
@@ -57,6 +60,9 @@ ROUTINE deg_to_rad(r_deg : REAL) : REAL FROM libind_mth
 --------------------------------------------------------------------------------
 -- 
 -- Convert given argument (in radians) to degrees
+-- 
+-- [in    ]  r_rad        : angle in radians
+-- [return]               : same angle in degrees
 -- 
 --------------------------------------------------------------------------------
 ROUTINE rad_to_deg(r_rad : REAL) : REAL FROM libind_mth
@@ -68,6 +74,8 @@ ROUTINE rad_to_deg(r_rad : REAL) : REAL FROM libind_mth
 -- 
 -- Convert all elements of given array (in degrees) to radians
 -- 
+-- [in    ]  a            : real array (elements in degrees)
+-- 
 --------------------------------------------------------------------------------
 ROUTINE arr_deg2rad(a : ARRAY OF REAL) FROM libind_mth
 
@@ -77,6 +85,8 @@ ROUTINE arr_deg2rad(a : ARRAY OF REAL) FROM libind_mth
 --------------------------------------------------------------------------------
 -- 
 -- Convert all elements of given array (in radians) to degrees
+-- 
+-- [in    ]  a            : real array (elements in radians)
 -- 
 --------------------------------------------------------------------------------
 ROUTINE arr_rad2deg(a : ARRAY OF REAL) FROM libind_mth


### PR DESCRIPTION
Minor changes: use built-in constants in math lib.

Tested in Roboguide, as well as on a R-30iA/7.70P/23.
