### PR TITLE
Fix for issue #27: add explicit socket close on ABORT

### DIFF
--- a/fanuc_driver/karel/ros_relay.kl
+++ b/fanuc_driver/karel/ros_relay.kl
@@ -60,7 +60,7 @@ PROGRAM ros_relay
 -- 
 --------------------------------------------------------------------------------
 %ALPHABETIZE
-%COMMENT = 'r22'
+%COMMENT = 'r23'
 %NOBUSYLAMP
 %NOLOCKGROUP
 %NOPAUSE = COMMAND + TPENABLE + ERROR
@@ -110,11 +110,13 @@ VAR
 	pkt_out_               : ind_pkt_t      -- outgoing reply msgs
 	stat_                  : INTEGER
 	sleep_time_            : INTEGER
-	do_it_                 : BOOLEAN
+	shutdwn_req_           : BOOLEAN        -- program abort requested status
 
 
 CONST
 	LOG_PFIX     = 'RREL '
+
+	COND_AH      =    1  -- ABORT handler id
 
 	CFG_OK       =    0  -- config ok
 	CFG_NOTDONE  =   -1  -- configuration not checked: user action required
@@ -164,6 +166,8 @@ CONST
 -- 
 --------------------------------------------------------------------------------
 ROUTINE check_cfg_(cfg : rrelay_cfg_t) : INTEGER FROM ros_relay
+ROUTINE install_ah_ FROM ros_relay
+ROUTINE remove_ah_ FROM ros_relay
 ROUTINE exec_move_(pkt : ind_pkt_t; cfg : rrelay_cfg_t) : INTEGER FROM ros_relay
 ROUTINE req_next_(pkt_in : ind_pkt_t; pkt_out : ind_pkt_t; sock_fd : FILE) : INTEGER FROM ros_relay
 ROUTINE send_err_(pkt_in : ind_pkt_t; pkt_out : ind_pkt_t; sock_fd : FILE) : INTEGER FROM ros_relay
@@ -190,9 +194,13 @@ BEGIN
 
 
 	-- init
-	stat_       = 0
-	sleep_time_ = ROUND(1000.0 / cfg_.loop_hz)
-	do_it_      = TRUE
+	stat_        = 0
+	sleep_time_  = ROUND(1000.0 / cfg_.loop_hz)
+	shutdwn_req_ = FALSE
+
+
+	-- initialise ABORT handler
+	install_ah_
 
 
 	-- enable log output
@@ -234,7 +242,7 @@ BEGIN
 
 
 	-- 
-	WHILE (do_it_) DO
+	WHILE (NOT shutdwn_req_) DO
 
 		-- inform user
 		log_info(LOG_PFIX + 'Waiting for ROS traj relay')
@@ -255,7 +263,7 @@ BEGIN
 		log_info(LOG_PFIX + 'Connected')
 
 		-- got client, start relay loop
-		WHILE (do_it_) DO
+		WHILE (NOT shutdwn_req_) DO
 
 			-- get new packet from the socket
 			-- TODO: this assumes 1 packet per iteration (ok for now)
@@ -356,6 +364,15 @@ exit_discon::
 exit_on_err::
 	-- nothing
 
+	-- make sure socket is closed (don t care about result)
+	stat_ = ssock_dconnf(sock_)
+
+	-- disable the ABORT handler
+	remove_ah_
+
+	-- done
+	log_info(LOG_PFIX + 'Exit')
+
 END ros_relay
 
 
@@ -387,6 +404,52 @@ BEGIN
 	-- all ok
 	RETURN (CFG_OK)
 END check_cfg_
+
+
+
+
+--------------------------------------------------------------------------------
+-- 
+-- Application handler for ABORT signals.
+-- 
+--------------------------------------------------------------------------------
+ROUTINE ab_hndlr_
+BEGIN
+	shutdwn_req_ = TRUE
+	CANCEL FILE sock_fd_
+END ab_hndlr_
+
+
+
+
+--------------------------------------------------------------------------------
+-- 
+-- Installs a condition handler that catches ABORT signals to allow the
+-- application to 'gracefully' exit.
+-- 
+--------------------------------------------------------------------------------
+ROUTINE install_ah_
+BEGIN
+	CONDITION[COND_AH]: WITH $SCAN_TIME = 256
+		WHEN ABORT DO
+			NOABORT
+			ab_hndlr_
+	ENDCONDITION
+	ENABLE CONDITION[COND_AH]
+END install_ah_
+
+
+
+
+--------------------------------------------------------------------------------
+-- 
+-- Deregisters the ABORT condition handler.
+-- 
+--------------------------------------------------------------------------------
+ROUTINE remove_ah_
+BEGIN
+	PURGE CONDITION[COND_AH]
+END remove_ah_
 
 
 

--- a/fanuc_driver/karel/ros_state.kl
+++ b/fanuc_driver/karel/ros_state.kl
@@ -52,7 +52,7 @@ PROGRAM ros_state
 -- 
 --------------------------------------------------------------------------------
 %ALPHABETIZE
-%COMMENT = 'r22'
+%COMMENT = 'r23'
 %NOBUSYLAMP
 %NOLOCKGROUP
 %NOPAUSE = COMMAND + TPENABLE + ERROR
@@ -99,11 +99,14 @@ VAR
 	stat_count_            : INTEGER      -- status loop counter
 	cur_j_pos_             : JOINTPOS     -- current position of robot joints
 	sleep_time_            : INTEGER
+	shutdwn_req_           : BOOLEAN      -- program abort requested status
 
 
 CONST
 	-- 
 	LOG_PFIX     = 'RSTA '
+
+	COND_AH      =    1  -- ABORT handler id
 
 	CFG_OK       =    0  -- config ok
 	CFG_NOTDONE  =   -1  -- configuration not checked: user action required
@@ -142,6 +145,8 @@ CONST
 -- 
 --------------------------------------------------------------------------------
 ROUTINE check_cfg_(cfg : rstate_cfg_t) : INTEGER FROM ros_state
+ROUTINE install_ah_ FROM ros_state
+ROUTINE remove_ah_ FROM ros_state
 
 
 
@@ -168,6 +173,11 @@ BEGIN
 	stat_        = 0
 	stat_count_  = 0
 	sleep_time_  = ROUND(1000.0 / cfg_.loop_hz)
+	shutdwn_req_ = FALSE
+
+
+	-- initialise ABORT handler
+	install_ah_
 
 
 	-- enable log output
@@ -203,7 +213,7 @@ BEGIN
 	stat_ = ssock_dconnf(sock_)
 
 	-- 
-	WHILE (TRUE) DO
+	WHILE (NOT shutdwn_req_) DO
 
 		-- inform user
 		log_info(LOG_PFIX + 'Waiting for ROS state proxy')
@@ -224,7 +234,7 @@ BEGIN
 		log_info(LOG_PFIX + 'Connected')
 
 		-- got client, start joint_state relay loop
-		WHILE (TRUE) DO
+		WHILE (NOT shutdwn_req_) DO
 
 			-- get current joint angles
 			cur_j_pos_ = CURJPOS(0, 0)
@@ -292,9 +302,17 @@ BEGIN
 	-- outer WHILE TRUE DO
 	ENDWHILE
 
-
 exit_on_err::
 	-- nothing
+
+	-- make sure socket is closed (don t care about result)
+	stat_ = ssock_dconnf(sock_)
+
+	-- disable the ABORT handler
+	remove_ah_
+
+	-- done
+	log_info(LOG_PFIX + 'Exit')
 
 END ros_state
 
@@ -321,3 +339,49 @@ BEGIN
 	-- all ok
 	RETURN (CFG_OK)
 END check_cfg_
+
+
+
+
+--------------------------------------------------------------------------------
+-- 
+-- Application handler for ABORT signals.
+-- 
+--------------------------------------------------------------------------------
+ROUTINE ab_hndlr_
+BEGIN
+	shutdwn_req_ = TRUE
+	CANCEL FILE sock_fd_
+END ab_hndlr_
+
+
+
+
+--------------------------------------------------------------------------------
+-- 
+-- Installs a condition handler that catches ABORT signals to allow the
+-- application to 'gracefully' exit.
+-- 
+--------------------------------------------------------------------------------
+ROUTINE install_ah_
+BEGIN
+	CONDITION[COND_AH]: WITH $SCAN_TIME = 256
+		WHEN ABORT DO
+			NOABORT
+			ab_hndlr_
+	ENDCONDITION
+	ENABLE CONDITION[COND_AH]
+END install_ah_
+
+
+
+
+--------------------------------------------------------------------------------
+-- 
+-- Deregisters the ABORT condition handler.
+-- 
+--------------------------------------------------------------------------------
+ROUTINE remove_ah_
+BEGIN
+	PURGE CONDITION[COND_AH]
+END remove_ah_


### PR DESCRIPTION
Adds a condition handler that traps ABORT signals and allows `ros_relay` and `ros_state` to properly shutdown and close any open sockets. This solves the issue where sockets on the controller remain in WAITING or OPEN state, confusing the ROS client programs (no data coming in, but still connected, while server programs have already been terminated).

Could potentially create conflicts with old versions of `ros_relay` and `ros_state` as I had to introduce a new variable (`shutdwn_req_`).

Tested on simulated and real R-30iA, HandlingTool V7.70
