### PR TITLE
Fix for issue #142: mongodb wrapper crashes trying to create db in non-writable location

### DIFF
--- a/fanuc_lrmate200ic5h_moveit_config/launch/default_warehouse_db.launch
+++ b/fanuc_lrmate200ic5h_moveit_config/launch/default_warehouse_db.launch
@@ -2,9 +2,12 @@
 
   <arg name="reset" default="false"/>
 
+  <!-- If not specified, we'll use a default database location -->
+  <arg name="moveit_warehouse_database_path" default="$(find fanuc_lrmate200ic5h_moveit_config)/default_warehouse_mongo_db" />
+
   <!-- Launch the warehouse with a default database location -->  
   <include file="$(find fanuc_lrmate200ic5h_moveit_config)/launch/warehouse.launch">
-    <arg name="moveit_warehouse_database_path" value="$(find fanuc_lrmate200ic5h_moveit_config)/default_warehouse_mongo_db" />
+    <arg name="moveit_warehouse_database_path" value="$(arg moveit_warehouse_database_path)" />
   </include>
 
   <!-- If we want to reset the database, run this node -->

--- a/fanuc_lrmate200ic5h_moveit_config/launch/demo.launch
+++ b/fanuc_lrmate200ic5h_moveit_config/launch/demo.launch
@@ -2,6 +2,8 @@
 
   <!-- By default, we do not start a database (it can be large) -->
   <arg name="db" default="false" />
+  <!-- Allow user to specify database location -->
+  <arg name="db_path" default="$(find fanuc_lrmate200ic5h_moveit_config)/default_warehouse_mongo_db" />
 
   <!-- By default, we are not in debug mode -->
   <arg name="debug" default="false" />
@@ -38,6 +40,8 @@
   </include>
 
   <!-- If database loading was enabled, start mongodb as well -->
-  <include file="$(find fanuc_lrmate200ic5h_moveit_config)/launch/default_warehouse_db.launch" if="$(arg db)"/>
+  <include file="$(find fanuc_lrmate200ic5h_moveit_config)/launch/default_warehouse_db.launch" if="$(arg db)">
+    <arg name="moveit_warehouse_database_path" value="$(arg db_path)"/>
+  </include>
 
 </launch>

--- a/fanuc_lrmate200ic5h_moveit_config/launch/moveit_planning_execution.launch
+++ b/fanuc_lrmate200ic5h_moveit_config/launch/moveit_planning_execution.launch
@@ -15,6 +15,11 @@
   <arg name="robot_ip" unless="$(arg sim)" />
   <arg name="use_bswap" unless="$(arg sim)" default="true" />
 
+  <!-- By default, we do not start a database (it can be large) -->
+  <arg name="db" default="false" />
+  <!-- Allow user to specify database location -->
+  <arg name="db_path" default="$(find fanuc_lrmate200ic5h_moveit_config)/default_warehouse_mongo_db" />
+
   <!-- load the robot_description parameter before launching ROS-I nodes -->
   <include file="$(find fanuc_lrmate200ic5h_moveit_config)/launch/planning_context.launch" >
     <arg name="load_robot_description" value="true" />
@@ -45,7 +50,10 @@
   <include file="$(find fanuc_lrmate200ic5h_moveit_config)/launch/moveit_rviz.launch">
     <arg name="config" value="true"/>
   </include>
-  
-  <include file="$(find fanuc_lrmate200ic5h_moveit_config)/launch/default_warehouse_db.launch" />
+
+  <!-- If database loading was enabled, start mongodb as well -->
+  <include file="$(find fanuc_lrmate200ic5h_moveit_config)/launch/default_warehouse_db.launch" if="$(arg db)">
+    <arg name="moveit_warehouse_database_path" value="$(arg db_path)"/>
+  </include>
 
 </launch>

--- a/fanuc_lrmate200ic5l_moveit_config/launch/default_warehouse_db.launch
+++ b/fanuc_lrmate200ic5l_moveit_config/launch/default_warehouse_db.launch
@@ -2,9 +2,12 @@
 
   <arg name="reset" default="false"/>
 
+  <!-- If not specified, we'll use a default database location -->
+  <arg name="moveit_warehouse_database_path" default="$(find fanuc_lrmate200ic5l_moveit_config)/default_warehouse_mongo_db" />
+
   <!-- Launch the warehouse with a default database location -->  
   <include file="$(find fanuc_lrmate200ic5l_moveit_config)/launch/warehouse.launch">
-    <arg name="moveit_warehouse_database_path" value="$(find fanuc_lrmate200ic5l_moveit_config)/default_warehouse_mongo_db" />
+    <arg name="moveit_warehouse_database_path" value="$(arg moveit_warehouse_database_path)" />
   </include>
 
   <!-- If we want to reset the database, run this node -->

--- a/fanuc_lrmate200ic5l_moveit_config/launch/demo.launch
+++ b/fanuc_lrmate200ic5l_moveit_config/launch/demo.launch
@@ -2,6 +2,8 @@
 
   <!-- By default, we do not start a database (it can be large) -->
   <arg name="db" default="false" />
+  <!-- Allow user to specify database location -->
+  <arg name="db_path" default="$(find fanuc_lrmate200ic5l_moveit_config)/default_warehouse_mongo_db" />
 
   <!-- By default, we are not in debug mode -->
   <arg name="debug" default="false" />
@@ -38,6 +40,8 @@
   </include>
 
   <!-- If database loading was enabled, start mongodb as well -->
-  <include file="$(find fanuc_lrmate200ic5l_moveit_config)/launch/default_warehouse_db.launch" if="$(arg db)"/>
+  <include file="$(find fanuc_lrmate200ic5l_moveit_config)/launch/default_warehouse_db.launch" if="$(arg db)">
+    <arg name="moveit_warehouse_database_path" value="$(arg db_path)"/>
+  </include>
 
 </launch>

--- a/fanuc_lrmate200ic5l_moveit_config/launch/moveit_planning_execution.launch
+++ b/fanuc_lrmate200ic5l_moveit_config/launch/moveit_planning_execution.launch
@@ -15,6 +15,11 @@
   <arg name="robot_ip" unless="$(arg sim)" />
   <arg name="use_bswap" unless="$(arg sim)" default="true" />
 
+  <!-- By default, we do not start a database (it can be large) -->
+  <arg name="db" default="false" />
+  <!-- Allow user to specify database location -->
+  <arg name="db_path" default="$(find fanuc_lrmate200ic5l_moveit_config)/default_warehouse_mongo_db" />
+
   <!-- load the robot_description parameter before launching ROS-I nodes -->
   <include file="$(find fanuc_lrmate200ic5l_moveit_config)/launch/planning_context.launch" >
     <arg name="load_robot_description" value="true" />
@@ -45,7 +50,10 @@
   <include file="$(find fanuc_lrmate200ic5l_moveit_config)/launch/moveit_rviz.launch">
     <arg name="config" value="true"/>
   </include>
-  
-  <include file="$(find fanuc_lrmate200ic5l_moveit_config)/launch/default_warehouse_db.launch" />
+
+  <!-- If database loading was enabled, start mongodb as well -->
+  <include file="$(find fanuc_lrmate200ic5l_moveit_config)/launch/default_warehouse_db.launch" if="$(arg db)">
+    <arg name="moveit_warehouse_database_path" value="$(arg db_path)"/>
+  </include>
 
 </launch>

--- a/fanuc_lrmate200ic_moveit_config/launch/default_warehouse_db.launch
+++ b/fanuc_lrmate200ic_moveit_config/launch/default_warehouse_db.launch
@@ -2,9 +2,12 @@
 
   <arg name="reset" default="false"/>
 
+  <!-- If not specified, we'll use a default database location -->
+  <arg name="moveit_warehouse_database_path" default="$(find fanuc_lrmate200ic_moveit_config)/default_warehouse_mongo_db" />
+
   <!-- Launch the warehouse with a default database location -->  
   <include file="$(find fanuc_lrmate200ic_moveit_config)/launch/warehouse.launch">
-    <arg name="moveit_warehouse_database_path" value="$(find fanuc_lrmate200ic_moveit_config)/default_warehouse_mongo_db" />
+    <arg name="moveit_warehouse_database_path" value="$(arg moveit_warehouse_database_path)" />
   </include>
 
   <!-- If we want to reset the database, run this node -->

--- a/fanuc_lrmate200ic_moveit_config/launch/demo.launch
+++ b/fanuc_lrmate200ic_moveit_config/launch/demo.launch
@@ -2,6 +2,8 @@
 
   <!-- By default, we do not start a database (it can be large) -->
   <arg name="db" default="false" />
+  <!-- Allow user to specify database location -->
+  <arg name="db_path" default="$(find fanuc_lrmate200ic_moveit_config)/default_warehouse_mongo_db" />
 
   <!-- By default, we are not in debug mode -->
   <arg name="debug" default="false" />
@@ -38,6 +40,8 @@
   </include>
 
   <!-- If database loading was enabled, start mongodb as well -->
-  <include file="$(find fanuc_lrmate200ic_moveit_config)/launch/default_warehouse_db.launch" if="$(arg db)"/>
+  <include file="$(find fanuc_lrmate200ic_moveit_config)/launch/default_warehouse_db.launch" if="$(arg db)">
+    <arg name="moveit_warehouse_database_path" value="$(arg db_path)"/>
+  </include>
 
 </launch>

--- a/fanuc_lrmate200ic_moveit_config/launch/moveit_planning_execution.launch
+++ b/fanuc_lrmate200ic_moveit_config/launch/moveit_planning_execution.launch
@@ -15,6 +15,11 @@
   <arg name="robot_ip" unless="$(arg sim)" />
   <arg name="use_bswap" unless="$(arg sim)" default="true" />
 
+  <!-- By default, we do not start a database (it can be large) -->
+  <arg name="db" default="false" />
+  <!-- Allow user to specify database location -->
+  <arg name="db_path" default="$(find fanuc_lrmate200ic_moveit_config)/default_warehouse_mongo_db" />
+
   <!-- load the robot_description parameter before launching ROS-I nodes -->
   <include file="$(find fanuc_lrmate200ic_moveit_config)/launch/planning_context.launch" >
     <arg name="load_robot_description" value="true" />
@@ -45,7 +50,10 @@
   <include file="$(find fanuc_lrmate200ic_moveit_config)/launch/moveit_rviz.launch">
     <arg name="config" value="true"/>
   </include>
-  
-  <include file="$(find fanuc_lrmate200ic_moveit_config)/launch/default_warehouse_db.launch" />
+
+  <!-- If database loading was enabled, start mongodb as well -->
+  <include file="$(find fanuc_lrmate200ic_moveit_config)/launch/default_warehouse_db.launch" if="$(arg db)">
+    <arg name="moveit_warehouse_database_path" value="$(arg db_path)"/>
+  </include>
 
 </launch>

--- a/fanuc_m10ia_moveit_config/launch/default_warehouse_db.launch
+++ b/fanuc_m10ia_moveit_config/launch/default_warehouse_db.launch
@@ -2,9 +2,12 @@
 
   <arg name="reset" default="false"/>
 
+  <!-- If not specified, we'll use a default database location -->
+  <arg name="moveit_warehouse_database_path" default="$(find fanuc_m10ia_moveit_config)/default_warehouse_mongo_db" />
+
   <!-- Launch the warehouse with a default database location -->  
   <include file="$(find fanuc_m10ia_moveit_config)/launch/warehouse.launch">
-    <arg name="moveit_warehouse_database_path" value="$(find fanuc_m10ia_moveit_config)/default_warehouse_mongo_db" />
+    <arg name="moveit_warehouse_database_path" value="$(arg moveit_warehouse_database_path)" />
   </include>
 
   <!-- If we want to reset the database, run this node -->

--- a/fanuc_m10ia_moveit_config/launch/demo.launch
+++ b/fanuc_m10ia_moveit_config/launch/demo.launch
@@ -2,6 +2,8 @@
 
   <!-- By default, we do not start a database (it can be large) -->
   <arg name="db" default="false" />
+  <!-- Allow user to specify database location -->
+  <arg name="db_path" default="$(find fanuc_m10ia_moveit_config)/default_warehouse_mongo_db" />
 
   <!-- By default, we are not in debug mode -->
   <arg name="debug" default="false" />
@@ -38,6 +40,8 @@
   </include>
 
   <!-- If database loading was enabled, start mongodb as well -->
-  <include file="$(find fanuc_m10ia_moveit_config)/launch/default_warehouse_db.launch" if="$(arg db)"/>
+  <include file="$(find fanuc_m10ia_moveit_config)/launch/default_warehouse_db.launch" if="$(arg db)">
+    <arg name="moveit_warehouse_database_path" value="$(arg db_path)"/>
+  </include>
 
 </launch>

--- a/fanuc_m10ia_moveit_config/launch/moveit_planning_execution.launch
+++ b/fanuc_m10ia_moveit_config/launch/moveit_planning_execution.launch
@@ -15,6 +15,11 @@
   <arg name="robot_ip" unless="$(arg sim)" />
   <arg name="use_bswap" unless="$(arg sim)" default="true" />
 
+  <!-- By default, we do not start a database (it can be large) -->
+  <arg name="db" default="false" />
+  <!-- Allow user to specify database location -->
+  <arg name="db_path" default="$(find fanuc_m10ia_moveit_config)/default_warehouse_mongo_db" />
+
   <!-- load the robot_description parameter before launching ROS-I nodes -->
   <include file="$(find fanuc_m10ia_moveit_config)/launch/planning_context.launch" >
     <arg name="load_robot_description" value="true" />
@@ -45,7 +50,10 @@
   <include file="$(find fanuc_m10ia_moveit_config)/launch/moveit_rviz.launch">
     <arg name="config" value="true"/>
   </include>
-  
-  <include file="$(find fanuc_m10ia_moveit_config)/launch/default_warehouse_db.launch" />
+
+  <!-- If database loading was enabled, start mongodb as well -->
+  <include file="$(find fanuc_m10ia_moveit_config)/launch/default_warehouse_db.launch" if="$(arg db)">
+    <arg name="moveit_warehouse_database_path" value="$(arg db_path)"/>
+  </include>
 
 </launch>

--- a/fanuc_m16ib20_moveit_config/launch/default_warehouse_db.launch
+++ b/fanuc_m16ib20_moveit_config/launch/default_warehouse_db.launch
@@ -2,9 +2,12 @@
 
   <arg name="reset" default="false"/>
 
+  <!-- If not specified, we'll use a default database location -->
+  <arg name="moveit_warehouse_database_path" default="$(find fanuc_m16ib20_moveit_config)/default_warehouse_mongo_db" />
+
   <!-- Launch the warehouse with a default database location -->  
   <include file="$(find fanuc_m16ib20_moveit_config)/launch/warehouse.launch">
-    <arg name="moveit_warehouse_database_path" value="$(find fanuc_m16ib20_moveit_config)/default_warehouse_mongo_db" />
+    <arg name="moveit_warehouse_database_path" value="$(arg moveit_warehouse_database_path)" />
   </include>
 
   <!-- If we want to reset the database, run this node -->

--- a/fanuc_m16ib20_moveit_config/launch/demo.launch
+++ b/fanuc_m16ib20_moveit_config/launch/demo.launch
@@ -2,6 +2,8 @@
 
   <!-- By default, we do not start a database (it can be large) -->
   <arg name="db" default="false" />
+  <!-- Allow user to specify database location -->
+  <arg name="db_path" default="$(find fanuc_m16ib20_moveit_config)/default_warehouse_mongo_db" />
 
   <!-- By default, we are not in debug mode -->
   <arg name="debug" default="false" />
@@ -38,6 +40,8 @@
   </include>
 
   <!-- If database loading was enabled, start mongodb as well -->
-  <include file="$(find fanuc_m16ib20_moveit_config)/launch/default_warehouse_db.launch" if="$(arg db)"/>
+  <include file="$(find fanuc_m16ib20_moveit_config)/launch/default_warehouse_db.launch" if="$(arg db)">
+    <arg name="moveit_warehouse_database_path" value="$(arg db_path)"/>
+  </include>
 
 </launch>

--- a/fanuc_m16ib20_moveit_config/launch/moveit_planning_execution.launch
+++ b/fanuc_m16ib20_moveit_config/launch/moveit_planning_execution.launch
@@ -15,6 +15,11 @@
   <arg name="robot_ip" unless="$(arg sim)" />
   <arg name="use_bswap" unless="$(arg sim)" default="true" />
 
+  <!-- By default, we do not start a database (it can be large) -->
+  <arg name="db" default="false" />
+  <!-- Allow user to specify database location -->
+  <arg name="db_path" default="$(find fanuc_m16ib20_moveit_config)/default_warehouse_mongo_db" />
+
   <!-- load the robot_description parameter before launching ROS-I nodes -->
   <include file="$(find fanuc_m16ib20_moveit_config)/launch/planning_context.launch" >
     <arg name="load_robot_description" value="true" />
@@ -45,7 +50,10 @@
   <include file="$(find fanuc_m16ib20_moveit_config)/launch/moveit_rviz.launch">
     <arg name="config" value="true"/>
   </include>
-  
-  <include file="$(find fanuc_m16ib20_moveit_config)/launch/default_warehouse_db.launch" />
+
+  <!-- If database loading was enabled, start mongodb as well -->
+  <include file="$(find fanuc_m16ib20_moveit_config)/launch/default_warehouse_db.launch" if="$(arg db)">
+    <arg name="moveit_warehouse_database_path" value="$(arg db_path)"/>
+  </include>
 
 </launch>

--- a/fanuc_m20ia10l_moveit_config/launch/default_warehouse_db.launch
+++ b/fanuc_m20ia10l_moveit_config/launch/default_warehouse_db.launch
@@ -2,9 +2,12 @@
 
   <arg name="reset" default="false"/>
 
+  <!-- If not specified, we'll use a default database location -->
+  <arg name="moveit_warehouse_database_path" default="$(find fanuc_m20ia10l_moveit_config)/default_warehouse_mongo_db" />
+
   <!-- Launch the warehouse with a default database location -->  
   <include file="$(find fanuc_m20ia10l_moveit_config)/launch/warehouse.launch">
-    <arg name="moveit_warehouse_database_path" value="$(find fanuc_m20ia10l_moveit_config)/default_warehouse_mongo_db" />
+    <arg name="moveit_warehouse_database_path" value="$(arg moveit_warehouse_database_path)" />
   </include>
 
   <!-- If we want to reset the database, run this node -->

--- a/fanuc_m20ia10l_moveit_config/launch/demo.launch
+++ b/fanuc_m20ia10l_moveit_config/launch/demo.launch
@@ -2,6 +2,8 @@
 
   <!-- By default, we do not start a database (it can be large) -->
   <arg name="db" default="false" />
+  <!-- Allow user to specify database location -->
+  <arg name="db_path" default="$(find fanuc_m20ia10l_moveit_config)/default_warehouse_mongo_db" />
 
   <!-- By default, we are not in debug mode -->
   <arg name="debug" default="false" />
@@ -38,6 +40,8 @@
   </include>
 
   <!-- If database loading was enabled, start mongodb as well -->
-  <include file="$(find fanuc_m20ia10l_moveit_config)/launch/default_warehouse_db.launch" if="$(arg db)"/>
+  <include file="$(find fanuc_m20ia10l_moveit_config)/launch/default_warehouse_db.launch" if="$(arg db)">
+    <arg name="moveit_warehouse_database_path" value="$(arg db_path)"/>
+  </include>
 
 </launch>

--- a/fanuc_m20ia10l_moveit_config/launch/moveit_planning_execution.launch
+++ b/fanuc_m20ia10l_moveit_config/launch/moveit_planning_execution.launch
@@ -15,6 +15,11 @@
   <arg name="robot_ip" unless="$(arg sim)" />
   <arg name="use_bswap" unless="$(arg sim)" default="true" />
 
+  <!-- By default, we do not start a database (it can be large) -->
+  <arg name="db" default="false" />
+  <!-- Allow user to specify database location -->
+  <arg name="db_path" default="$(find fanuc_m20ia10l_moveit_config)/default_warehouse_mongo_db" />
+
   <!-- load the robot_description parameter before launching ROS-I nodes -->
   <include file="$(find fanuc_m20ia10l_moveit_config)/launch/planning_context.launch" >
     <arg name="load_robot_description" value="true" />
@@ -45,7 +50,10 @@
   <include file="$(find fanuc_m20ia10l_moveit_config)/launch/moveit_rviz.launch">
     <arg name="config" value="true"/>
   </include>
-  
-  <include file="$(find fanuc_m20ia10l_moveit_config)/launch/default_warehouse_db.launch" />
+
+  <!-- If database loading was enabled, start mongodb as well -->
+  <include file="$(find fanuc_m20ia10l_moveit_config)/launch/default_warehouse_db.launch" if="$(arg db)">
+    <arg name="moveit_warehouse_database_path" value="$(arg db_path)"/>
+  </include>
 
 </launch>

--- a/fanuc_m20ia_moveit_config/launch/default_warehouse_db.launch
+++ b/fanuc_m20ia_moveit_config/launch/default_warehouse_db.launch
@@ -2,9 +2,12 @@
 
   <arg name="reset" default="false"/>
 
+  <!-- If not specified, we'll use a default database location -->
+  <arg name="moveit_warehouse_database_path" default="$(find fanuc_m20ia_moveit_config)/default_warehouse_mongo_db" />
+
   <!-- Launch the warehouse with a default database location -->  
   <include file="$(find fanuc_m20ia_moveit_config)/launch/warehouse.launch">
-    <arg name="moveit_warehouse_database_path" value="$(find fanuc_m20ia_moveit_config)/default_warehouse_mongo_db" />
+    <arg name="moveit_warehouse_database_path" value="$(arg moveit_warehouse_database_path)" />
   </include>
 
   <!-- If we want to reset the database, run this node -->

--- a/fanuc_m20ia_moveit_config/launch/demo.launch
+++ b/fanuc_m20ia_moveit_config/launch/demo.launch
@@ -2,6 +2,8 @@
 
   <!-- By default, we do not start a database (it can be large) -->
   <arg name="db" default="false" />
+  <!-- Allow user to specify database location -->
+  <arg name="db_path" default="$(find fanuc_m20ia_moveit_config)/default_warehouse_mongo_db" />
 
   <!-- By default, we are not in debug mode -->
   <arg name="debug" default="false" />
@@ -38,6 +40,8 @@
   </include>
 
   <!-- If database loading was enabled, start mongodb as well -->
-  <include file="$(find fanuc_m20ia_moveit_config)/launch/default_warehouse_db.launch" if="$(arg db)"/>
+  <include file="$(find fanuc_m20ia_moveit_config)/launch/default_warehouse_db.launch" if="$(arg db)">
+    <arg name="moveit_warehouse_database_path" value="$(arg db_path)"/>
+  </include>
 
 </launch>

--- a/fanuc_m20ia_moveit_config/launch/moveit_planning_execution.launch
+++ b/fanuc_m20ia_moveit_config/launch/moveit_planning_execution.launch
@@ -15,6 +15,11 @@
   <arg name="robot_ip" unless="$(arg sim)" />
   <arg name="use_bswap" unless="$(arg sim)" default="true" />
 
+  <!-- By default, we do not start a database (it can be large) -->
+  <arg name="db" default="false" />
+  <!-- Allow user to specify database location -->
+  <arg name="db_path" default="$(find fanuc_m20ia_moveit_config)/default_warehouse_mongo_db" />
+
   <!-- load the robot_description parameter before launching ROS-I nodes -->
   <include file="$(find fanuc_m20ia_moveit_config)/launch/planning_context.launch" >
     <arg name="load_robot_description" value="true" />
@@ -45,7 +50,10 @@
   <include file="$(find fanuc_m20ia_moveit_config)/launch/moveit_rviz.launch">
     <arg name="config" value="true"/>
   </include>
-  
-  <include file="$(find fanuc_m20ia_moveit_config)/launch/default_warehouse_db.launch" />
+
+  <!-- If database loading was enabled, start mongodb as well -->
+  <include file="$(find fanuc_m20ia_moveit_config)/launch/default_warehouse_db.launch" if="$(arg db)">
+    <arg name="moveit_warehouse_database_path" value="$(arg db_path)"/>
+  </include>
 
 </launch>

--- a/fanuc_m430ia2f_moveit_config/launch/default_warehouse_db.launch
+++ b/fanuc_m430ia2f_moveit_config/launch/default_warehouse_db.launch
@@ -2,9 +2,12 @@
 
   <arg name="reset" default="false"/>
 
+  <!-- If not specified, we'll use a default database location -->
+  <arg name="moveit_warehouse_database_path" default="$(find fanuc_m430ia2f_moveit_config)/default_warehouse_mongo_db" />
+
   <!-- Launch the warehouse with a default database location -->  
   <include file="$(find fanuc_m430ia2f_moveit_config)/launch/warehouse.launch">
-    <arg name="moveit_warehouse_database_path" value="$(find fanuc_m430ia2f_moveit_config)/default_warehouse_mongo_db" />
+    <arg name="moveit_warehouse_database_path" value="$(arg moveit_warehouse_database_path)" />
   </include>
 
   <!-- If we want to reset the database, run this node -->

--- a/fanuc_m430ia2f_moveit_config/launch/demo.launch
+++ b/fanuc_m430ia2f_moveit_config/launch/demo.launch
@@ -2,6 +2,8 @@
 
   <!-- By default, we do not start a database (it can be large) -->
   <arg name="db" default="false" />
+  <!-- Allow user to specify database location -->
+  <arg name="db_path" default="$(find fanuc_m430ia2f_moveit_config)/default_warehouse_mongo_db" />
 
   <!-- By default, we are not in debug mode -->
   <arg name="debug" default="false" />
@@ -38,6 +40,8 @@
   </include>
 
   <!-- If database loading was enabled, start mongodb as well -->
-  <include file="$(find fanuc_m430ia2f_moveit_config)/launch/default_warehouse_db.launch" if="$(arg db)"/>
+  <include file="$(find fanuc_m430ia2f_moveit_config)/launch/default_warehouse_db.launch" if="$(arg db)">
+    <arg name="moveit_warehouse_database_path" value="$(arg db_path)"/>
+  </include>
 
 </launch>

--- a/fanuc_m430ia2f_moveit_config/launch/moveit_planning_execution.launch
+++ b/fanuc_m430ia2f_moveit_config/launch/moveit_planning_execution.launch
@@ -15,6 +15,11 @@
   <arg name="robot_ip" unless="$(arg sim)" />
   <arg name="use_bswap" unless="$(arg sim)" default="true" />
 
+  <!-- By default, we do not start a database (it can be large) -->
+  <arg name="db" default="false" />
+  <!-- Allow user to specify database location -->
+  <arg name="db_path" default="$(find fanuc_m430ia2f_moveit_config)/default_warehouse_mongo_db" />
+
   <!-- load the robot_description parameter before launching ROS-I nodes -->
   <include file="$(find fanuc_m430ia2f_moveit_config)/launch/planning_context.launch" >
     <arg name="load_robot_description" value="true" />
@@ -45,7 +50,10 @@
   <include file="$(find fanuc_m430ia2f_moveit_config)/launch/moveit_rviz.launch">
     <arg name="config" value="true"/>
   </include>
-  
-  <include file="$(find fanuc_m430ia2f_moveit_config)/launch/default_warehouse_db.launch" />
+
+  <!-- If database loading was enabled, start mongodb as well -->
+  <include file="$(find fanuc_m430ia2f_moveit_config)/launch/default_warehouse_db.launch" if="$(arg db)">
+    <arg name="moveit_warehouse_database_path" value="$(arg db_path)"/>
+  </include>
 
 </launch>

--- a/fanuc_m430ia2p_moveit_config/launch/default_warehouse_db.launch
+++ b/fanuc_m430ia2p_moveit_config/launch/default_warehouse_db.launch
@@ -2,9 +2,12 @@
 
   <arg name="reset" default="false"/>
 
+  <!-- If not specified, we'll use a default database location -->
+  <arg name="moveit_warehouse_database_path" default="$(find fanuc_m430ia2p_moveit_config)/default_warehouse_mongo_db" />
+
   <!-- Launch the warehouse with a default database location -->  
   <include file="$(find fanuc_m430ia2p_moveit_config)/launch/warehouse.launch">
-    <arg name="moveit_warehouse_database_path" value="$(find fanuc_m430ia2p_moveit_config)/default_warehouse_mongo_db" />
+    <arg name="moveit_warehouse_database_path" value="$(arg moveit_warehouse_database_path)" />
   </include>
 
   <!-- If we want to reset the database, run this node -->

--- a/fanuc_m430ia2p_moveit_config/launch/demo.launch
+++ b/fanuc_m430ia2p_moveit_config/launch/demo.launch
@@ -2,6 +2,8 @@
 
   <!-- By default, we do not start a database (it can be large) -->
   <arg name="db" default="false" />
+  <!-- Allow user to specify database location -->
+  <arg name="db_path" default="$(find fanuc_m430ia2p_moveit_config)/default_warehouse_mongo_db" />
 
   <!-- By default, we are not in debug mode -->
   <arg name="debug" default="false" />
@@ -38,6 +40,8 @@
   </include>
 
   <!-- If database loading was enabled, start mongodb as well -->
-  <include file="$(find fanuc_m430ia2p_moveit_config)/launch/default_warehouse_db.launch" if="$(arg db)"/>
+  <include file="$(find fanuc_m430ia2p_moveit_config)/launch/default_warehouse_db.launch" if="$(arg db)">
+    <arg name="moveit_warehouse_database_path" value="$(arg db_path)"/>
+  </include>
 
 </launch>

--- a/fanuc_m430ia2p_moveit_config/launch/moveit_planning_execution.launch
+++ b/fanuc_m430ia2p_moveit_config/launch/moveit_planning_execution.launch
@@ -15,6 +15,11 @@
   <arg name="robot_ip" unless="$(arg sim)" />
   <arg name="use_bswap" unless="$(arg sim)" default="true" />
 
+  <!-- By default, we do not start a database (it can be large) -->
+  <arg name="db" default="false" />
+  <!-- Allow user to specify database location -->
+  <arg name="db_path" default="$(find fanuc_m430ia2p_moveit_config)/default_warehouse_mongo_db" />
+
   <!-- load the robot_description parameter before launching ROS-I nodes -->
   <include file="$(find fanuc_m430ia2p_moveit_config)/launch/planning_context.launch" >
     <arg name="load_robot_description" value="true" />
@@ -45,7 +50,10 @@
   <include file="$(find fanuc_m430ia2p_moveit_config)/launch/moveit_rviz.launch">
     <arg name="config" value="true"/>
   </include>
-  
-  <include file="$(find fanuc_m430ia2p_moveit_config)/launch/default_warehouse_db.launch" />
+
+  <!-- If database loading was enabled, start mongodb as well -->
+  <include file="$(find fanuc_m430ia2p_moveit_config)/launch/default_warehouse_db.launch" if="$(arg db)">
+    <arg name="moveit_warehouse_database_path" value="$(arg db_path)"/>
+  </include>
 
 </launch>


### PR DESCRIPTION
This prevents the creation of a MongoDB database, unless the user has specifically requested it with the 'db' launch file argument.

Prevents 'Permission denied' errors when starting moveit_planning_execution.launch from
released MoveIt configuration package (which are installed in a non-writable location).
