### PR TITLE
Fix for issue #121: old wiki links

### DIFF
--- a/fanuc/package.xml
+++ b/fanuc/package.xml
@@ -6,7 +6,7 @@
   <maintainer email="g.a.vanderhoorn@tudelft.nl">G.A. vd. Hoorn (TU Delft Robotics Institute)</maintainer>
   <license>BSD</license>
 
-  <url type="website">http://ros.org/wiki/fanuc</url>
+  <url type="website">http://wiki.ros.org/fanuc</url>
   <url type="bugtracker">https://github.com/ros-industrial/fanuc/issues</url>
   <url type="repository">https://github.com/ros-industrial/fanuc</url>
 

--- a/fanuc_assets/package.xml
+++ b/fanuc_assets/package.xml
@@ -19,7 +19,7 @@
   <maintainer email="g.a.vanderhoorn@tudelft.nl">G.A. vd. Hoorn (TU Delft Robotics Institute)</maintainer>
   <license>BSD</license>
 
-  <url type="website">http://ros.org/wiki/fanuc_assets</url>
+  <url type="website">http://wiki.ros.org/fanuc_assets</url>
   <url type="bugtracker">https://github.com/ros-industrial/fanuc/issues</url>
   <url type="repository">https://github.com/ros-industrial/fanuc</url>
 

--- a/fanuc_driver/package.xml
+++ b/fanuc_driver/package.xml
@@ -15,7 +15,7 @@
   <maintainer email="g.a.vanderhoorn@tudelft.nl">G.A. vd. Hoorn (TU Delft Robotics Institute)</maintainer>
   <license>BSD</license>
 
-  <url type="website">http://ros.org/wiki/fanuc_driver</url>
+  <url type="website">http://wiki.ros.org/fanuc_driver</url>
   <url type="bugtracker">https://github.com/ros-industrial/fanuc/issues</url>
   <url type="repository">https://github.com/ros-industrial/fanuc</url>
 

--- a/fanuc_m10ia_support/package.xml
+++ b/fanuc_m10ia_support/package.xml
@@ -27,7 +27,7 @@
   <maintainer email="g.a.vanderhoorn@tudelft.nl">G.A. vd. Hoorn (TU Delft Robotics Institute)</maintainer>
   <license>BSD</license>
 
-  <url type="website">http://ros.org/wiki/fanuc_m10ia_support</url>
+  <url type="website">http://wiki.ros.org/fanuc_m10ia_support</url>
   <url type="bugtracker">https://github.com/ros-industrial/fanuc/issues</url>
   <url type="repository">https://github.com/ros-industrial/fanuc</url>
 

--- a/fanuc_m16ib_support/package.xml
+++ b/fanuc_m16ib_support/package.xml
@@ -32,7 +32,7 @@
   <maintainer email="g.a.vanderhoorn@tudelft.nl">G.A. vd. Hoorn (TU Delft Robotics Institute)</maintainer>
   <license>BSD</license>
 
-  <url type="website">http://ros.org/wiki/fanuc_m16ib_support</url>
+  <url type="website">http://wiki.ros.org/fanuc_m16ib_support</url>
   <url type="bugtracker">https://github.com/ros-industrial/fanuc/issues</url>
   <url type="repository">https://github.com/ros-industrial/fanuc</url>
 

--- a/fanuc_m430ia_support/package.xml
+++ b/fanuc_m430ia_support/package.xml
@@ -31,7 +31,7 @@
   <maintainer email="g.a.vanderhoorn@tudelft.nl">G.A. vd. Hoorn (TU Delft Robotics Institute)</maintainer>
   <license>BSD</license>
 
-  <url type="website">http://ros.org/wiki/fanuc_m430ia_support</url>
+  <url type="website">http://wiki.ros.org/fanuc_m430ia_support</url>
   <url type="bugtracker">https://github.com/ros-industrial/fanuc/issues</url>
   <url type="repository">https://github.com/ros-industrial/fanuc</url>
 

--- a/fanuc_resources/package.xml
+++ b/fanuc_resources/package.xml
@@ -19,7 +19,7 @@
   <maintainer email="g.a.vanderhoorn@tudelft.nl">G.A. vd. Hoorn (TU Delft Robotics Institute)</maintainer>
   <license>BSD</license>
 
-  <url type="website">http://ros.org/wiki/fanuc_resources</url>
+  <url type="website">http://wiki.ros.org/fanuc_resources</url>
   <url type="bugtracker">https://github.com/ros-industrial/fanuc/issues</url>
   <url type="repository">https://github.com/ros-industrial/fanuc</url>
 


### PR DESCRIPTION
Simple change to manifests: updates old 'ros.org/wiki/..' style links to 'wiki.ros.org/..'.
