### PR TITLE
Fix for issue #152: abort starting driver when joint 2-3 interaction parameter has not been set

### DIFF
--- a/fanuc_driver/src/fanuc_joint_streamer_node.cpp
+++ b/fanuc_driver/src/fanuc_joint_streamer_node.cpp
@@ -1,7 +1,7 @@
 /*
  * Software License Agreement (BSD License)
  *
- * Copyright (c) 2013, TU Delft Robotics Institute
+ * Copyright (c) 2013-2015, TU Delft Robotics Institute
  * All rights reserved.
  *
  * Redistribution and use in source and binary forms, with or without
@@ -40,6 +40,8 @@
 
 #include <industrial_robot_client/joint_trajectory_streamer.h>
 
+#include <stdexcept>
+
 
 using industrial_robot_client::joint_trajectory_streamer::JointTrajectoryStreamer;
 
@@ -52,15 +54,13 @@ class Fanuc_JointTrajectoryStreamer : public JointTrajectoryStreamer
 public:
   Fanuc_JointTrajectoryStreamer() : JointTrajectoryStreamer(), J23_factor_(0)
   {
-    if (ros::param::has("J23_factor"))
+    if (!ros::param::has("J23_factor"))
     {
-      ros::param::get("J23_factor", this->J23_factor_);
+      ROS_FATAL("Joint 2-3 linkage factor parameter not supplied.");
+      throw std::runtime_error("Cannot find required parameter 'J23_factor' on parameter server.");
     }
-    else
-    {
-      // TODO: abort on missing parameter
-      ROS_ERROR("Joint 2-3 linkage factor parameter not supplied.");
-    }
+
+    ros::param::get("J23_factor", this->J23_factor_);
   }
 
 

--- a/fanuc_driver/src/fanuc_robot_state_node.cpp
+++ b/fanuc_driver/src/fanuc_robot_state_node.cpp
@@ -1,7 +1,7 @@
 /*
  * Software License Agreement (BSD License)
  *
- * Copyright (c) 2013, TU Delft Robotics Institute
+ * Copyright (c) 2013-2015, TU Delft Robotics Institute
  * All rights reserved.
  *
  * Redistribution and use in source and binary forms, with or without
@@ -41,6 +41,8 @@
 #include <industrial_robot_client/robot_state_interface.h>
 #include <industrial_utils/param_utils.h>
 
+#include <stdexcept>
+
 
 using industrial_robot_client::robot_state_interface::RobotStateInterface;
 using industrial_robot_client::joint_relay_handler::JointRelayHandler;
@@ -55,15 +57,13 @@ class Fanuc_JointRelayHandler : public JointRelayHandler
 public:
   Fanuc_JointRelayHandler() : JointRelayHandler(), J23_factor_(0)
   {
-    if (ros::param::has("J23_factor"))
+    if (!ros::param::has("J23_factor"))
     {
-      ros::param::get("J23_factor", this->J23_factor_);
+      ROS_FATAL("Joint 2-3 linkage factor parameter not supplied.");
+      throw std::runtime_error("Cannot find required parameter 'J23_factor' on parameter server.");
     }
-    else
-    {
-      // TODO: abort on missing parameter
-      ROS_ERROR("Joint 2-3 linkage factor parameter not supplied.");
-    }
+
+    ros::param::get("J23_factor", this->J23_factor_);
   }
 
 


### PR DESCRIPTION
There is no valid default for this parameter, so aborting is the only sane thing to do.

Starting the `robot_state` node without the parameter set results in:

```
[1427045843.884540067] [ INFO] [/state_interface] [ros.simple_message]: Added message handler for message type: 0
[1427045843.886287861] [FATAL] [/state_interface] [ros.fanuc_driver]: Joint 2-3 linkage factor parameter not supplied.
terminate called after throwing an instance of 'std::runtime_error'
  what():  Cannot find required parameter 'J23_factor' on parameter server.
Aborted (core dumped)
```
