### PR TITLE
support: add 'base' link (transform to World Coordinates). Fix #101.

### DIFF
--- a/fanuc_m10ia_support/urdf/m10ia.urdf
+++ b/fanuc_m10ia_support/urdf/m10ia.urdf
@@ -171,4 +171,11 @@
     <parent link="link_6"/>
     <child link="tool0"/>
   </joint>
+  <link name="base"/>
+  <joint name="base_link-base" type="fixed">
+    <origin rpy="0 0 0" xyz="0 0 0.450"/>
+    <parent link="base_link"/>
+    <child link="base"/>
+  </joint>
 </robot>
+

--- a/fanuc_m10ia_support/urdf/m10ia_macro.xacro
+++ b/fanuc_m10ia_support/urdf/m10ia_macro.xacro
@@ -160,5 +160,13 @@
 			<parent link="${prefix}link_6"/>
 			<child link="${prefix}tool0"/>
 		</joint>
+
+		<!-- ROS base_link to Fanuc World Coordinates transform -->
+		<link name="${prefix}base" />
+		<joint name="${prefix}base_link-base" type="fixed">
+			<origin xyz="0 0 0.450" rpy="0 0 0"/>
+			<parent link="${prefix}base_link"/>
+			<child link="${prefix}base"/>
+		</joint>
 	</xacro:macro>
 </robot>

--- a/fanuc_m16ib_support/urdf/m16ib20.urdf
+++ b/fanuc_m16ib_support/urdf/m16ib20.urdf
@@ -171,4 +171,11 @@
     <parent link="link_6"/>
     <child link="tool0"/>
   </joint>
+  <link name="base"/>
+  <joint name="base_link-base" type="fixed">
+    <origin rpy="0 0 0" xyz="0 0 0.525"/>
+    <parent link="base_link"/>
+    <child link="base"/>
+  </joint>
 </robot>
+

--- a/fanuc_m16ib_support/urdf/m16ib20_macro.xacro
+++ b/fanuc_m16ib_support/urdf/m16ib20_macro.xacro
@@ -160,5 +160,13 @@
 			<parent link="${prefix}link_6"/>
 			<child link="${prefix}tool0"/>
 		</joint>
+
+		<!-- ROS base_link to Fanuc World Coordinates transform -->
+		<link name="${prefix}base" />
+		<joint name="${prefix}base_link-base" type="fixed">
+			<origin xyz="0 0 0.525" rpy="0 0 0"/>
+			<parent link="${prefix}base_link"/>
+			<child link="${prefix}base"/>
+		</joint>
 	</xacro:macro>
 </robot>

--- a/fanuc_m430ia_support/urdf/m430ia2f.urdf
+++ b/fanuc_m430ia_support/urdf/m430ia2f.urdf
@@ -147,4 +147,11 @@
     <parent link="link_5"/>
     <child link="tool0"/>
   </joint>
+  <link name="base"/>
+  <joint name="base_link-base" type="fixed">
+    <origin rpy="0 0 0" xyz="0 0 0.440"/>
+    <parent link="base_link"/>
+    <child link="base"/>
+  </joint>
 </robot>
+

--- a/fanuc_m430ia_support/urdf/m430ia2f_macro.xacro
+++ b/fanuc_m430ia_support/urdf/m430ia2f_macro.xacro
@@ -138,5 +138,13 @@
 			<parent link="${prefix}link_5"/>
 			<child link="${prefix}tool0"/>
 		</joint>
+
+		<!-- ROS base_link to Fanuc World Coordinates transform -->
+		<link name="${prefix}base" />
+		<joint name="${prefix}base_link-base" type="fixed">
+			<origin xyz="0 0 0.440" rpy="0 0 0"/>
+			<parent link="${prefix}base_link"/>
+			<child link="${prefix}base"/>
+		</joint>
 	</xacro:macro>
 </robot>

--- a/fanuc_m430ia_support/urdf/m430ia2p.urdf
+++ b/fanuc_m430ia_support/urdf/m430ia2p.urdf
@@ -171,4 +171,11 @@
     <parent link="link_6"/>
     <child link="tool0"/>
   </joint>
+  <link name="base"/>
+  <joint name="base_link-base" type="fixed">
+    <origin rpy="0 0 0" xyz="0 0 0.410"/>
+    <parent link="base_link"/>
+    <child link="base"/>
+  </joint>
 </robot>
+

--- a/fanuc_m430ia_support/urdf/m430ia2p_macro.xacro
+++ b/fanuc_m430ia_support/urdf/m430ia2p_macro.xacro
@@ -160,5 +160,13 @@
 			<parent link="${prefix}link_6" />
 			<child link="${prefix}tool0" />
 		</joint>
+
+		<!-- ROS base_link to Fanuc World Coordinates transform -->
+		<link name="${prefix}base" />
+		<joint name="${prefix}base_link-base" type="fixed">
+			<origin xyz="0 0 0.410" rpy="0 0 0"/>
+			<parent link="${prefix}base_link"/>
+			<child link="${prefix}base"/>
+		</joint>
 	</xacro:macro>
 </robot>


### PR DESCRIPTION
This should not affect existing kinematic plugins or MoveIt configurations:
- the link is not part of the main kinematic chain
- the transform is implemented as a fixed joint
