### PR TITLE
Fix issue 118: make indentation conform to ROS styleguide

### DIFF
--- a/fanuc_assets/urdf/common_colours.xacro
+++ b/fanuc_assets/urdf/common_colours.xacro
@@ -1,15 +1,15 @@
 <?xml version="1.0"?>
 <robot xmlns:xacro="http://ros.org/wiki/xacro">
 
-	<!-- RAL 1021 -->
-	<xacro:property name="color_fanuc_yellow"   value="0.96 0.76 0.13 1.0" />
-	<!-- RAL 9002 -->
-	<xacro:property name="color_fanuc_white"    value="0.86 0.85 0.81 1.0" />
-	<!-- RAL 7024 -->
-	<xacro:property name="color_fanuc_grey"     value="0.34 0.35 0.36 1.0" />
+  <!-- RAL 1021 -->
+  <xacro:property name="color_fanuc_yellow"   value="0.96 0.76 0.13 1.0" />
+  <!-- RAL 9002 -->
+  <xacro:property name="color_fanuc_white"    value="0.86 0.85 0.81 1.0" />
+  <!-- RAL 7024 -->
+  <xacro:property name="color_fanuc_grey"     value="0.34 0.35 0.36 1.0" />
 
-	<!-- approximations -->
-	<xacro:property name="color_fanuc_black"    value="0.15 0.15 0.15 1.0" />
-	<xacro:property name="color_fanuc_greyish"  value="0.75 0.75 0.75 1.0" />
+  <!-- approximations -->
+  <xacro:property name="color_fanuc_black"    value="0.15 0.15 0.15 1.0" />
+  <xacro:property name="color_fanuc_greyish"  value="0.75 0.75 0.75 1.0" />
 
 </robot>

--- a/fanuc_assets/urdf/common_constants.xacro
+++ b/fanuc_assets/urdf/common_constants.xacro
@@ -1,11 +1,11 @@
 <?xml version="1.0"?>
 <robot xmlns:xacro="http://ros.org/wiki/xacro">
 
-	<!-- Pi, the ratio of a circle's circumference to its diameter -->
-	<xacro:property name="m_pi" value="3.1415926535" />
-	<!-- Pi divided by two -->
-	<xacro:property name="m_pi_2" value="1.570796327" />
-	<!-- Pi divided by four -->
-	<xacro:property name="m_pi_4" value="0.785398163" />
+  <!-- Pi, the ratio of a circle's circumference to its diameter -->
+  <xacro:property name="m_pi" value="3.1415926535" />
+  <!-- Pi divided by two -->
+  <xacro:property name="m_pi_2" value="1.570796327" />
+  <!-- Pi divided by four -->
+  <xacro:property name="m_pi_4" value="0.785398163" />
 
 </robot>

--- a/fanuc_assets/urdf/common_materials.xacro
+++ b/fanuc_assets/urdf/common_materials.xacro
@@ -1,35 +1,35 @@
 <?xml version="1.0"?>
 <robot xmlns:xacro="http://ros.org/wiki/xacro">
-	<xacro:include filename="$(find fanuc_assets)/urdf/common_colours.xacro"/>
+  <xacro:include filename="$(find fanuc_assets)/urdf/common_colours.xacro"/>
 
-	<xacro:macro name="material_fanuc_yellow">
-		<material name="">
-			<color rgba="${color_fanuc_yellow}"/>
-		</material>
-	</xacro:macro>
+  <xacro:macro name="material_fanuc_yellow">
+    <material name="">
+      <color rgba="${color_fanuc_yellow}"/>
+    </material>
+  </xacro:macro>
 
-	<xacro:macro name="material_fanuc_white">
-		<material name="">
-			<color rgba="${color_fanuc_white}"/>
-		</material>
-	</xacro:macro>
+  <xacro:macro name="material_fanuc_white">
+    <material name="">
+      <color rgba="${color_fanuc_white}"/>
+    </material>
+  </xacro:macro>
 
-	<xacro:macro name="material_fanuc_black">
-		<material name="">
-			<color rgba="${color_fanuc_black}"/>
-		</material>
-	</xacro:macro>
+  <xacro:macro name="material_fanuc_black">
+    <material name="">
+      <color rgba="${color_fanuc_black}"/>
+    </material>
+  </xacro:macro>
 
-	<xacro:macro name="material_fanuc_grey">
-		<material name="">
-			<color rgba="${color_fanuc_grey}"/>
-		</material>
-	</xacro:macro>
+  <xacro:macro name="material_fanuc_grey">
+    <material name="">
+      <color rgba="${color_fanuc_grey}"/>
+    </material>
+  </xacro:macro>
 
-	<xacro:macro name="material_fanuc_greyish">
-		<material name="">
-			<color rgba="${color_fanuc_greyish}"/>
-		</material>
-	</xacro:macro>
+  <xacro:macro name="material_fanuc_greyish">
+    <material name="">
+      <color rgba="${color_fanuc_greyish}"/>
+    </material>
+  </xacro:macro>
 
 </robot>

--- a/fanuc_driver/include/fanuc_driver/fanuc_utils.h
+++ b/fanuc_driver/include/fanuc_driver/fanuc_utils.h
@@ -60,7 +60,7 @@ namespace utils
  *   J3_out = J3_in + j23_factor * J2_in
  */
 void linkage_transform(const std::vector<double>& joints_in,
-		std::vector<double>* joints_out, double J23_factor = 0);
+    std::vector<double>* joints_out, double J23_factor = 0);
 
 /**
  * \brief Corrects for parallel linkage coupling between joints.
@@ -71,7 +71,7 @@ void linkage_transform(const std::vector<double>& joints_in,
  *   J3_out = J3_in + j23_factor * J2_in
  */
 void linkage_transform(const trajectory_msgs::JointTrajectoryPoint& pt_in,
-		trajectory_msgs::JointTrajectoryPoint* pt_out, double J23_factor = 0);
+    trajectory_msgs::JointTrajectoryPoint* pt_out, double J23_factor = 0);
 
 
 } //fanuc

--- a/fanuc_driver/launch/motion_streaming_interface.launch
+++ b/fanuc_driver/launch/motion_streaming_interface.launch
@@ -2,26 +2,26 @@
   Wrapper launch file for the Fanuc specific motion streaming interface node.
 -->
 <launch>
-	<!-- IP of robot (or PC running simulation) -->
-	<arg name="robot_ip" />
+  <!-- IP of robot (or PC running simulation) -->
+  <arg name="robot_ip" />
 
-	<!-- J23_factor: set to correct factor to compensate for J23 coupling:
-	            -1 : negative coupling (J3' = J3 - J2)
-	             0 : no coupling       (J3' = J3)
-	             1 : positive coupling (J3' = J3 + J2)
-	-->
-	<arg name="J23_factor" />
+  <!-- J23_factor: set to correct factor to compensate for J23 coupling:
+              -1 : negative coupling (J3' = J3 - J2)
+               0 : no coupling       (J3' = J3)
+               1 : positive coupling (J3' = J3 + J2)
+  -->
+  <arg name="J23_factor" />
 
-	<!-- Load the byte-swapping version of robot_state if required -->
-	<arg name="use_bswap" />
+  <!-- Load the byte-swapping version of robot_state if required -->
+  <arg name="use_bswap" />
 
-	<!-- put them on the parameter server -->
-	<param name="robot_ip_address" type="str" value="$(arg robot_ip)" />
-	<param name="J23_factor"       type="int" value="$(arg J23_factor)" />
+  <!-- put them on the parameter server -->
+  <param name="robot_ip_address" type="str" value="$(arg robot_ip)" />
+  <param name="J23_factor"       type="int" value="$(arg J23_factor)" />
 
-	<!-- load the correct version of the motion streaming node -->
-	<node if="$(arg use_bswap)" name="motion_streaming_interface"
-		pkg="fanuc_driver" type="motion_streaming_interface_bswap" />
-	<node unless="$(arg use_bswap)" name="motion_streaming_interface"
-		pkg="fanuc_driver" type="motion_streaming_interface" />
+  <!-- load the correct version of the motion streaming node -->
+  <node if="$(arg use_bswap)" name="motion_streaming_interface"
+    pkg="fanuc_driver" type="motion_streaming_interface_bswap" />
+  <node unless="$(arg use_bswap)" name="motion_streaming_interface"
+    pkg="fanuc_driver" type="motion_streaming_interface" />
 </launch>

--- a/fanuc_driver/launch/robot_interface_streaming.launch
+++ b/fanuc_driver/launch/robot_interface_streaming.launch
@@ -15,45 +15,45 @@
     robot_interface_streaming.launch robot_ip:=<value> J23_factor:=<-1,0,1> use_bswap:=<true,false>
 -->
 
-	<!-- robot_ip: IP-address of the robot's socket-messaging server -->
-	<arg name="robot_ip" />
+  <!-- robot_ip: IP-address of the robot's socket-messaging server -->
+  <arg name="robot_ip" />
 
-	<!-- J23_factor: set to correct factor to compensate for J23 coupling:
-	            -1 : negative coupling (J3' = J3 - J2)
-	             0 : no coupling (J3' == J3)
-	             1 : positive coupling (J3' = J3 + J2)
-	-->
-	<arg name="J23_factor" />
+  <!-- J23_factor: set to correct factor to compensate for J23 coupling:
+              -1 : negative coupling (J3' = J3 - J2)
+               0 : no coupling (J3' == J3)
+               1 : positive coupling (J3' = J3 + J2)
+  -->
+  <arg name="J23_factor" />
 
-	<!-- Load the byte-swapping versions of Fanuc nodes if required -->
-	<arg name="use_bswap" />
+  <!-- Load the byte-swapping versions of Fanuc nodes if required -->
+  <arg name="use_bswap" />
 
-	<!-- copy the specified parameters to the Parameter Server, for 
-	     use by nodes below -->
-	<param name="robot_ip_address" type="str" value="$(arg robot_ip)" />
-	<param name="J23_factor"       type="int" value="$(arg J23_factor)" />
+  <!-- copy the specified parameters to the Parameter Server, for 
+       use by nodes below -->
+  <param name="robot_ip_address" type="str" value="$(arg robot_ip)" />
+  <param name="J23_factor"       type="int" value="$(arg J23_factor)" />
 
-	<!-- robot_state: publishes joint positions and robot-state data
-	     (from socket connection to robot)
-	-->
-	<include file="$(find fanuc_driver)/launch/robot_state.launch">
-		<arg name="robot_ip"   value="$(arg robot_ip)" />
-		<arg name="J23_factor" value="$(arg J23_factor)" />
-		<arg name="use_bswap"  value="$(arg use_bswap)" />
-	</include>
+  <!-- robot_state: publishes joint positions and robot-state data
+       (from socket connection to robot)
+  -->
+  <include file="$(find fanuc_driver)/launch/robot_state.launch">
+    <arg name="robot_ip"   value="$(arg robot_ip)" />
+    <arg name="J23_factor" value="$(arg J23_factor)" />
+    <arg name="use_bswap"  value="$(arg use_bswap)" />
+  </include>
 
-	<!-- motion_streaming_interface: sends robot motion commands by 
-	     STREAMING path to robot (using socket connection to robot) 
-	-->
-	<include file="$(find fanuc_driver)/launch/motion_streaming_interface.launch">
-		<arg name="robot_ip"   value="$(arg robot_ip)" />
-		<arg name="J23_factor" value="$(arg J23_factor)" />
-		<arg name="use_bswap"  value="$(arg use_bswap)" />
-	</include>
+  <!-- motion_streaming_interface: sends robot motion commands by 
+       STREAMING path to robot (using socket connection to robot) 
+  -->
+  <include file="$(find fanuc_driver)/launch/motion_streaming_interface.launch">
+    <arg name="robot_ip"   value="$(arg robot_ip)" />
+    <arg name="J23_factor" value="$(arg J23_factor)" />
+    <arg name="use_bswap"  value="$(arg use_bswap)" />
+  </include>
 
-	<!-- joint_trajectory_action: provides actionlib interface for 
-	     high-level robot control
-	-->
-	<node pkg="industrial_robot_client" type="joint_trajectory_action" 
-		name="joint_trajectory_action" />
+  <!-- joint_trajectory_action: provides actionlib interface for 
+       high-level robot control
+  -->
+  <node pkg="industrial_robot_client" type="joint_trajectory_action" 
+    name="joint_trajectory_action" />
 </launch>

--- a/fanuc_driver/launch/robot_state.launch
+++ b/fanuc_driver/launch/robot_state.launch
@@ -2,26 +2,26 @@
   Wrapper launch file for the Fanuc specific robot_state node.
 -->
 <launch>
-	<!-- IP of robot (or PC running simulation) -->
-	<arg name="robot_ip" />
+  <!-- IP of robot (or PC running simulation) -->
+  <arg name="robot_ip" />
 
-	<!-- J23_factor: set to correct factor to compensate for J23 coupling:
-	            -1 : negative coupling (J3' = J3 - J2)
-	             0 : no coupling       (J3' = J3)
-	             1 : positive coupling (J3' = J3 + J2)
-	-->
-	<arg name="J23_factor" />
+  <!-- J23_factor: set to correct factor to compensate for J23 coupling:
+              -1 : negative coupling (J3' = J3 - J2)
+               0 : no coupling       (J3' = J3)
+               1 : positive coupling (J3' = J3 + J2)
+  -->
+  <arg name="J23_factor" />
 
-	<!-- Load the byte-swapping version of robot_state if required -->
-	<arg name="use_bswap" />
+  <!-- Load the byte-swapping version of robot_state if required -->
+  <arg name="use_bswap" />
 
-	<!-- put them on the parameter server -->
-	<param name="robot_ip_address" type="str" value="$(arg robot_ip)" />
-	<param name="J23_factor"       type="int" value="$(arg J23_factor)" />
+  <!-- put them on the parameter server -->
+  <param name="robot_ip_address" type="str" value="$(arg robot_ip)" />
+  <param name="J23_factor"       type="int" value="$(arg J23_factor)" />
 
-	<!-- load the correct version of the robot state node -->
-	<node if="$(arg use_bswap)" name="joint_state" 
-		pkg="fanuc_driver" type="robot_state_bswap" />
-	<node unless="$(arg use_bswap)" name="joint_state" 
-		pkg="fanuc_driver" type="robot_state" />
+  <!-- load the correct version of the robot state node -->
+  <node if="$(arg use_bswap)" name="joint_state" 
+    pkg="fanuc_driver" type="robot_state_bswap" />
+  <node unless="$(arg use_bswap)" name="joint_state" 
+    pkg="fanuc_driver" type="robot_state" />
 </launch>

--- a/fanuc_driver/src/fanuc_joint_streamer_node.cpp
+++ b/fanuc_driver/src/fanuc_joint_streamer_node.cpp
@@ -46,48 +46,48 @@ using industrial_robot_client::joint_trajectory_streamer::JointTrajectoryStreame
 
 class Fanuc_JointTrajectoryStreamer : public JointTrajectoryStreamer
 {
-	int J23_factor_;
+  int J23_factor_;
 
 
 public:
-	Fanuc_JointTrajectoryStreamer() : JointTrajectoryStreamer(), J23_factor_(0)
-	{
-		if (ros::param::has("J23_factor"))
-		{
-			ros::param::get("J23_factor", this->J23_factor_);
-		}
-		else
-		{
-			// TODO: abort on missing parameter
-			ROS_ERROR("Joint 2-3 linkage factor parameter not supplied.");
-		}
-	}
+  Fanuc_JointTrajectoryStreamer() : JointTrajectoryStreamer(), J23_factor_(0)
+  {
+    if (ros::param::has("J23_factor"))
+    {
+      ros::param::get("J23_factor", this->J23_factor_);
+    }
+    else
+    {
+      // TODO: abort on missing parameter
+      ROS_ERROR("Joint 2-3 linkage factor parameter not supplied.");
+    }
+  }
 
 
-	virtual ~Fanuc_JointTrajectoryStreamer() {}
+  virtual ~Fanuc_JointTrajectoryStreamer() {}
 
 
-	bool transform(const trajectory_msgs::JointTrajectoryPoint& pt_in,
-			trajectory_msgs::JointTrajectoryPoint* pt_out)
-	{
-		// sending points back to the Fanuc, so invert factor
-		fanuc::utils::linkage_transform(pt_in, pt_out, -J23_factor_);
+  bool transform(const trajectory_msgs::JointTrajectoryPoint& pt_in,
+      trajectory_msgs::JointTrajectoryPoint* pt_out)
+  {
+    // sending points back to the Fanuc, so invert factor
+    fanuc::utils::linkage_transform(pt_in, pt_out, -J23_factor_);
 
-		return true;
-	}
+    return true;
+  }
 };
 
 
 int main(int argc, char** argv)
 {
-	// initialize node
-	ros::init(argc, argv, "motion_interface");
+  // initialize node
+  ros::init(argc, argv, "motion_interface");
 
-	// launch the default JointTrajectoryStreamer connection/handlers
-	Fanuc_JointTrajectoryStreamer motionInterface;
+  // launch the default JointTrajectoryStreamer connection/handlers
+  Fanuc_JointTrajectoryStreamer motionInterface;
 
-	motionInterface.init();
-	motionInterface.run();
+  motionInterface.init();
+  motionInterface.run();
 
-	return 0;
+  return 0;
 }

--- a/fanuc_driver/src/fanuc_robot_state_node.cpp
+++ b/fanuc_driver/src/fanuc_robot_state_node.cpp
@@ -49,54 +49,54 @@ using industrial_utils::param::getJointNames;
 
 class Fanuc_JointRelayHandler : public JointRelayHandler
 {
-	int J23_factor_;
+  int J23_factor_;
 
 
 public:
-	Fanuc_JointRelayHandler() : JointRelayHandler(), J23_factor_(0)
-	{
-		if (ros::param::has("J23_factor"))
-		{
-			ros::param::get("J23_factor", this->J23_factor_);
-		}
-		else
-		{
-			// TODO: abort on missing parameter
-			ROS_ERROR("Joint 2-3 linkage factor parameter not supplied.");
-		}
-	}
+  Fanuc_JointRelayHandler() : JointRelayHandler(), J23_factor_(0)
+  {
+    if (ros::param::has("J23_factor"))
+    {
+      ros::param::get("J23_factor", this->J23_factor_);
+    }
+    else
+    {
+      // TODO: abort on missing parameter
+      ROS_ERROR("Joint 2-3 linkage factor parameter not supplied.");
+    }
+  }
 
 
-	virtual ~Fanuc_JointRelayHandler() {}
+  virtual ~Fanuc_JointRelayHandler() {}
 
 
-	bool transform(const std::vector<double>& pos_in, std::vector<double>* pos_out)
-	{
-		// compensate for J2-J3 coupling in Fanuc manipulator, if required
-		fanuc::utils::linkage_transform(pos_in, pos_out, J23_factor_);
-		return true;
-	}
+  bool transform(const std::vector<double>& pos_in, std::vector<double>* pos_out)
+  {
+    // compensate for J2-J3 coupling in Fanuc manipulator, if required
+    fanuc::utils::linkage_transform(pos_in, pos_out, J23_factor_);
+    return true;
+  }
 };
 
 
 int main(int argc, char** argv)
 {
-	// initialize node
-	ros::init(argc, argv, "state_interface");
+  // initialize node
+  ros::init(argc, argv, "state_interface");
 
-	// launch the default Robot State Interface connection/handlers
-	RobotStateInterface rsi;
-	rsi.init();
+  // launch the default Robot State Interface connection/handlers
+  RobotStateInterface rsi;
+  rsi.init();
 
-	// replace the generic JointRelayHandler with our Fanuc specific one as
-	// we need to correct the reported joint angles
-	Fanuc_JointRelayHandler jointHandler;
-	std::vector<std::string> joint_names = rsi.get_joint_names();
-	jointHandler.init(rsi.get_connection(), joint_names);
-	rsi.add_handler(&jointHandler);
+  // replace the generic JointRelayHandler with our Fanuc specific one as
+  // we need to correct the reported joint angles
+  Fanuc_JointRelayHandler jointHandler;
+  std::vector<std::string> joint_names = rsi.get_joint_names();
+  jointHandler.init(rsi.get_connection(), joint_names);
+  rsi.add_handler(&jointHandler);
 
-	// run the node
-	rsi.run();
+  // run the node
+  rsi.run();
 
-	return 0;
+  return 0;
 }

--- a/fanuc_driver/src/fanuc_utils.cpp
+++ b/fanuc_driver/src/fanuc_utils.cpp
@@ -50,20 +50,20 @@ namespace utils
 // TBD: This transform should also account for velocity/acceleration affects
 //      due to linkage, so that velocity calculation is accurate
 void linkage_transform(const trajectory_msgs::JointTrajectoryPoint& pt_in,
-		trajectory_msgs::JointTrajectoryPoint* pt_out, double J23_factor)
+    trajectory_msgs::JointTrajectoryPoint* pt_out, double J23_factor)
 {
-	*pt_out = pt_in;
-	linkage_transform(pt_in.positions, &(pt_out->positions), J23_factor);
+  *pt_out = pt_in;
+  linkage_transform(pt_in.positions, &(pt_out->positions), J23_factor);
 }
 
 
 void linkage_transform(const std::vector<double>& points_in,
-		std::vector<double>* points_out, double J23_factor)
+    std::vector<double>* points_out, double J23_factor)
 {
-	ROS_ASSERT(points_in.size() > 3);
+  ROS_ASSERT(points_in.size() > 3);
 
-	*points_out = points_in;
-	points_out->at(2) += J23_factor * points_out->at(1);
+  *points_out = points_in;
+  points_out->at(2) += J23_factor * points_out->at(1);
 }
 
 

--- a/fanuc_m10ia_support/launch/load_m10ia.launch
+++ b/fanuc_m10ia_support/launch/load_m10ia.launch
@@ -1,3 +1,3 @@
 <launch>
-	<param name="robot_description" command="$(find xacro)/xacro.py '$(find fanuc_m10ia_support)/urdf/m10ia.xacro'" />
+  <param name="robot_description" command="$(find xacro)/xacro.py '$(find fanuc_m10ia_support)/urdf/m10ia.xacro'" />
 </launch>

--- a/fanuc_m10ia_support/launch/robot_interface_streaming_m10ia.launch
+++ b/fanuc_m10ia_support/launch/robot_interface_streaming_m10ia.launch
@@ -10,15 +10,15 @@
     robot_interface_streaming_m10ia.launch robot_ip:=<value>
 -->
 <launch>
-	<arg name="robot_ip" />
-	<arg name="J23_factor" default="1" />
-	<arg name="use_bswap" default="true" />
+  <arg name="robot_ip" />
+  <arg name="J23_factor" default="1" />
+  <arg name="use_bswap" default="true" />
 
-	<rosparam command="load" file="$(find fanuc_m10ia_support)/config/joint_names_m10ia.yaml" />
+  <rosparam command="load" file="$(find fanuc_m10ia_support)/config/joint_names_m10ia.yaml" />
 
-	<include file="$(find fanuc_driver)/launch/robot_interface_streaming.launch">
-		<arg name="robot_ip"   value="$(arg robot_ip)" />
-		<arg name="J23_factor" value="$(arg J23_factor)" />
-		<arg name="use_bswap"  value="$(arg use_bswap)" />
-	</include>
+  <include file="$(find fanuc_driver)/launch/robot_interface_streaming.launch">
+    <arg name="robot_ip"   value="$(arg robot_ip)" />
+    <arg name="J23_factor" value="$(arg J23_factor)" />
+    <arg name="use_bswap"  value="$(arg use_bswap)" />
+  </include>
 </launch>

--- a/fanuc_m10ia_support/launch/robot_state_visualize_m10ia.launch
+++ b/fanuc_m10ia_support/launch/robot_state_visualize_m10ia.launch
@@ -10,22 +10,22 @@
     robot_state_visualize_m10ia.launch robot_ip:=<value>
 -->
 <launch>
-	<arg name="robot_ip" />
-	<arg name="J23_factor" default="1" />
-	<arg name="use_bswap" default="true" />
+  <arg name="robot_ip" />
+  <arg name="J23_factor" default="1" />
+  <arg name="use_bswap" default="true" />
 
-	<rosparam command="load" file="$(find fanuc_m10ia_support)/config/joint_names_m10ia.yaml" />
+  <rosparam command="load" file="$(find fanuc_m10ia_support)/config/joint_names_m10ia.yaml" />
 
-	<include file="$(find fanuc_driver)/launch/robot_state.launch">
-		<arg name="robot_ip"   value="$(arg robot_ip)" />
-		<arg name="J23_factor" value="$(arg J23_factor)" />
-		<arg name="use_bswap"  value="$(arg use_bswap)" />
-	</include>
+  <include file="$(find fanuc_driver)/launch/robot_state.launch">
+    <arg name="robot_ip"   value="$(arg robot_ip)" />
+    <arg name="J23_factor" value="$(arg J23_factor)" />
+    <arg name="use_bswap"  value="$(arg use_bswap)" />
+  </include>
 
-	<node name="robot_state_publisher" pkg="robot_state_publisher" 
-		type="robot_state_publisher" />
+  <node name="robot_state_publisher" pkg="robot_state_publisher" 
+    type="robot_state_publisher" />
 
-	<include file="$(find fanuc_m10ia_support)/launch/load_m10ia.launch" />
+  <include file="$(find fanuc_m10ia_support)/launch/load_m10ia.launch" />
 
-	<node name="rviz" pkg="rviz" type="rviz" args="-d $(find industrial_robot_client)/config/robot_state_visualize.rviz" required="true" />
+  <node name="rviz" pkg="rviz" type="rviz" args="-d $(find industrial_robot_client)/config/robot_state_visualize.rviz" required="true" />
 </launch>

--- a/fanuc_m10ia_support/launch/test_m10ia.launch
+++ b/fanuc_m10ia_support/launch/test_m10ia.launch
@@ -1,7 +1,7 @@
 <launch>
-	<include file="$(find fanuc_m10ia_support)/launch/load_m10ia.launch" />
-	<param name="use_gui" value="true" />
-	<node name="joint_state_publisher" pkg="joint_state_publisher" type="joint_state_publisher" />
-	<node name="robot_state_publisher" pkg="robot_state_publisher" type="robot_state_publisher" />
-	<node name="rviz" pkg="rviz" type="rviz" args="-d $(find industrial_robot_client)/config/robot_state_visualize.rviz" required="true" />
+  <include file="$(find fanuc_m10ia_support)/launch/load_m10ia.launch" />
+  <param name="use_gui" value="true" />
+  <node name="joint_state_publisher" pkg="joint_state_publisher" type="joint_state_publisher" />
+  <node name="robot_state_publisher" pkg="robot_state_publisher" type="robot_state_publisher" />
+  <node name="rviz" pkg="rviz" type="rviz" args="-d $(find industrial_robot_client)/config/robot_state_visualize.rviz" required="true" />
 </launch>

--- a/fanuc_m10ia_support/urdf/m10ia.xacro
+++ b/fanuc_m10ia_support/urdf/m10ia.xacro
@@ -1,6 +1,6 @@
 <?xml version="1.0" ?>
 
 <robot name="fanuc_m10ia" xmlns:xacro="http://ros.org/wiki/xacro">
-	<xacro:include filename="$(find fanuc_m10ia_support)/urdf/m10ia_macro.xacro"/>
-	<xacro:fanuc_m10ia prefix=""/>
+  <xacro:include filename="$(find fanuc_m10ia_support)/urdf/m10ia_macro.xacro"/>
+  <xacro:fanuc_m10ia prefix=""/>
 </robot>

--- a/fanuc_m10ia_support/urdf/m10ia_macro.xacro
+++ b/fanuc_m10ia_support/urdf/m10ia_macro.xacro
@@ -1,172 +1,172 @@
 <?xml version="1.0"?>
 <robot xmlns:xacro="http://ros.org/wiki/xacro">
-	<xacro:include filename="$(find fanuc_resources)/urdf/common_materials.xacro"/>
-	<xacro:include filename="$(find fanuc_resources)/urdf/common_constants.xacro"/>
+  <xacro:include filename="$(find fanuc_resources)/urdf/common_materials.xacro"/>
+  <xacro:include filename="$(find fanuc_resources)/urdf/common_constants.xacro"/>
 
-	<xacro:macro name="fanuc_m10ia" params="prefix">
-		<!-- links -->
-		<link name="${prefix}base_link">
-			<visual>
-				<origin xyz="0 0 0" rpy="0 0 0"/>
-				<geometry>
-					<mesh filename="package://fanuc_m10ia_support/meshes/m10ia/visual/base_link.stl"/>
-				</geometry>
-				<xacro:material_fanuc_grey />
-			</visual>
-			<collision>
-				<origin xyz="0 0 0" rpy="0 0 0"/>
-				<geometry>
-					<mesh filename="package://fanuc_m10ia_support/meshes/m10ia/collision/base_link.stl"/>
-				</geometry>
-			</collision>
-		</link>
-		<link name="${prefix}link_1">
-			<visual>
-				<origin xyz="0 0 0" rpy="0 0 0"/>
-				<geometry>
-					<mesh filename="package://fanuc_m10ia_support/meshes/m10ia/visual/link_1.stl"/>
-				</geometry>
-				<xacro:material_fanuc_yellow />
-			</visual>
-			<collision>
-				<origin xyz="0 0 0" rpy="0 0 0"/>
-				<geometry>
-					<mesh filename="package://fanuc_m10ia_support/meshes/m10ia/collision/link_1.stl"/>
-				</geometry>
-			</collision>
-		</link>
-		<link name="${prefix}link_2">
-			<visual>
-				<origin xyz="0 0 0" rpy="0 0 0"/>
-				<geometry>
-					<mesh filename="package://fanuc_m10ia_support/meshes/m10ia/visual/link_2.stl"/>
-				</geometry>
-				<xacro:material_fanuc_yellow />
-			</visual>
-			<collision>
-				<origin xyz="0 0 0" rpy="0 0 0"/>
-				<geometry>
-					<mesh filename="package://fanuc_m10ia_support/meshes/m10ia/collision/link_2.stl"/>
-				</geometry>
-			</collision>
-		</link>
-		<link name="${prefix}link_3">
-			<visual>
-				<origin xyz="0 0 0" rpy="0 0 0"/>
-				<geometry>
-					<mesh filename="package://fanuc_m10ia_support/meshes/m10ia/visual/link_3.stl"/>
-				</geometry>
-				<xacro:material_fanuc_yellow />
-			</visual>
-			<collision>
-				<origin xyz="0 0 0" rpy="0 0 0"/>
-				<geometry>
-					<mesh filename="package://fanuc_m10ia_support/meshes/m10ia/collision/link_3.stl"/>
-				</geometry>
-			</collision>
-		</link>
-		<link name="${prefix}link_4">
-			<visual>
-				<origin xyz="0 0 0" rpy="0 0 0"/>
-				<geometry>
-					<mesh filename="package://fanuc_m10ia_support/meshes/m10ia/visual/link_4.stl"/>
-				</geometry>
-				<xacro:material_fanuc_yellow />
-			</visual>
-			<collision>
-				<origin xyz="0 0 0" rpy="0 0 0"/>
-				<geometry>
-					<mesh filename="package://fanuc_m10ia_support/meshes/m10ia/collision/link_4.stl"/>
-				</geometry>
-			</collision>
-		</link>
-		<link name="${prefix}link_5">
-			<visual>
-				<origin xyz="0 0 0" rpy="0 0 0"/>
-				<geometry>
-					<mesh filename="package://fanuc_m10ia_support/meshes/m10ia/visual/link_5.stl"/>
-				</geometry>
-				<xacro:material_fanuc_yellow />
-			</visual>
-			<collision>
-				<origin xyz="0 0 0" rpy="0 0 0"/>
-				<geometry>
-					<mesh filename="package://fanuc_m10ia_support/meshes/m10ia/collision/link_5.stl"/>
-				</geometry>
-			</collision>
-		</link>
-		<link name="${prefix}link_6">
-			<visual>
-				<origin xyz="0 0 0" rpy="0 0 0"/>
-				<geometry>
-					<mesh filename="package://fanuc_m10ia_support/meshes/m10ia/visual/link_6.stl"/>
-				</geometry>
-				<xacro:material_fanuc_black />
-			</visual>
-			<collision>
-				<origin xyz="0 0 0" rpy="0 0 0"/>
-				<geometry>
-					<mesh filename="package://fanuc_m10ia_support/meshes/m10ia/collision/link_6.stl"/>
-				</geometry>
-			</collision>
-		</link>
-		<link name="${prefix}tool0"/>
+  <xacro:macro name="fanuc_m10ia" params="prefix">
+    <!-- links -->
+    <link name="${prefix}base_link">
+      <visual>
+        <origin xyz="0 0 0" rpy="0 0 0"/>
+        <geometry>
+          <mesh filename="package://fanuc_m10ia_support/meshes/m10ia/visual/base_link.stl"/>
+        </geometry>
+        <xacro:material_fanuc_grey />
+      </visual>
+      <collision>
+        <origin xyz="0 0 0" rpy="0 0 0"/>
+        <geometry>
+          <mesh filename="package://fanuc_m10ia_support/meshes/m10ia/collision/base_link.stl"/>
+        </geometry>
+      </collision>
+    </link>
+    <link name="${prefix}link_1">
+      <visual>
+        <origin xyz="0 0 0" rpy="0 0 0"/>
+        <geometry>
+          <mesh filename="package://fanuc_m10ia_support/meshes/m10ia/visual/link_1.stl"/>
+        </geometry>
+        <xacro:material_fanuc_yellow />
+      </visual>
+      <collision>
+        <origin xyz="0 0 0" rpy="0 0 0"/>
+        <geometry>
+          <mesh filename="package://fanuc_m10ia_support/meshes/m10ia/collision/link_1.stl"/>
+        </geometry>
+      </collision>
+    </link>
+    <link name="${prefix}link_2">
+      <visual>
+        <origin xyz="0 0 0" rpy="0 0 0"/>
+        <geometry>
+          <mesh filename="package://fanuc_m10ia_support/meshes/m10ia/visual/link_2.stl"/>
+        </geometry>
+        <xacro:material_fanuc_yellow />
+      </visual>
+      <collision>
+        <origin xyz="0 0 0" rpy="0 0 0"/>
+        <geometry>
+          <mesh filename="package://fanuc_m10ia_support/meshes/m10ia/collision/link_2.stl"/>
+        </geometry>
+      </collision>
+    </link>
+    <link name="${prefix}link_3">
+      <visual>
+        <origin xyz="0 0 0" rpy="0 0 0"/>
+        <geometry>
+          <mesh filename="package://fanuc_m10ia_support/meshes/m10ia/visual/link_3.stl"/>
+        </geometry>
+        <xacro:material_fanuc_yellow />
+      </visual>
+      <collision>
+        <origin xyz="0 0 0" rpy="0 0 0"/>
+        <geometry>
+          <mesh filename="package://fanuc_m10ia_support/meshes/m10ia/collision/link_3.stl"/>
+        </geometry>
+      </collision>
+    </link>
+    <link name="${prefix}link_4">
+      <visual>
+        <origin xyz="0 0 0" rpy="0 0 0"/>
+        <geometry>
+          <mesh filename="package://fanuc_m10ia_support/meshes/m10ia/visual/link_4.stl"/>
+        </geometry>
+        <xacro:material_fanuc_yellow />
+      </visual>
+      <collision>
+        <origin xyz="0 0 0" rpy="0 0 0"/>
+        <geometry>
+          <mesh filename="package://fanuc_m10ia_support/meshes/m10ia/collision/link_4.stl"/>
+        </geometry>
+      </collision>
+    </link>
+    <link name="${prefix}link_5">
+      <visual>
+        <origin xyz="0 0 0" rpy="0 0 0"/>
+        <geometry>
+          <mesh filename="package://fanuc_m10ia_support/meshes/m10ia/visual/link_5.stl"/>
+        </geometry>
+        <xacro:material_fanuc_yellow />
+      </visual>
+      <collision>
+        <origin xyz="0 0 0" rpy="0 0 0"/>
+        <geometry>
+          <mesh filename="package://fanuc_m10ia_support/meshes/m10ia/collision/link_5.stl"/>
+        </geometry>
+      </collision>
+    </link>
+    <link name="${prefix}link_6">
+      <visual>
+        <origin xyz="0 0 0" rpy="0 0 0"/>
+        <geometry>
+          <mesh filename="package://fanuc_m10ia_support/meshes/m10ia/visual/link_6.stl"/>
+        </geometry>
+        <xacro:material_fanuc_black />
+      </visual>
+      <collision>
+        <origin xyz="0 0 0" rpy="0 0 0"/>
+        <geometry>
+          <mesh filename="package://fanuc_m10ia_support/meshes/m10ia/collision/link_6.stl"/>
+        </geometry>
+      </collision>
+    </link>
+    <link name="${prefix}tool0"/>
 
-		<!-- joints -->
-		<joint name="${prefix}joint_1" type="revolute">
-			<origin xyz="0 0 0.450" rpy="0 0 0"/>
-			<parent link="${prefix}base_link"/>
-			<child link="${prefix}link_1"/>
-			<axis xyz="0 0 1"/>
-			<limit lower="-3.14" upper="3.14" effort="0" velocity="3.67"/>
-		</joint>
-		<joint name="${prefix}joint_2" type="revolute">
-			<origin xyz="0.150 0 0" rpy="0 0 0"/>
-			<parent link="${prefix}link_1"/>
-			<child link="${prefix}link_2"/>
-			<axis xyz="0 1 0"/>
-			<limit lower="-1.57" upper="2.79" effort="0" velocity="3.32"/>
-		</joint>
-		<joint name="${prefix}joint_3" type="revolute">
-			<origin xyz="0 0 0.600" rpy="0 0 0"/>
-			<parent link="${prefix}link_2"/>
-			<child link="${prefix}link_3"/>
-			<axis xyz="0 -1 0"/>
-			<limit lower="-3.14" upper="4.61" effort="0" velocity="3.67"/>
-		</joint>
-		<joint name="${prefix}joint_4" type="revolute">
-			<origin xyz="0 0 0.200" rpy="0 0 0"/>
-			<parent link="${prefix}link_3"/>
-			<child link="${prefix}link_4"/>
-			<axis xyz="-1 0 0"/>
-			<limit lower="-3.31" upper="3.31" effort="0" velocity="6.98"/>
-		</joint>
-		<joint name="${prefix}joint_5" type="revolute">
-			<origin xyz="0.640 0 0" rpy="0 0 0"/>
-			<parent link="${prefix}link_4"/>
-			<child link="${prefix}link_5"/>
-			<axis xyz="0 -1 0"/>
-			<limit lower="-3.31" upper="3.31" effort="0" velocity="6.98"/>
-		</joint>
-		<joint name="${prefix}joint_6" type="revolute">
-			<origin xyz="0.100 0 0" rpy="0 0 0"/>
-			<parent link="${prefix}link_5"/>
-			<child link="${prefix}link_6"/>
-			<axis xyz="-1 0 0"/>
-			<limit lower="-6.28" upper="6.28" effort="0" velocity="10.47"/>
-		</joint>
-		<joint name="${prefix}joint_6-tool0" type="fixed">
-			<origin xyz="0 0 0" rpy="${m_pi} ${-m_pi_2} 0" />
-			<parent link="${prefix}link_6"/>
-			<child link="${prefix}tool0"/>
-		</joint>
+    <!-- joints -->
+    <joint name="${prefix}joint_1" type="revolute">
+      <origin xyz="0 0 0.450" rpy="0 0 0"/>
+      <parent link="${prefix}base_link"/>
+      <child link="${prefix}link_1"/>
+      <axis xyz="0 0 1"/>
+      <limit lower="-3.14" upper="3.14" effort="0" velocity="3.67"/>
+    </joint>
+    <joint name="${prefix}joint_2" type="revolute">
+      <origin xyz="0.150 0 0" rpy="0 0 0"/>
+      <parent link="${prefix}link_1"/>
+      <child link="${prefix}link_2"/>
+      <axis xyz="0 1 0"/>
+      <limit lower="-1.57" upper="2.79" effort="0" velocity="3.32"/>
+    </joint>
+    <joint name="${prefix}joint_3" type="revolute">
+      <origin xyz="0 0 0.600" rpy="0 0 0"/>
+      <parent link="${prefix}link_2"/>
+      <child link="${prefix}link_3"/>
+      <axis xyz="0 -1 0"/>
+      <limit lower="-3.14" upper="4.61" effort="0" velocity="3.67"/>
+    </joint>
+    <joint name="${prefix}joint_4" type="revolute">
+      <origin xyz="0 0 0.200" rpy="0 0 0"/>
+      <parent link="${prefix}link_3"/>
+      <child link="${prefix}link_4"/>
+      <axis xyz="-1 0 0"/>
+      <limit lower="-3.31" upper="3.31" effort="0" velocity="6.98"/>
+    </joint>
+    <joint name="${prefix}joint_5" type="revolute">
+      <origin xyz="0.640 0 0" rpy="0 0 0"/>
+      <parent link="${prefix}link_4"/>
+      <child link="${prefix}link_5"/>
+      <axis xyz="0 -1 0"/>
+      <limit lower="-3.31" upper="3.31" effort="0" velocity="6.98"/>
+    </joint>
+    <joint name="${prefix}joint_6" type="revolute">
+      <origin xyz="0.100 0 0" rpy="0 0 0"/>
+      <parent link="${prefix}link_5"/>
+      <child link="${prefix}link_6"/>
+      <axis xyz="-1 0 0"/>
+      <limit lower="-6.28" upper="6.28" effort="0" velocity="10.47"/>
+    </joint>
+    <joint name="${prefix}joint_6-tool0" type="fixed">
+      <origin xyz="0 0 0" rpy="${m_pi} ${-m_pi_2} 0" />
+      <parent link="${prefix}link_6"/>
+      <child link="${prefix}tool0"/>
+    </joint>
 
-		<!-- ROS base_link to Fanuc World Coordinates transform -->
-		<link name="${prefix}base" />
-		<joint name="${prefix}base_link-base" type="fixed">
-			<origin xyz="0 0 0.450" rpy="0 0 0"/>
-			<parent link="${prefix}base_link"/>
-			<child link="${prefix}base"/>
-		</joint>
-	</xacro:macro>
+    <!-- ROS base_link to Fanuc World Coordinates transform -->
+    <link name="${prefix}base" />
+    <joint name="${prefix}base_link-base" type="fixed">
+      <origin xyz="0 0 0.450" rpy="0 0 0"/>
+      <parent link="${prefix}base_link"/>
+      <child link="${prefix}base"/>
+    </joint>
+  </xacro:macro>
 </robot>

--- a/fanuc_m16ib_support/launch/load_m16ib20.launch
+++ b/fanuc_m16ib_support/launch/load_m16ib20.launch
@@ -1,3 +1,3 @@
 <launch>
-	<param name="robot_description" command="$(find xacro)/xacro.py '$(find fanuc_m16ib_support)/urdf/m16ib20.xacro'" />
+  <param name="robot_description" command="$(find xacro)/xacro.py '$(find fanuc_m16ib_support)/urdf/m16ib20.xacro'" />
 </launch>

--- a/fanuc_m16ib_support/launch/robot_interface_streaming_m16ib20.launch
+++ b/fanuc_m16ib_support/launch/robot_interface_streaming_m16ib20.launch
@@ -10,15 +10,15 @@
     robot_interface_streaming_m16ib20.launch robot_ip:=<value>
 -->
 <launch>
-	<arg name="robot_ip" />
-	<arg name="J23_factor" default="1" />
-	<arg name="use_bswap" default="true" />
+  <arg name="robot_ip" />
+  <arg name="J23_factor" default="1" />
+  <arg name="use_bswap" default="true" />
 
-	<rosparam command="load" file="$(find fanuc_m16ib_support)/config/joint_names_m16ib20.yaml" />
+  <rosparam command="load" file="$(find fanuc_m16ib_support)/config/joint_names_m16ib20.yaml" />
 
-	<include file="$(find fanuc_driver)/launch/robot_interface_streaming.launch">
-		<arg name="robot_ip"   value="$(arg robot_ip)" />
-		<arg name="J23_factor" value="$(arg J23_factor)" />
-		<arg name="use_bswap"  value="$(arg use_bswap)" />
-	</include>
+  <include file="$(find fanuc_driver)/launch/robot_interface_streaming.launch">
+    <arg name="robot_ip"   value="$(arg robot_ip)" />
+    <arg name="J23_factor" value="$(arg J23_factor)" />
+    <arg name="use_bswap"  value="$(arg use_bswap)" />
+  </include>
 </launch>

--- a/fanuc_m16ib_support/launch/robot_state_visualize_m16ib20.launch
+++ b/fanuc_m16ib_support/launch/robot_state_visualize_m16ib20.launch
@@ -10,22 +10,22 @@
     robot_state_visualize_m16ib20.launch robot_ip:=<value>
 -->
 <launch>
-	<arg name="robot_ip" />
-	<arg name="J23_factor" default="1" />
-	<arg name="use_bswap" default="true" />
+  <arg name="robot_ip" />
+  <arg name="J23_factor" default="1" />
+  <arg name="use_bswap" default="true" />
 
-	<rosparam command="load" file="$(find fanuc_m16ib_support)/config/joint_names_m16ib20.yaml" />
+  <rosparam command="load" file="$(find fanuc_m16ib_support)/config/joint_names_m16ib20.yaml" />
 
-	<include file="$(find fanuc_driver)/launch/robot_state.launch">
-		<arg name="robot_ip"   value="$(arg robot_ip)" />
-		<arg name="J23_factor" value="$(arg J23_factor)" />
-		<arg name="use_bswap"  value="$(arg use_bswap)" />
-	</include>
+  <include file="$(find fanuc_driver)/launch/robot_state.launch">
+    <arg name="robot_ip"   value="$(arg robot_ip)" />
+    <arg name="J23_factor" value="$(arg J23_factor)" />
+    <arg name="use_bswap"  value="$(arg use_bswap)" />
+  </include>
 
-	<node name="robot_state_publisher" pkg="robot_state_publisher" 
-		type="robot_state_publisher" />
+  <node name="robot_state_publisher" pkg="robot_state_publisher" 
+    type="robot_state_publisher" />
 
-	<include file="$(find fanuc_m16ib_support)/launch/load_m16ib20.launch" />
+  <include file="$(find fanuc_m16ib_support)/launch/load_m16ib20.launch" />
 
-	<node name="rviz" pkg="rviz" type="rviz" args="-d $(find industrial_robot_client)/config/robot_state_visualize.rviz" required="true" />
+  <node name="rviz" pkg="rviz" type="rviz" args="-d $(find industrial_robot_client)/config/robot_state_visualize.rviz" required="true" />
 </launch>

--- a/fanuc_m16ib_support/launch/test_m16ib20.launch
+++ b/fanuc_m16ib_support/launch/test_m16ib20.launch
@@ -1,7 +1,7 @@
 <launch>
-	<include file="$(find fanuc_m16ib_support)/launch/load_m16ib20.launch" />
-	<param name="use_gui" value="true" />
-	<node name="joint_state_publisher" pkg="joint_state_publisher" type="joint_state_publisher" />
-	<node name="robot_state_publisher" pkg="robot_state_publisher" type="robot_state_publisher" />
-	<node name="rviz" pkg="rviz" type="rviz" args="-d $(find industrial_robot_client)/config/robot_state_visualize.rviz" required="true" />
+  <include file="$(find fanuc_m16ib_support)/launch/load_m16ib20.launch" />
+  <param name="use_gui" value="true" />
+  <node name="joint_state_publisher" pkg="joint_state_publisher" type="joint_state_publisher" />
+  <node name="robot_state_publisher" pkg="robot_state_publisher" type="robot_state_publisher" />
+  <node name="rviz" pkg="rviz" type="rviz" args="-d $(find industrial_robot_client)/config/robot_state_visualize.rviz" required="true" />
 </launch>

--- a/fanuc_m16ib_support/urdf/m16ib20.xacro
+++ b/fanuc_m16ib_support/urdf/m16ib20.xacro
@@ -1,6 +1,6 @@
 <?xml version="1.0" ?>
 
 <robot name="fanuc_m16ib20" xmlns:xacro="http://ros.org/wiki/xacro">
-	<xacro:include filename="$(find fanuc_m16ib_support)/urdf/m16ib20_macro.xacro"/>
-	<xacro:fanuc_m16ib20 prefix=""/>
+  <xacro:include filename="$(find fanuc_m16ib_support)/urdf/m16ib20_macro.xacro"/>
+  <xacro:fanuc_m16ib20 prefix=""/>
 </robot>

--- a/fanuc_m16ib_support/urdf/m16ib20_macro.xacro
+++ b/fanuc_m16ib_support/urdf/m16ib20_macro.xacro
@@ -1,172 +1,172 @@
 <?xml version="1.0" ?>
 <robot xmlns:xacro="http://ros.org/wiki/xacro">
-	<xacro:include filename="$(find fanuc_resources)/urdf/common_materials.xacro"/>
-	<xacro:include filename="$(find fanuc_resources)/urdf/common_constants.xacro"/>
+  <xacro:include filename="$(find fanuc_resources)/urdf/common_materials.xacro"/>
+  <xacro:include filename="$(find fanuc_resources)/urdf/common_constants.xacro"/>
 
-	<xacro:macro name="fanuc_m16ib20" params="prefix">
-		<!-- links -->
-		<link name="${prefix}base_link">
-			<visual>
-				<origin xyz="0 0 0" rpy="0 0 0"/>
-				<geometry>
-					<mesh filename="package://fanuc_m16ib_support/meshes/m16ib20/visual/base_link.stl"/>
-				</geometry>
-				<xacro:material_fanuc_yellow />
-			</visual>
-			<collision>
-				<origin xyz="0 0 0" rpy="0 0 0"/>
-				<geometry>
-					<mesh filename="package://fanuc_m16ib_support/meshes/m16ib20/collision/base_link.stl"/>
-				</geometry>
-			</collision>
-		</link>
-		<link name="${prefix}link_1">
-			<visual>
-				<origin xyz="0 0 0" rpy="0 0 0"/>
-				<geometry>
-					<mesh filename="package://fanuc_m16ib_support/meshes/m16ib20/visual/link_1.stl"/>
-				</geometry>
-				<xacro:material_fanuc_yellow />
-			</visual>
-			<collision>
-				<origin xyz="0 0 0" rpy="0 0 0"/>
-				<geometry>
-					<mesh filename="package://fanuc_m16ib_support/meshes/m16ib20/collision/link_1.stl"/>
-				</geometry>
-			</collision>
-		</link>
-		<link name="${prefix}link_2">
-			<visual>
-				<origin xyz="0 0 0" rpy="0 0 0"/>
-				<geometry>
-					<mesh filename="package://fanuc_m16ib_support/meshes/m16ib20/visual/link_2.stl"/>
-				</geometry>
-				<xacro:material_fanuc_yellow />
-			</visual>
-			<collision>
-				<origin xyz="0 0 0" rpy="0 0 0"/>
-				<geometry>
-					<mesh filename="package://fanuc_m16ib_support/meshes/m16ib20/collision/link_2.stl"/>
-				</geometry>
-			</collision>
-		</link>
-		<link name="${prefix}link_3">
-			<visual>
-				<origin xyz="0 0 0" rpy="0 0 0"/>
-				<geometry>
-					<mesh filename="package://fanuc_m16ib_support/meshes/m16ib20/visual/link_3.stl"/>
-				</geometry>
-				<xacro:material_fanuc_yellow />
-			</visual>
-			<collision>
-				<origin xyz="0 0 0" rpy="0 0 0"/>
-				<geometry>
-					<mesh filename="package://fanuc_m16ib_support/meshes/m16ib20/collision/link_3.stl"/>
-				</geometry>
-			</collision>
-		</link>
-		<link name="${prefix}link_4">
-			<visual>
-				<origin xyz="0 0 0" rpy="0 0 0"/>
-				<geometry>
-					<mesh filename="package://fanuc_m16ib_support/meshes/m16ib20/visual/link_4.stl"/>
-				</geometry>
-				<xacro:material_fanuc_yellow />
-			</visual>
-			<collision>
-				<origin xyz="0 0 0" rpy="0 0 0"/>
-				<geometry>
-					<mesh filename="package://fanuc_m16ib_support/meshes/m16ib20/collision/link_4.stl"/>
-				</geometry>
-			</collision>
-		</link>
-		<link name="${prefix}link_5">
-			<visual>
-				<origin xyz="0 0 0" rpy="0 0 0"/>
-				<geometry>
-					<mesh filename="package://fanuc_m16ib_support/meshes/m16ib20/visual/link_5.stl"/>
-				</geometry>
-				<xacro:material_fanuc_yellow />
-			</visual>
-			<collision>
-				<origin xyz="0 0 0" rpy="0 0 0"/>
-				<geometry>
-					<mesh filename="package://fanuc_m16ib_support/meshes/m16ib20/collision/link_5.stl"/>
-				</geometry>
-			</collision>
-		</link>
-		<link name="${prefix}link_6">
-			<visual>
-				<origin xyz="0 0 0" rpy="0 0 0"/>
-				<geometry>
-					<mesh filename="package://fanuc_m16ib_support/meshes/m16ib20/visual/link_6.stl"/>
-				</geometry>
-				<xacro:material_fanuc_black />
-			</visual>
-			<collision>
-				<origin xyz="0 0 0" rpy="0 0 0"/>
-				<geometry>
-					<mesh filename="package://fanuc_m16ib_support/meshes/m16ib20/collision/link_6.stl"/>
-				</geometry>
-			</collision>
-		</link>
-		<link name="${prefix}tool0"/>
+  <xacro:macro name="fanuc_m16ib20" params="prefix">
+    <!-- links -->
+    <link name="${prefix}base_link">
+      <visual>
+        <origin xyz="0 0 0" rpy="0 0 0"/>
+        <geometry>
+          <mesh filename="package://fanuc_m16ib_support/meshes/m16ib20/visual/base_link.stl"/>
+        </geometry>
+        <xacro:material_fanuc_yellow />
+      </visual>
+      <collision>
+        <origin xyz="0 0 0" rpy="0 0 0"/>
+        <geometry>
+          <mesh filename="package://fanuc_m16ib_support/meshes/m16ib20/collision/base_link.stl"/>
+        </geometry>
+      </collision>
+    </link>
+    <link name="${prefix}link_1">
+      <visual>
+        <origin xyz="0 0 0" rpy="0 0 0"/>
+        <geometry>
+          <mesh filename="package://fanuc_m16ib_support/meshes/m16ib20/visual/link_1.stl"/>
+        </geometry>
+        <xacro:material_fanuc_yellow />
+      </visual>
+      <collision>
+        <origin xyz="0 0 0" rpy="0 0 0"/>
+        <geometry>
+          <mesh filename="package://fanuc_m16ib_support/meshes/m16ib20/collision/link_1.stl"/>
+        </geometry>
+      </collision>
+    </link>
+    <link name="${prefix}link_2">
+      <visual>
+        <origin xyz="0 0 0" rpy="0 0 0"/>
+        <geometry>
+          <mesh filename="package://fanuc_m16ib_support/meshes/m16ib20/visual/link_2.stl"/>
+        </geometry>
+        <xacro:material_fanuc_yellow />
+      </visual>
+      <collision>
+        <origin xyz="0 0 0" rpy="0 0 0"/>
+        <geometry>
+          <mesh filename="package://fanuc_m16ib_support/meshes/m16ib20/collision/link_2.stl"/>
+        </geometry>
+      </collision>
+    </link>
+    <link name="${prefix}link_3">
+      <visual>
+        <origin xyz="0 0 0" rpy="0 0 0"/>
+        <geometry>
+          <mesh filename="package://fanuc_m16ib_support/meshes/m16ib20/visual/link_3.stl"/>
+        </geometry>
+        <xacro:material_fanuc_yellow />
+      </visual>
+      <collision>
+        <origin xyz="0 0 0" rpy="0 0 0"/>
+        <geometry>
+          <mesh filename="package://fanuc_m16ib_support/meshes/m16ib20/collision/link_3.stl"/>
+        </geometry>
+      </collision>
+    </link>
+    <link name="${prefix}link_4">
+      <visual>
+        <origin xyz="0 0 0" rpy="0 0 0"/>
+        <geometry>
+          <mesh filename="package://fanuc_m16ib_support/meshes/m16ib20/visual/link_4.stl"/>
+        </geometry>
+        <xacro:material_fanuc_yellow />
+      </visual>
+      <collision>
+        <origin xyz="0 0 0" rpy="0 0 0"/>
+        <geometry>
+          <mesh filename="package://fanuc_m16ib_support/meshes/m16ib20/collision/link_4.stl"/>
+        </geometry>
+      </collision>
+    </link>
+    <link name="${prefix}link_5">
+      <visual>
+        <origin xyz="0 0 0" rpy="0 0 0"/>
+        <geometry>
+          <mesh filename="package://fanuc_m16ib_support/meshes/m16ib20/visual/link_5.stl"/>
+        </geometry>
+        <xacro:material_fanuc_yellow />
+      </visual>
+      <collision>
+        <origin xyz="0 0 0" rpy="0 0 0"/>
+        <geometry>
+          <mesh filename="package://fanuc_m16ib_support/meshes/m16ib20/collision/link_5.stl"/>
+        </geometry>
+      </collision>
+    </link>
+    <link name="${prefix}link_6">
+      <visual>
+        <origin xyz="0 0 0" rpy="0 0 0"/>
+        <geometry>
+          <mesh filename="package://fanuc_m16ib_support/meshes/m16ib20/visual/link_6.stl"/>
+        </geometry>
+        <xacro:material_fanuc_black />
+      </visual>
+      <collision>
+        <origin xyz="0 0 0" rpy="0 0 0"/>
+        <geometry>
+          <mesh filename="package://fanuc_m16ib_support/meshes/m16ib20/collision/link_6.stl"/>
+        </geometry>
+      </collision>
+    </link>
+    <link name="${prefix}tool0"/>
 
-		<!-- joints -->
-		<joint name="${prefix}joint_1" type="revolute">
-			<origin xyz="0 0 0.525" rpy="0 0 0"/>
-			<parent link="${prefix}base_link"/>
-			<child link="${prefix}link_1"/>
-			<axis xyz="0 0 1"/>
-			<limit effort="0" lower="-2.9671" upper="2.9671" velocity="2.8798" />
-		</joint>
-		<joint name="${prefix}joint_2" type="revolute">
-			<origin xyz="0.150 0 0" rpy="0 0 0"/>
-			<parent link="${prefix}link_1"/>
-			<child link="${prefix}link_2"/>
-			<axis xyz="0 1 0"/>
-			<limit effort="0" lower="-1.5708" upper="2.7925" velocity="2.8798" />
-		</joint>
-		<joint name="${prefix}joint_3" type="revolute">
-			<origin xyz="0 0 0.770" rpy="0 0 0"/>
-			<parent link="${prefix}link_2"/>
-			<child link="${prefix}link_3"/>
-			<axis xyz="0 -1 0"/>
-			<limit effort="0" lower="-2.9671" upper="5.0615" velocity="3.0543" />
-		</joint>
-		<joint name="${prefix}joint_4" type="revolute">
-			<origin xyz="0 0 0.100" rpy="0 0 0"/>
-			<parent link="${prefix}link_3"/>
-			<child link="${prefix}link_4"/>
-			<axis xyz="-1 0 0"/>
-			<limit effort="0" lower="-3.4907" upper="3.4907" velocity="6.1087" />
-		</joint>
-		<joint name="${prefix}joint_5" type="revolute">
-			<origin xyz="0.740 0 0" rpy="0 0 0"/>
-			<parent link="${prefix}link_4"/>
-			<child link="${prefix}link_5"/>
-			<axis xyz="0 -1 0"/>
-			<limit effort="0" lower="-2.4435" upper="2.4435" velocity="5.9341" />
-		</joint>
-		<joint name="${prefix}joint_6" type="revolute">
-			<origin xyz="0.100 0 0" rpy="0 0 0"/>
-			<parent link="${prefix}link_5"/>
-			<child link="${prefix}link_6"/>
-			<axis xyz="-1 0 0"/>
-			<limit effort="0" lower="-7.8540" upper="7.8540" velocity="9.0757" />
-		</joint>
-		<joint name="${prefix}joint_6-tool0" type="fixed">
-			<origin xyz="0 0 0" rpy="${m_pi} ${-m_pi_2} 0" />
-			<parent link="${prefix}link_6"/>
-			<child link="${prefix}tool0"/>
-		</joint>
+    <!-- joints -->
+    <joint name="${prefix}joint_1" type="revolute">
+      <origin xyz="0 0 0.525" rpy="0 0 0"/>
+      <parent link="${prefix}base_link"/>
+      <child link="${prefix}link_1"/>
+      <axis xyz="0 0 1"/>
+      <limit effort="0" lower="-2.9671" upper="2.9671" velocity="2.8798" />
+    </joint>
+    <joint name="${prefix}joint_2" type="revolute">
+      <origin xyz="0.150 0 0" rpy="0 0 0"/>
+      <parent link="${prefix}link_1"/>
+      <child link="${prefix}link_2"/>
+      <axis xyz="0 1 0"/>
+      <limit effort="0" lower="-1.5708" upper="2.7925" velocity="2.8798" />
+    </joint>
+    <joint name="${prefix}joint_3" type="revolute">
+      <origin xyz="0 0 0.770" rpy="0 0 0"/>
+      <parent link="${prefix}link_2"/>
+      <child link="${prefix}link_3"/>
+      <axis xyz="0 -1 0"/>
+      <limit effort="0" lower="-2.9671" upper="5.0615" velocity="3.0543" />
+    </joint>
+    <joint name="${prefix}joint_4" type="revolute">
+      <origin xyz="0 0 0.100" rpy="0 0 0"/>
+      <parent link="${prefix}link_3"/>
+      <child link="${prefix}link_4"/>
+      <axis xyz="-1 0 0"/>
+      <limit effort="0" lower="-3.4907" upper="3.4907" velocity="6.1087" />
+    </joint>
+    <joint name="${prefix}joint_5" type="revolute">
+      <origin xyz="0.740 0 0" rpy="0 0 0"/>
+      <parent link="${prefix}link_4"/>
+      <child link="${prefix}link_5"/>
+      <axis xyz="0 -1 0"/>
+      <limit effort="0" lower="-2.4435" upper="2.4435" velocity="5.9341" />
+    </joint>
+    <joint name="${prefix}joint_6" type="revolute">
+      <origin xyz="0.100 0 0" rpy="0 0 0"/>
+      <parent link="${prefix}link_5"/>
+      <child link="${prefix}link_6"/>
+      <axis xyz="-1 0 0"/>
+      <limit effort="0" lower="-7.8540" upper="7.8540" velocity="9.0757" />
+    </joint>
+    <joint name="${prefix}joint_6-tool0" type="fixed">
+      <origin xyz="0 0 0" rpy="${m_pi} ${-m_pi_2} 0" />
+      <parent link="${prefix}link_6"/>
+      <child link="${prefix}tool0"/>
+    </joint>
 
-		<!-- ROS base_link to Fanuc World Coordinates transform -->
-		<link name="${prefix}base" />
-		<joint name="${prefix}base_link-base" type="fixed">
-			<origin xyz="0 0 0.525" rpy="0 0 0"/>
-			<parent link="${prefix}base_link"/>
-			<child link="${prefix}base"/>
-		</joint>
-	</xacro:macro>
+    <!-- ROS base_link to Fanuc World Coordinates transform -->
+    <link name="${prefix}base" />
+    <joint name="${prefix}base_link-base" type="fixed">
+      <origin xyz="0 0 0.525" rpy="0 0 0"/>
+      <parent link="${prefix}base_link"/>
+      <child link="${prefix}base"/>
+    </joint>
+  </xacro:macro>
 </robot>

--- a/fanuc_m430ia_support/launch/load_m430ia2f.launch
+++ b/fanuc_m430ia_support/launch/load_m430ia2f.launch
@@ -1,3 +1,3 @@
 <launch>
-	<param name="robot_description" command="$(find xacro)/xacro.py '$(find fanuc_m430ia_support)/urdf/m430ia2f.xacro'" />
+  <param name="robot_description" command="$(find xacro)/xacro.py '$(find fanuc_m430ia_support)/urdf/m430ia2f.xacro'" />
 </launch>

--- a/fanuc_m430ia_support/launch/load_m430ia2p.launch
+++ b/fanuc_m430ia_support/launch/load_m430ia2p.launch
@@ -1,3 +1,3 @@
 <launch>
-	<param name="robot_description" command="$(find xacro)/xacro.py '$(find fanuc_m430ia_support)/urdf/m430ia2p.xacro'" />
+  <param name="robot_description" command="$(find xacro)/xacro.py '$(find fanuc_m430ia_support)/urdf/m430ia2p.xacro'" />
 </launch>

--- a/fanuc_m430ia_support/launch/robot_interface_streaming_m430ia2f.launch
+++ b/fanuc_m430ia_support/launch/robot_interface_streaming_m430ia2f.launch
@@ -10,15 +10,15 @@
     robot_interface_streaming_m430ia2f.launch robot_ip:=<value>
 -->
 <launch>
-	<arg name="robot_ip" />
-	<arg name="J23_factor" default="-1" />
-	<arg name="use_bswap" default="true" />
+  <arg name="robot_ip" />
+  <arg name="J23_factor" default="-1" />
+  <arg name="use_bswap" default="true" />
 
-	<rosparam command="load" file="$(find fanuc_m430ia_support)/config/joint_names_m430ia2f.yaml" />
+  <rosparam command="load" file="$(find fanuc_m430ia_support)/config/joint_names_m430ia2f.yaml" />
 
-	<include file="$(find fanuc_driver)/launch/robot_interface_streaming.launch">
-		<arg name="robot_ip"   value="$(arg robot_ip)" />
-		<arg name="J23_factor" value="$(arg J23_factor)" />
-		<arg name="use_bswap"  value="$(arg use_bswap)" />
-	</include>
+  <include file="$(find fanuc_driver)/launch/robot_interface_streaming.launch">
+    <arg name="robot_ip"   value="$(arg robot_ip)" />
+    <arg name="J23_factor" value="$(arg J23_factor)" />
+    <arg name="use_bswap"  value="$(arg use_bswap)" />
+  </include>
 </launch>

--- a/fanuc_m430ia_support/launch/robot_interface_streaming_m430ia2p.launch
+++ b/fanuc_m430ia_support/launch/robot_interface_streaming_m430ia2p.launch
@@ -10,15 +10,15 @@
     robot_interface_streaming_m430ia2p.launch robot_ip:=<value>
 -->
 <launch>
-	<arg name="robot_ip" />
-	<arg name="J23_factor" default="-1" />
-	<arg name="use_bswap" default="true" />
+  <arg name="robot_ip" />
+  <arg name="J23_factor" default="-1" />
+  <arg name="use_bswap" default="true" />
 
-	<rosparam command="load" file="$(find fanuc_m430ia_support)/config/joint_names_m430ia2p.yaml" />
+  <rosparam command="load" file="$(find fanuc_m430ia_support)/config/joint_names_m430ia2p.yaml" />
 
-	<include file="$(find fanuc_driver)/launch/robot_interface_streaming.launch">
-		<arg name="robot_ip"   value="$(arg robot_ip)" />
-		<arg name="J23_factor" value="$(arg J23_factor)" />
-		<arg name="use_bswap"  value="$(arg use_bswap)" />
-	</include>
+  <include file="$(find fanuc_driver)/launch/robot_interface_streaming.launch">
+    <arg name="robot_ip"   value="$(arg robot_ip)" />
+    <arg name="J23_factor" value="$(arg J23_factor)" />
+    <arg name="use_bswap"  value="$(arg use_bswap)" />
+  </include>
 </launch>

--- a/fanuc_m430ia_support/launch/robot_state_visualize_m430ia2f.launch
+++ b/fanuc_m430ia_support/launch/robot_state_visualize_m430ia2f.launch
@@ -10,22 +10,22 @@
     robot_state_visualize_m430ia2f.launch robot_ip:=<value>
 -->
 <launch>
-	<arg name="robot_ip" />
-	<arg name="J23_factor" default="-1" />
-	<arg name="use_bswap" default="true" />
+  <arg name="robot_ip" />
+  <arg name="J23_factor" default="-1" />
+  <arg name="use_bswap" default="true" />
 
-	<rosparam command="load" file="$(find fanuc_m430ia_support)/config/joint_names_m430ia2f.yaml" />
+  <rosparam command="load" file="$(find fanuc_m430ia_support)/config/joint_names_m430ia2f.yaml" />
 
-	<include file="$(find fanuc_driver)/launch/robot_state.launch">
-		<arg name="robot_ip"   value="$(arg robot_ip)" />
-		<arg name="J23_factor" value="$(arg J23_factor)" />
-		<arg name="use_bswap"  value="$(arg use_bswap)" />
-	</include>
+  <include file="$(find fanuc_driver)/launch/robot_state.launch">
+    <arg name="robot_ip"   value="$(arg robot_ip)" />
+    <arg name="J23_factor" value="$(arg J23_factor)" />
+    <arg name="use_bswap"  value="$(arg use_bswap)" />
+  </include>
 
-	<node name="robot_state_publisher" pkg="robot_state_publisher" 
-		type="robot_state_publisher" />
+  <node name="robot_state_publisher" pkg="robot_state_publisher" 
+    type="robot_state_publisher" />
 
-	<include file="$(find fanuc_m430ia_support)/launch/load_m430ia2f.launch" />
+  <include file="$(find fanuc_m430ia_support)/launch/load_m430ia2f.launch" />
 
-	<node name="rviz" pkg="rviz" type="rviz" args="-d $(find industrial_robot_client)/config/robot_state_visualize.rviz" required="true" />
+  <node name="rviz" pkg="rviz" type="rviz" args="-d $(find industrial_robot_client)/config/robot_state_visualize.rviz" required="true" />
 </launch>

--- a/fanuc_m430ia_support/launch/robot_state_visualize_m430ia2p.launch
+++ b/fanuc_m430ia_support/launch/robot_state_visualize_m430ia2p.launch
@@ -10,22 +10,22 @@
     robot_state_visualize_m430ia2p.launch robot_ip:=<value>
 -->
 <launch>
-	<arg name="robot_ip" />
-	<arg name="J23_factor" default="-1" />
-	<arg name="use_bswap" default="true" />
+  <arg name="robot_ip" />
+  <arg name="J23_factor" default="-1" />
+  <arg name="use_bswap" default="true" />
 
-	<rosparam command="load" file="$(find fanuc_m430ia_support)/config/joint_names_m430ia2p.yaml" />
+  <rosparam command="load" file="$(find fanuc_m430ia_support)/config/joint_names_m430ia2p.yaml" />
 
-	<include file="$(find fanuc_driver)/launch/robot_state.launch">
-		<arg name="robot_ip"   value="$(arg robot_ip)" />
-		<arg name="J23_factor" value="$(arg J23_factor)" />
-		<arg name="use_bswap"  value="$(arg use_bswap)" />
-	</include>
+  <include file="$(find fanuc_driver)/launch/robot_state.launch">
+    <arg name="robot_ip"   value="$(arg robot_ip)" />
+    <arg name="J23_factor" value="$(arg J23_factor)" />
+    <arg name="use_bswap"  value="$(arg use_bswap)" />
+  </include>
 
-	<node name="robot_state_publisher" pkg="robot_state_publisher" 
-		type="robot_state_publisher" />
+  <node name="robot_state_publisher" pkg="robot_state_publisher" 
+    type="robot_state_publisher" />
 
-	<include file="$(find fanuc_m430ia_support)/launch/load_m430ia2p.launch" />
+  <include file="$(find fanuc_m430ia_support)/launch/load_m430ia2p.launch" />
 
-	<node name="rviz" pkg="rviz" type="rviz" args="-d $(find industrial_robot_client)/config/robot_state_visualize.rviz" required="true" />
+  <node name="rviz" pkg="rviz" type="rviz" args="-d $(find industrial_robot_client)/config/robot_state_visualize.rviz" required="true" />
 </launch>

--- a/fanuc_m430ia_support/launch/test_m430ia2f.launch
+++ b/fanuc_m430ia_support/launch/test_m430ia2f.launch
@@ -1,7 +1,7 @@
 <launch>
-	<include file="$(find fanuc_m430ia_support)/launch/load_m430ia2f.launch" />
-	<param name="use_gui" value="true" />
-	<node name="joint_state_publisher" pkg="joint_state_publisher" type="joint_state_publisher" />
-	<node name="robot_state_publisher" pkg="robot_state_publisher" type="robot_state_publisher" />
-	<node name="rviz" pkg="rviz" type="rviz" args="-d $(find industrial_robot_client)/config/robot_state_visualize.rviz" required="true" />
+  <include file="$(find fanuc_m430ia_support)/launch/load_m430ia2f.launch" />
+  <param name="use_gui" value="true" />
+  <node name="joint_state_publisher" pkg="joint_state_publisher" type="joint_state_publisher" />
+  <node name="robot_state_publisher" pkg="robot_state_publisher" type="robot_state_publisher" />
+  <node name="rviz" pkg="rviz" type="rviz" args="-d $(find industrial_robot_client)/config/robot_state_visualize.rviz" required="true" />
 </launch>

--- a/fanuc_m430ia_support/launch/test_m430ia2p.launch
+++ b/fanuc_m430ia_support/launch/test_m430ia2p.launch
@@ -1,7 +1,7 @@
 <launch>
-	<include file="$(find fanuc_m430ia_support)/launch/load_m430ia2p.launch" />
-	<param name="use_gui" value="true" />
-	<node name="joint_state_publisher" pkg="joint_state_publisher" type="joint_state_publisher" />
-	<node name="robot_state_publisher" pkg="robot_state_publisher" type="robot_state_publisher" />
-	<node name="rviz" pkg="rviz" type="rviz" args="-d $(find industrial_robot_client)/config/robot_state_visualize.rviz" required="true" />
+  <include file="$(find fanuc_m430ia_support)/launch/load_m430ia2p.launch" />
+  <param name="use_gui" value="true" />
+  <node name="joint_state_publisher" pkg="joint_state_publisher" type="joint_state_publisher" />
+  <node name="robot_state_publisher" pkg="robot_state_publisher" type="robot_state_publisher" />
+  <node name="rviz" pkg="rviz" type="rviz" args="-d $(find industrial_robot_client)/config/robot_state_visualize.rviz" required="true" />
 </launch>

--- a/fanuc_m430ia_support/urdf/m430ia2f.xacro
+++ b/fanuc_m430ia_support/urdf/m430ia2f.xacro
@@ -1,6 +1,6 @@
 <?xml version="1.0" ?>
 
 <robot name="fanuc_m430ia2f" xmlns:xacro="http://ros.org/wiki/xacro">
-	<xacro:include filename="$(find fanuc_m430ia_support)/urdf/m430ia2f_macro.xacro"/>
-	<xacro:fanuc_m430ia2f prefix=""/>
+  <xacro:include filename="$(find fanuc_m430ia_support)/urdf/m430ia2f_macro.xacro"/>
+  <xacro:fanuc_m430ia2f prefix=""/>
 </robot>

--- a/fanuc_m430ia_support/urdf/m430ia2f_macro.xacro
+++ b/fanuc_m430ia_support/urdf/m430ia2f_macro.xacro
@@ -1,150 +1,150 @@
 <?xml version="1.0"?>
 <robot xmlns:xacro="http://ros.org/wiki/xacro">
-	<xacro:include filename="$(find fanuc_resources)/urdf/common_materials.xacro"/>
-	<xacro:include filename="$(find fanuc_resources)/urdf/common_constants.xacro"/>
+  <xacro:include filename="$(find fanuc_resources)/urdf/common_materials.xacro"/>
+  <xacro:include filename="$(find fanuc_resources)/urdf/common_constants.xacro"/>
 
-	<xacro:macro name="fanuc_m430ia2f" params="prefix">
-		<!-- links -->
-		<link name="${prefix}base_link">
-			<visual>
-				<origin xyz="0 0 0" rpy="0 0 0"/>
-				<geometry>
-					<mesh filename="package://fanuc_m430ia_support/meshes/m430ia2f/visual/base_link.stl"/>
-				</geometry>
-				<xacro:material_fanuc_white />
-			</visual>
-			<collision>
-				<origin xyz="0 0 0" rpy="0 0 0"/>
-				<geometry>
-					<mesh filename="package://fanuc_m430ia_support/meshes/m430ia2f/collision/base_link.stl"/>
-				</geometry>
-			</collision>
-		</link>
-		<link name="${prefix}link_1">
-			<visual>
-				<origin xyz="0 0 0" rpy="0 0 0"/>
-				<geometry>
-					<mesh filename="package://fanuc_m430ia_support/meshes/m430ia2f/visual/link_1.stl"/>
-				</geometry>
-				<xacro:material_fanuc_white />
-			</visual>
-			<collision>
-				<origin xyz="0 0 0" rpy="0 0 0"/>
-				<geometry>
-					<mesh filename="package://fanuc_m430ia_support/meshes/m430ia2f/collision/link_1.stl"/>
-				</geometry>
-			</collision>
-		</link>
-		<link name="${prefix}link_2">
-			<visual>
-				<origin xyz="0 0 0" rpy="0 0 0"/>
-				<geometry>
-					<mesh filename="package://fanuc_m430ia_support/meshes/m430ia2f/visual/link_2.stl"/>
-				</geometry>
-				<xacro:material_fanuc_white />
-			</visual>
-			<collision>
-				<origin xyz="0 0 0" rpy="0 0 0"/>
-				<geometry>
-					<mesh filename="package://fanuc_m430ia_support/meshes/m430ia2f/collision/link_2.stl"/>
-				</geometry>
-			</collision>
-		</link>
-		<link name="${prefix}link_3">
-			<visual>
-				<origin xyz="0 0 0" rpy="0 0 0"/>
-				<geometry>
-					<mesh filename="package://fanuc_m430ia_support/meshes/m430ia2f/visual/link_3.stl"/>
-				</geometry>
-				<xacro:material_fanuc_white />
-			</visual>
-			<collision>
-				<origin xyz="0 0 0" rpy="0 0 0"/>
-				<geometry>
-					<mesh filename="package://fanuc_m430ia_support/meshes/m430ia2f/collision/link_3.stl"/>
-				</geometry>
-			</collision>
-		</link>
-		<link name="${prefix}link_4">
-			<visual>
-				<origin xyz="0 0 0" rpy="0 0 0"/>
-				<geometry>
-					<mesh filename="package://fanuc_m430ia_support/meshes/m430ia2f/visual/link_4.stl"/>
-				</geometry>
-				<xacro:material_fanuc_white />
-			</visual>
-			<collision>
-				<origin xyz="0 0 0" rpy="0 0 0"/>
-				<geometry>
-					<mesh filename="package://fanuc_m430ia_support/meshes/m430ia2f/collision/link_4.stl"/>
-				</geometry>
-			</collision>
-		</link>
-		<link name="${prefix}link_5">
-			<visual>
-				<origin xyz="0 0 0" rpy="0 0 0"/>
-				<geometry>
-					<mesh filename="package://fanuc_m430ia_support/meshes/m430ia2f/visual/link_5.stl"/>
-				</geometry>
-				<xacro:material_fanuc_white />
-			</visual>
-			<collision>
-				<origin xyz="0 0 0" rpy="0 0 0"/>
-				<geometry>
-					<mesh filename="package://fanuc_m430ia_support/meshes/m430ia2f/collision/link_5.stl"/>
-				</geometry>
-			</collision>
-		</link>
-		<link name="${prefix}tool0"/>
+  <xacro:macro name="fanuc_m430ia2f" params="prefix">
+    <!-- links -->
+    <link name="${prefix}base_link">
+      <visual>
+        <origin xyz="0 0 0" rpy="0 0 0"/>
+        <geometry>
+          <mesh filename="package://fanuc_m430ia_support/meshes/m430ia2f/visual/base_link.stl"/>
+        </geometry>
+        <xacro:material_fanuc_white />
+      </visual>
+      <collision>
+        <origin xyz="0 0 0" rpy="0 0 0"/>
+        <geometry>
+          <mesh filename="package://fanuc_m430ia_support/meshes/m430ia2f/collision/base_link.stl"/>
+        </geometry>
+      </collision>
+    </link>
+    <link name="${prefix}link_1">
+      <visual>
+        <origin xyz="0 0 0" rpy="0 0 0"/>
+        <geometry>
+          <mesh filename="package://fanuc_m430ia_support/meshes/m430ia2f/visual/link_1.stl"/>
+        </geometry>
+        <xacro:material_fanuc_white />
+      </visual>
+      <collision>
+        <origin xyz="0 0 0" rpy="0 0 0"/>
+        <geometry>
+          <mesh filename="package://fanuc_m430ia_support/meshes/m430ia2f/collision/link_1.stl"/>
+        </geometry>
+      </collision>
+    </link>
+    <link name="${prefix}link_2">
+      <visual>
+        <origin xyz="0 0 0" rpy="0 0 0"/>
+        <geometry>
+          <mesh filename="package://fanuc_m430ia_support/meshes/m430ia2f/visual/link_2.stl"/>
+        </geometry>
+        <xacro:material_fanuc_white />
+      </visual>
+      <collision>
+        <origin xyz="0 0 0" rpy="0 0 0"/>
+        <geometry>
+          <mesh filename="package://fanuc_m430ia_support/meshes/m430ia2f/collision/link_2.stl"/>
+        </geometry>
+      </collision>
+    </link>
+    <link name="${prefix}link_3">
+      <visual>
+        <origin xyz="0 0 0" rpy="0 0 0"/>
+        <geometry>
+          <mesh filename="package://fanuc_m430ia_support/meshes/m430ia2f/visual/link_3.stl"/>
+        </geometry>
+        <xacro:material_fanuc_white />
+      </visual>
+      <collision>
+        <origin xyz="0 0 0" rpy="0 0 0"/>
+        <geometry>
+          <mesh filename="package://fanuc_m430ia_support/meshes/m430ia2f/collision/link_3.stl"/>
+        </geometry>
+      </collision>
+    </link>
+    <link name="${prefix}link_4">
+      <visual>
+        <origin xyz="0 0 0" rpy="0 0 0"/>
+        <geometry>
+          <mesh filename="package://fanuc_m430ia_support/meshes/m430ia2f/visual/link_4.stl"/>
+        </geometry>
+        <xacro:material_fanuc_white />
+      </visual>
+      <collision>
+        <origin xyz="0 0 0" rpy="0 0 0"/>
+        <geometry>
+          <mesh filename="package://fanuc_m430ia_support/meshes/m430ia2f/collision/link_4.stl"/>
+        </geometry>
+      </collision>
+    </link>
+    <link name="${prefix}link_5">
+      <visual>
+        <origin xyz="0 0 0" rpy="0 0 0"/>
+        <geometry>
+          <mesh filename="package://fanuc_m430ia_support/meshes/m430ia2f/visual/link_5.stl"/>
+        </geometry>
+        <xacro:material_fanuc_white />
+      </visual>
+      <collision>
+        <origin xyz="0 0 0" rpy="0 0 0"/>
+        <geometry>
+          <mesh filename="package://fanuc_m430ia_support/meshes/m430ia2f/collision/link_5.stl"/>
+        </geometry>
+      </collision>
+    </link>
+    <link name="${prefix}tool0"/>
 
-		<!-- joints -->
-		<joint name="${prefix}joint_1" type="revolute">
-			<origin xyz="0 0 0.440" rpy="0 0 0"/>
-			<parent link="${prefix}base_link"/>
-			<child link="${prefix}link_1"/>
-			<axis xyz="0 0 1"/>
-			<limit lower="-3.1415" upper="3.1415" effort="0" velocity="5.24"/>
-		</joint>
-		<joint name="${prefix}joint_2" type="revolute">
-			<origin xyz="0 0 0" rpy="0 0 0"/>
-			<parent link="${prefix}link_1"/>
-			<child link="${prefix}link_2"/>
-			<axis xyz="0 1 0"/>
-			<limit lower="-2.01" upper="2.01" effort="0" velocity="5.59"/>
-		</joint>
-		<joint name="${prefix}joint_3" type="revolute">
-			<origin xyz="0 -0.095 0.350" rpy="0 0 0"/>
-			<parent link="${prefix}link_2"/>
-			<child link="${prefix}link_3"/>
-			<axis xyz="0 1 0"/>
-			<limit lower="-3.34" upper="3.34" effort="0" velocity="5.59"/>
-		</joint>
-		<joint name="${prefix}joint_4" type="revolute">
-			<origin xyz="0 0 0.550" rpy="0 0 0"/>
-			<parent link="${prefix}link_3"/>
-			<child link="${prefix}link_4"/>
-			<axis xyz="0 1 0"/>
-			<limit lower="-2.62" upper="2.62" effort="0" velocity="6.28"/>
-		</joint>
-		<joint name="${prefix}joint_5" type="revolute">
-			<origin xyz="0 0 0.065" rpy="0 0 0"/>
-			<parent link="${prefix}link_4"/>
-			<child link="${prefix}link_5"/>
-			<axis xyz="0 0 1"/>
-			<limit lower="-4.71" upper="4.71" effort="0" velocity="20.94"/>
-		</joint>
-		<joint name="${prefix}joint_5-tool0" type="fixed">
-			<origin xyz="0 0 0" rpy="0 0 0" />
-			<parent link="${prefix}link_5"/>
-			<child link="${prefix}tool0"/>
-		</joint>
+    <!-- joints -->
+    <joint name="${prefix}joint_1" type="revolute">
+      <origin xyz="0 0 0.440" rpy="0 0 0"/>
+      <parent link="${prefix}base_link"/>
+      <child link="${prefix}link_1"/>
+      <axis xyz="0 0 1"/>
+      <limit lower="-3.1415" upper="3.1415" effort="0" velocity="5.24"/>
+    </joint>
+    <joint name="${prefix}joint_2" type="revolute">
+      <origin xyz="0 0 0" rpy="0 0 0"/>
+      <parent link="${prefix}link_1"/>
+      <child link="${prefix}link_2"/>
+      <axis xyz="0 1 0"/>
+      <limit lower="-2.01" upper="2.01" effort="0" velocity="5.59"/>
+    </joint>
+    <joint name="${prefix}joint_3" type="revolute">
+      <origin xyz="0 -0.095 0.350" rpy="0 0 0"/>
+      <parent link="${prefix}link_2"/>
+      <child link="${prefix}link_3"/>
+      <axis xyz="0 1 0"/>
+      <limit lower="-3.34" upper="3.34" effort="0" velocity="5.59"/>
+    </joint>
+    <joint name="${prefix}joint_4" type="revolute">
+      <origin xyz="0 0 0.550" rpy="0 0 0"/>
+      <parent link="${prefix}link_3"/>
+      <child link="${prefix}link_4"/>
+      <axis xyz="0 1 0"/>
+      <limit lower="-2.62" upper="2.62" effort="0" velocity="6.28"/>
+    </joint>
+    <joint name="${prefix}joint_5" type="revolute">
+      <origin xyz="0 0 0.065" rpy="0 0 0"/>
+      <parent link="${prefix}link_4"/>
+      <child link="${prefix}link_5"/>
+      <axis xyz="0 0 1"/>
+      <limit lower="-4.71" upper="4.71" effort="0" velocity="20.94"/>
+    </joint>
+    <joint name="${prefix}joint_5-tool0" type="fixed">
+      <origin xyz="0 0 0" rpy="0 0 0" />
+      <parent link="${prefix}link_5"/>
+      <child link="${prefix}tool0"/>
+    </joint>
 
-		<!-- ROS base_link to Fanuc World Coordinates transform -->
-		<link name="${prefix}base" />
-		<joint name="${prefix}base_link-base" type="fixed">
-			<origin xyz="0 0 0.440" rpy="0 0 0"/>
-			<parent link="${prefix}base_link"/>
-			<child link="${prefix}base"/>
-		</joint>
-	</xacro:macro>
+    <!-- ROS base_link to Fanuc World Coordinates transform -->
+    <link name="${prefix}base" />
+    <joint name="${prefix}base_link-base" type="fixed">
+      <origin xyz="0 0 0.440" rpy="0 0 0"/>
+      <parent link="${prefix}base_link"/>
+      <child link="${prefix}base"/>
+    </joint>
+  </xacro:macro>
 </robot>

--- a/fanuc_m430ia_support/urdf/m430ia2p.xacro
+++ b/fanuc_m430ia_support/urdf/m430ia2p.xacro
@@ -1,6 +1,6 @@
 <?xml version="1.0" ?>
 
 <robot name="fanuc_m430ia2p" xmlns:xacro="http://ros.org/wiki/xacro">
-	<xacro:include filename="$(find fanuc_m430ia_support)/urdf/m430ia2p_macro.xacro"/>
-	<xacro:fanuc_m430ia2p prefix=""/>
+  <xacro:include filename="$(find fanuc_m430ia_support)/urdf/m430ia2p_macro.xacro"/>
+  <xacro:fanuc_m430ia2p prefix=""/>
 </robot>

--- a/fanuc_m430ia_support/urdf/m430ia2p_macro.xacro
+++ b/fanuc_m430ia_support/urdf/m430ia2p_macro.xacro
@@ -1,172 +1,172 @@
 <?xml version="1.0" ?>
 <robot xmlns:xacro="http://ros.org/wiki/xacro">
-	<xacro:include filename="$(find fanuc_resources)/urdf/common_materials.xacro"/>
-	<xacro:include filename="$(find fanuc_resources)/urdf/common_constants.xacro"/>
+  <xacro:include filename="$(find fanuc_resources)/urdf/common_materials.xacro"/>
+  <xacro:include filename="$(find fanuc_resources)/urdf/common_constants.xacro"/>
 
-	<xacro:macro name="fanuc_m430ia2p" params="prefix">
-		<!-- links -->
-		<link name="${prefix}base_link">
-			<visual>
-				<origin xyz="0 0 0" rpy="0 0 0"/>
-				<geometry>
-					<mesh filename="package://fanuc_m430ia_support/meshes/m430ia2p/visual/base_link.stl"/>
-				</geometry>
-				<xacro:material_fanuc_white />
-			</visual>
-			<collision>
-				<origin xyz="0 0 0" rpy="0 0 0"/>
-				<geometry>
-					<mesh filename="package://fanuc_m430ia_support/meshes/m430ia2p/collision/base_link.stl"/>
-				</geometry>
-			</collision>
-		</link>
-		<link name="${prefix}link_1">
-			<visual>
-				<origin xyz="0 0 0" rpy="0 0 0"/>
-				<geometry>
-					<mesh filename="package://fanuc_m430ia_support/meshes/m430ia2p/visual/link_1.stl"/>
-				</geometry>
-				<xacro:material_fanuc_white />
-			</visual>
-			<collision>
-				<origin xyz="0 0 0" rpy="0 0 0"/>
-				<geometry>
-					<mesh filename="package://fanuc_m430ia_support/meshes/m430ia2p/collision/link_1.stl"/>
-				</geometry>
-			</collision>
-		</link>
-		<link name="${prefix}link_2">
-			<visual>
-				<origin xyz="0 0 0" rpy="0 0 0"/>
-				<geometry>
-					<mesh filename="package://fanuc_m430ia_support/meshes/m430ia2p/visual/link_2.stl"/>
-				</geometry>
-				<xacro:material_fanuc_white />
-			</visual>
-			<collision>
-				<origin xyz="0 0 0" rpy="0 0 0"/>
-				<geometry>
-					<mesh filename="package://fanuc_m430ia_support/meshes/m430ia2p/collision/link_2.stl"/>
-				</geometry>
-			</collision>
-		</link>
-		<link name="${prefix}link_3">
-			<visual>
-				<origin xyz="0 0 0" rpy="0 0 0"/>
-				<geometry>
-					<mesh filename="package://fanuc_m430ia_support/meshes/m430ia2p/visual/link_3.stl"/>
-				</geometry>
-				<xacro:material_fanuc_white />
-			</visual>
-			<collision>
-				<origin xyz="0 0 0" rpy="0 0 0"/>
-				<geometry>
-					<mesh filename="package://fanuc_m430ia_support/meshes/m430ia2p/collision/link_3.stl"/>
-				</geometry>
-			</collision>
-		</link>
-		<link name="${prefix}link_4">
-			<visual>
-				<origin xyz="0 0 0" rpy="0 0 0"/>
-				<geometry>
-					<mesh filename="package://fanuc_m430ia_support/meshes/m430ia2p/visual/link_4.stl"/>
-				</geometry>
-				<xacro:material_fanuc_white />
-			</visual>
-			<collision>
-				<origin xyz="0 0 0" rpy="0 0 0"/>
-				<geometry>
-					<mesh filename="package://fanuc_m430ia_support/meshes/m430ia2p/collision/link_4.stl"/>
-				</geometry>
-			</collision>
-		</link>
-		<link name="${prefix}link_5">
-			<visual>
-				<origin xyz="0 0 0" rpy="0 0 0"/>
-				<geometry>
-					<mesh filename="package://fanuc_m430ia_support/meshes/m430ia2p/visual/link_5.stl"/>
-				</geometry>
-				<xacro:material_fanuc_white />
-			</visual>
-			<collision>
-				<origin xyz="0 0 0" rpy="0 0 0"/>
-				<geometry>
-					<mesh filename="package://fanuc_m430ia_support/meshes/m430ia2p/collision/link_5.stl"/>
-				</geometry>
-			</collision>
-		</link>
-		<link name="${prefix}link_6">
-			<visual>
-				<origin xyz="0 0 0" rpy="0 0 0"/>
-				<geometry>
-					<mesh filename="package://fanuc_m430ia_support/meshes/m430ia2p/visual/link_6.stl"/>
-				</geometry>
-				<xacro:material_fanuc_white />
-			</visual>
-			<collision>
-				<origin xyz="0 0 0" rpy="0 0 0"/>
-				<geometry>
-					<mesh filename="package://fanuc_m430ia_support/meshes/m430ia2p/collision/link_6.stl"/>
-				</geometry>
-			</collision>
-		</link>
-		<link name="${prefix}tool0" />
+  <xacro:macro name="fanuc_m430ia2p" params="prefix">
+    <!-- links -->
+    <link name="${prefix}base_link">
+      <visual>
+        <origin xyz="0 0 0" rpy="0 0 0"/>
+        <geometry>
+          <mesh filename="package://fanuc_m430ia_support/meshes/m430ia2p/visual/base_link.stl"/>
+        </geometry>
+        <xacro:material_fanuc_white />
+      </visual>
+      <collision>
+        <origin xyz="0 0 0" rpy="0 0 0"/>
+        <geometry>
+          <mesh filename="package://fanuc_m430ia_support/meshes/m430ia2p/collision/base_link.stl"/>
+        </geometry>
+      </collision>
+    </link>
+    <link name="${prefix}link_1">
+      <visual>
+        <origin xyz="0 0 0" rpy="0 0 0"/>
+        <geometry>
+          <mesh filename="package://fanuc_m430ia_support/meshes/m430ia2p/visual/link_1.stl"/>
+        </geometry>
+        <xacro:material_fanuc_white />
+      </visual>
+      <collision>
+        <origin xyz="0 0 0" rpy="0 0 0"/>
+        <geometry>
+          <mesh filename="package://fanuc_m430ia_support/meshes/m430ia2p/collision/link_1.stl"/>
+        </geometry>
+      </collision>
+    </link>
+    <link name="${prefix}link_2">
+      <visual>
+        <origin xyz="0 0 0" rpy="0 0 0"/>
+        <geometry>
+          <mesh filename="package://fanuc_m430ia_support/meshes/m430ia2p/visual/link_2.stl"/>
+        </geometry>
+        <xacro:material_fanuc_white />
+      </visual>
+      <collision>
+        <origin xyz="0 0 0" rpy="0 0 0"/>
+        <geometry>
+          <mesh filename="package://fanuc_m430ia_support/meshes/m430ia2p/collision/link_2.stl"/>
+        </geometry>
+      </collision>
+    </link>
+    <link name="${prefix}link_3">
+      <visual>
+        <origin xyz="0 0 0" rpy="0 0 0"/>
+        <geometry>
+          <mesh filename="package://fanuc_m430ia_support/meshes/m430ia2p/visual/link_3.stl"/>
+        </geometry>
+        <xacro:material_fanuc_white />
+      </visual>
+      <collision>
+        <origin xyz="0 0 0" rpy="0 0 0"/>
+        <geometry>
+          <mesh filename="package://fanuc_m430ia_support/meshes/m430ia2p/collision/link_3.stl"/>
+        </geometry>
+      </collision>
+    </link>
+    <link name="${prefix}link_4">
+      <visual>
+        <origin xyz="0 0 0" rpy="0 0 0"/>
+        <geometry>
+          <mesh filename="package://fanuc_m430ia_support/meshes/m430ia2p/visual/link_4.stl"/>
+        </geometry>
+        <xacro:material_fanuc_white />
+      </visual>
+      <collision>
+        <origin xyz="0 0 0" rpy="0 0 0"/>
+        <geometry>
+          <mesh filename="package://fanuc_m430ia_support/meshes/m430ia2p/collision/link_4.stl"/>
+        </geometry>
+      </collision>
+    </link>
+    <link name="${prefix}link_5">
+      <visual>
+        <origin xyz="0 0 0" rpy="0 0 0"/>
+        <geometry>
+          <mesh filename="package://fanuc_m430ia_support/meshes/m430ia2p/visual/link_5.stl"/>
+        </geometry>
+        <xacro:material_fanuc_white />
+      </visual>
+      <collision>
+        <origin xyz="0 0 0" rpy="0 0 0"/>
+        <geometry>
+          <mesh filename="package://fanuc_m430ia_support/meshes/m430ia2p/collision/link_5.stl"/>
+        </geometry>
+      </collision>
+    </link>
+    <link name="${prefix}link_6">
+      <visual>
+        <origin xyz="0 0 0" rpy="0 0 0"/>
+        <geometry>
+          <mesh filename="package://fanuc_m430ia_support/meshes/m430ia2p/visual/link_6.stl"/>
+        </geometry>
+        <xacro:material_fanuc_white />
+      </visual>
+      <collision>
+        <origin xyz="0 0 0" rpy="0 0 0"/>
+        <geometry>
+          <mesh filename="package://fanuc_m430ia_support/meshes/m430ia2p/collision/link_6.stl"/>
+        </geometry>
+      </collision>
+    </link>
+    <link name="${prefix}tool0" />
 
-		<!-- joints -->
-		<joint name="${prefix}joint_1" type="revolute">
-			<origin xyz="0 0 0.410" rpy="0 0 0"/>
-			<parent link="${prefix}base_link"/>
-			<child link="${prefix}link_1"/>
-			<axis xyz="0 0 1"/>
-			<limit lower="-3.14" upper="3.14" effort="0" velocity="5.24"/>
-		</joint>
-		<joint name="${prefix}joint_2" type="revolute">
-			<origin xyz="0 0 0" rpy="0 0 0"/>
-			<parent link="${prefix}link_1"/>
-			<child link="${prefix}link_2"/>
-			<axis xyz="0 1 0"/>
-			<limit lower="-2.01" upper="2.01" effort="0" velocity="5.59"/>
-		</joint>
-		<joint name="${prefix}joint_3" type="revolute">
-			<origin xyz="0 0 0.350" rpy="0 0 0"/>
-			<parent link="${prefix}link_2"/>
-			<child link="${prefix}link_3"/>
-			<axis xyz="0 1 0"/>
-			<limit lower="-3.49" upper="3.49" effort="0" velocity="5.93"/>
-		</joint>
-		<joint name="${prefix}joint_4" type="revolute">
-			<origin xyz="0 0 0" rpy="0 0 0"/>
-			<parent link="${prefix}link_3"/>
-			<child link="${prefix}link_4"/>
-			<axis xyz="0 0 1"/>
-			<limit lower="-3.32" upper="3.32" effort="0" velocity="5.24"/>
-		</joint>
-		<joint name="${prefix}joint_5" type="revolute">
-			<origin xyz="0 0 0.350" rpy="0 0 0"/>
-			<parent link="${prefix}link_4"/>
-			<child link="${prefix}link_5"/>
-			<axis xyz="0 1 0"/>
-			<limit lower="-2.62" upper="2.62" effort="0" velocity="5.24"/>
-		</joint>
-		<joint name="${prefix}joint_6" type="revolute">
-			<origin xyz="0 -0.095 0.065" rpy="0 0 0"/>
-			<parent link="${prefix}link_5"/>
-			<child link="${prefix}link_6"/>
-			<axis xyz="0 0 1"/>
-			<limit lower="-4.71" upper="4.71" effort="0" velocity="12.57"/>
-		</joint>
-		<joint name="${prefix}joint_6-tool0" type="fixed">
-			<origin xyz="0 0 0" rpy="0 0 0" />
-			<parent link="${prefix}link_6" />
-			<child link="${prefix}tool0" />
-		</joint>
+    <!-- joints -->
+    <joint name="${prefix}joint_1" type="revolute">
+      <origin xyz="0 0 0.410" rpy="0 0 0"/>
+      <parent link="${prefix}base_link"/>
+      <child link="${prefix}link_1"/>
+      <axis xyz="0 0 1"/>
+      <limit lower="-3.14" upper="3.14" effort="0" velocity="5.24"/>
+    </joint>
+    <joint name="${prefix}joint_2" type="revolute">
+      <origin xyz="0 0 0" rpy="0 0 0"/>
+      <parent link="${prefix}link_1"/>
+      <child link="${prefix}link_2"/>
+      <axis xyz="0 1 0"/>
+      <limit lower="-2.01" upper="2.01" effort="0" velocity="5.59"/>
+    </joint>
+    <joint name="${prefix}joint_3" type="revolute">
+      <origin xyz="0 0 0.350" rpy="0 0 0"/>
+      <parent link="${prefix}link_2"/>
+      <child link="${prefix}link_3"/>
+      <axis xyz="0 1 0"/>
+      <limit lower="-3.49" upper="3.49" effort="0" velocity="5.93"/>
+    </joint>
+    <joint name="${prefix}joint_4" type="revolute">
+      <origin xyz="0 0 0" rpy="0 0 0"/>
+      <parent link="${prefix}link_3"/>
+      <child link="${prefix}link_4"/>
+      <axis xyz="0 0 1"/>
+      <limit lower="-3.32" upper="3.32" effort="0" velocity="5.24"/>
+    </joint>
+    <joint name="${prefix}joint_5" type="revolute">
+      <origin xyz="0 0 0.350" rpy="0 0 0"/>
+      <parent link="${prefix}link_4"/>
+      <child link="${prefix}link_5"/>
+      <axis xyz="0 1 0"/>
+      <limit lower="-2.62" upper="2.62" effort="0" velocity="5.24"/>
+    </joint>
+    <joint name="${prefix}joint_6" type="revolute">
+      <origin xyz="0 -0.095 0.065" rpy="0 0 0"/>
+      <parent link="${prefix}link_5"/>
+      <child link="${prefix}link_6"/>
+      <axis xyz="0 0 1"/>
+      <limit lower="-4.71" upper="4.71" effort="0" velocity="12.57"/>
+    </joint>
+    <joint name="${prefix}joint_6-tool0" type="fixed">
+      <origin xyz="0 0 0" rpy="0 0 0" />
+      <parent link="${prefix}link_6" />
+      <child link="${prefix}tool0" />
+    </joint>
 
-		<!-- ROS base_link to Fanuc World Coordinates transform -->
-		<link name="${prefix}base" />
-		<joint name="${prefix}base_link-base" type="fixed">
-			<origin xyz="0 0 0.410" rpy="0 0 0"/>
-			<parent link="${prefix}base_link"/>
-			<child link="${prefix}base"/>
-		</joint>
-	</xacro:macro>
+    <!-- ROS base_link to Fanuc World Coordinates transform -->
+    <link name="${prefix}base" />
+    <joint name="${prefix}base_link-base" type="fixed">
+      <origin xyz="0 0 0.410" rpy="0 0 0"/>
+      <parent link="${prefix}base_link"/>
+      <child link="${prefix}base"/>
+    </joint>
+  </xacro:macro>
 </robot>

--- a/fanuc_resources/urdf/common_colours.xacro
+++ b/fanuc_resources/urdf/common_colours.xacro
@@ -1,15 +1,15 @@
 <?xml version="1.0"?>
 <robot xmlns:xacro="http://ros.org/wiki/xacro">
 
-	<!-- RAL 1021 -->
-	<xacro:property name="color_fanuc_yellow"   value="0.96 0.76 0.13 1.0" />
-	<!-- RAL 9002 -->
-	<xacro:property name="color_fanuc_white"    value="0.86 0.85 0.81 1.0" />
-	<!-- RAL 7024 -->
-	<xacro:property name="color_fanuc_grey"     value="0.34 0.35 0.36 1.0" />
+  <!-- RAL 1021 -->
+  <xacro:property name="color_fanuc_yellow"   value="0.96 0.76 0.13 1.0" />
+  <!-- RAL 9002 -->
+  <xacro:property name="color_fanuc_white"    value="0.86 0.85 0.81 1.0" />
+  <!-- RAL 7024 -->
+  <xacro:property name="color_fanuc_grey"     value="0.34 0.35 0.36 1.0" />
 
-	<!-- approximations -->
-	<xacro:property name="color_fanuc_black"    value="0.15 0.15 0.15 1.0" />
-	<xacro:property name="color_fanuc_greyish"  value="0.75 0.75 0.75 1.0" />
+  <!-- approximations -->
+  <xacro:property name="color_fanuc_black"    value="0.15 0.15 0.15 1.0" />
+  <xacro:property name="color_fanuc_greyish"  value="0.75 0.75 0.75 1.0" />
 
 </robot>

--- a/fanuc_resources/urdf/common_constants.xacro
+++ b/fanuc_resources/urdf/common_constants.xacro
@@ -1,11 +1,11 @@
 <?xml version="1.0"?>
 <robot xmlns:xacro="http://ros.org/wiki/xacro">
 
-	<!-- Pi, the ratio of a circle's circumference to its diameter -->
-	<xacro:property name="m_pi" value="3.1415926535" />
-	<!-- Pi divided by two -->
-	<xacro:property name="m_pi_2" value="1.570796327" />
-	<!-- Pi divided by four -->
-	<xacro:property name="m_pi_4" value="0.785398163" />
+  <!-- Pi, the ratio of a circle's circumference to its diameter -->
+  <xacro:property name="m_pi" value="3.1415926535" />
+  <!-- Pi divided by two -->
+  <xacro:property name="m_pi_2" value="1.570796327" />
+  <!-- Pi divided by four -->
+  <xacro:property name="m_pi_4" value="0.785398163" />
 
 </robot>

--- a/fanuc_resources/urdf/common_materials.xacro
+++ b/fanuc_resources/urdf/common_materials.xacro
@@ -1,35 +1,35 @@
 <?xml version="1.0"?>
 <robot xmlns:xacro="http://ros.org/wiki/xacro">
-	<xacro:include filename="$(find fanuc_resources)/urdf/common_colours.xacro"/>
+  <xacro:include filename="$(find fanuc_resources)/urdf/common_colours.xacro"/>
 
-	<xacro:macro name="material_fanuc_yellow">
-		<material name="">
-			<color rgba="${color_fanuc_yellow}"/>
-		</material>
-	</xacro:macro>
+  <xacro:macro name="material_fanuc_yellow">
+    <material name="">
+      <color rgba="${color_fanuc_yellow}"/>
+    </material>
+  </xacro:macro>
 
-	<xacro:macro name="material_fanuc_white">
-		<material name="">
-			<color rgba="${color_fanuc_white}"/>
-		</material>
-	</xacro:macro>
+  <xacro:macro name="material_fanuc_white">
+    <material name="">
+      <color rgba="${color_fanuc_white}"/>
+    </material>
+  </xacro:macro>
 
-	<xacro:macro name="material_fanuc_black">
-		<material name="">
-			<color rgba="${color_fanuc_black}"/>
-		</material>
-	</xacro:macro>
+  <xacro:macro name="material_fanuc_black">
+    <material name="">
+      <color rgba="${color_fanuc_black}"/>
+    </material>
+  </xacro:macro>
 
-	<xacro:macro name="material_fanuc_grey">
-		<material name="">
-			<color rgba="${color_fanuc_grey}"/>
-		</material>
-	</xacro:macro>
+  <xacro:macro name="material_fanuc_grey">
+    <material name="">
+      <color rgba="${color_fanuc_grey}"/>
+    </material>
+  </xacro:macro>
 
-	<xacro:macro name="material_fanuc_greyish">
-		<material name="">
-			<color rgba="${color_fanuc_greyish}"/>
-		</material>
-	</xacro:macro>
+  <xacro:macro name="material_fanuc_greyish">
+    <material name="">
+      <color rgba="${color_fanuc_greyish}"/>
+    </material>
+  </xacro:macro>
 
 </robot>


### PR DESCRIPTION
As per subject.

No functional changes.

Easily fixed using the `expand` utility in the appropriate directories:

``` bash
for i in `ls`; do expand -i -t2 $i > temp; mv temp $i; done
```
