### PR TITLE
driver: add Makefile and robot.ini to build driver.

### DIFF
--- a/fanuc_driver/karel/Makefile
+++ b/fanuc_driver/karel/Makefile
@@ -1,0 +1,28 @@
+
+CC=ktrans.exe
+SUPPORT_VER?=V7.70-1
+CFLAGS=/ver $(SUPPORT_VER)
+
+SRCS=\
+	libind_hdr.kl \
+	libind_log.kl \
+	libind_mth.kl \
+	libind_pkt.kl \
+	libind_rs.kl  \
+	libssock.kl   \
+	ros_relay.kl  \
+	ros_state.kl
+
+OBJS=$(SRCS:.kl=.pc)
+
+.PHONY: clean
+
+all: $(OBJS)
+
+clean:
+	@rm -f $(OBJS)
+
+%.pc: %.kl
+	@echo ">>> Building $^"
+	@$(CC) $^ $(CFLAGS)
+	@echo ""

--- a/fanuc_driver/karel/robot.ini
+++ b/fanuc_driver/karel/robot.ini
@@ -1,0 +1,2 @@
+[WinOLPC_Util]
+Robot=.


### PR DESCRIPTION
This allows building the driver from the command line, in stead of
using Roboguide. The Makefile by default builds for V7.70 systems,
but this can be overriden by setting the SUPPORT_VER variable. Example:

``` bash
make SUPPORT_VER=V8.20-1
```

This would build for V8.20 systems.

The included robot.ini file seems to be the absolute minimum needed
to succesfully compile the Karel sources. P-code files will not be
copied to any Roboguide workcells, but are written to the cwd.

Note: ktrans.exe is expected to be on the path.
