### PR TITLE
Fix for issue #70: running tests without first building fails

### DIFF
--- a/fanuc_driver/CMakeLists.txt
+++ b/fanuc_driver/CMakeLists.txt
@@ -73,7 +73,14 @@ set_target_properties(${PROJECT_NAME}_motion_streaming_interface_bswap
 
 if (CATKIN_ENABLE_TESTING)
   find_package(roslaunch REQUIRED)
-  roslaunch_add_file_check(tests/roslaunch_test.xml)
+  roslaunch_add_file_check(tests/roslaunch_test.xml
+    DEPENDENCIES
+      # not nice, but industrial_robot_client doesn't prefix its targets
+      joint_trajectory_action
+      ${PROJECT_NAME}_robot_state
+      ${PROJECT_NAME}_robot_state_bswap
+      ${PROJECT_NAME}_motion_streaming_interface
+      ${PROJECT_NAME}_motion_streaming_interface_bswap)
 endif()
 
 

--- a/fanuc_driver/package.xml
+++ b/fanuc_driver/package.xml
@@ -22,7 +22,7 @@
   <buildtool_depend>catkin</buildtool_depend>
 
   <build_depend>industrial_robot_client</build_depend>
-  <build_depend>roslaunch</build_depend>
+  <build_depend version_gte="1.9.55">roslaunch</build_depend>
 
   <run_depend>industrial_robot_client</run_depend>
 </package>

--- a/fanuc_m10ia_support/CMakeLists.txt
+++ b/fanuc_m10ia_support/CMakeLists.txt
@@ -8,7 +8,14 @@ catkin_package()
 
 if (CATKIN_ENABLE_TESTING)
   find_package(roslaunch REQUIRED)
-  roslaunch_add_file_check(tests/roslaunch_test.xml)
+  roslaunch_add_file_check(tests/roslaunch_test.xml
+    DEPENDENCIES
+      # not nice, but industrial_robot_client doesn't prefix its targets
+      joint_trajectory_action
+      fanuc_driver_robot_state
+      fanuc_driver_robot_state_bswap
+      fanuc_driver_motion_streaming_interface
+      fanuc_driver_motion_streaming_interface_bswap)
 endif()
 
 foreach(dir config launch meshes urdf)

--- a/fanuc_m10ia_support/package.xml
+++ b/fanuc_m10ia_support/package.xml
@@ -33,7 +33,7 @@
 
   <buildtool_depend>catkin</buildtool_depend>
 
-  <build_depend>roslaunch</build_depend>
+  <build_depend version_gte="1.9.55">roslaunch</build_depend>
 
   <run_depend>fanuc_resources</run_depend>
   <run_depend>fanuc_driver</run_depend>

--- a/fanuc_m16ib_support/CMakeLists.txt
+++ b/fanuc_m16ib_support/CMakeLists.txt
@@ -8,7 +8,14 @@ catkin_package()
 
 if (CATKIN_ENABLE_TESTING)
   find_package(roslaunch REQUIRED)
-  roslaunch_add_file_check(tests/roslaunch_test.xml)
+  roslaunch_add_file_check(tests/roslaunch_test.xml
+    DEPENDENCIES
+      # not nice, but industrial_robot_client doesn't prefix its targets
+      joint_trajectory_action
+      fanuc_driver_robot_state
+      fanuc_driver_robot_state_bswap
+      fanuc_driver_motion_streaming_interface
+      fanuc_driver_motion_streaming_interface_bswap)
 endif()
 
 foreach(dir config launch meshes urdf)

--- a/fanuc_m16ib_support/package.xml
+++ b/fanuc_m16ib_support/package.xml
@@ -38,7 +38,7 @@
 
   <buildtool_depend>catkin</buildtool_depend>
 
-  <build_depend>roslaunch</build_depend>
+  <build_depend version_gte="1.9.55">roslaunch</build_depend>
 
   <run_depend>fanuc_resources</run_depend>
   <run_depend>fanuc_driver</run_depend>

--- a/fanuc_m430ia_support/CMakeLists.txt
+++ b/fanuc_m430ia_support/CMakeLists.txt
@@ -8,7 +8,14 @@ catkin_package()
 
 if (CATKIN_ENABLE_TESTING)
   find_package(roslaunch REQUIRED)
-  roslaunch_add_file_check(tests/roslaunch_test.xml)
+  roslaunch_add_file_check(tests/roslaunch_test.xml
+    DEPENDENCIES
+      # not nice, but industrial_robot_client doesn't prefix its targets
+      joint_trajectory_action
+      fanuc_driver_robot_state
+      fanuc_driver_robot_state_bswap
+      fanuc_driver_motion_streaming_interface
+      fanuc_driver_motion_streaming_interface_bswap)
 endif()
 
 foreach(dir config launch meshes urdf)

--- a/fanuc_m430ia_support/package.xml
+++ b/fanuc_m430ia_support/package.xml
@@ -37,7 +37,7 @@
 
   <buildtool_depend>catkin</buildtool_depend>
 
-  <build_depend>roslaunch</build_depend>
+  <build_depend version_gte="1.9.55">roslaunch</build_depend>
 
   <run_depend>fanuc_resources</run_depend>
   <run_depend>fanuc_driver</run_depend>


### PR DESCRIPTION
This uses the `DEPENDENCIES` argument added in `roslaunch` v1.9.55 to declare dependencies on the targets used in the roslaunch tests.

Tested on Hydro.

Commits updating the support packages in `fanuc_experimental` with the same changes will follow after acceptance of this PR.
