### PR TITLE
Fix for issue 115: upgrade all manifests to package 'format 2'

### DIFF
--- a/fanuc/package.xml
+++ b/fanuc/package.xml
@@ -1,4 +1,4 @@
-<package>
+<package format="2">
   <name>fanuc</name>
   <version>0.3.2</version>
   <description>ROS-Industrial support for Fanuc manipulators (metapackage).</description>
@@ -12,29 +12,30 @@
 
   <buildtool_depend>catkin</buildtool_depend>
 
-  <run_depend>fanuc_driver</run_depend>
-  <run_depend>fanuc_lrmate200ic5h_moveit_config</run_depend>
-  <run_depend>fanuc_lrmate200ic5l_moveit_config</run_depend>
-  <run_depend>fanuc_lrmate200ic_moveit_config</run_depend>
-  <run_depend>fanuc_lrmate200ic_moveit_plugins</run_depend>
-  <run_depend>fanuc_lrmate200ic_support</run_depend>
-  <run_depend>fanuc_m10ia_moveit_config</run_depend>
-  <run_depend>fanuc_m10ia_moveit_plugins</run_depend>
-  <run_depend>fanuc_m10ia_support</run_depend>
-  <run_depend>fanuc_m16ib20_moveit_config</run_depend>
-  <run_depend>fanuc_m16ib_moveit_plugins</run_depend>
-  <run_depend>fanuc_m16ib_support</run_depend>
-  <run_depend>fanuc_m20ia10l_moveit_config</run_depend>
-  <run_depend>fanuc_m20ia_moveit_config</run_depend>
-  <run_depend>fanuc_m20ia_moveit_plugins</run_depend>
-  <run_depend>fanuc_m20ia_support</run_depend>
-  <run_depend>fanuc_m430ia2f_moveit_config</run_depend>
-  <run_depend>fanuc_m430ia2p_moveit_config</run_depend>
-  <run_depend>fanuc_m430ia_moveit_plugins</run_depend>
-  <run_depend>fanuc_m430ia_support</run_depend>
-  <run_depend>fanuc_resources</run_depend>
+  <exec_depend>fanuc_driver</exec_depend>
+  <exec_depend>fanuc_lrmate200ic5h_moveit_config</exec_depend>
+  <exec_depend>fanuc_lrmate200ic5l_moveit_config</exec_depend>
+  <exec_depend>fanuc_lrmate200ic_moveit_config</exec_depend>
+  <exec_depend>fanuc_lrmate200ic_moveit_plugins</exec_depend>
+  <exec_depend>fanuc_lrmate200ic_support</exec_depend>
+  <exec_depend>fanuc_m10ia_moveit_config</exec_depend>
+  <exec_depend>fanuc_m10ia_moveit_plugins</exec_depend>
+  <exec_depend>fanuc_m10ia_support</exec_depend>
+  <exec_depend>fanuc_m16ib20_moveit_config</exec_depend>
+  <exec_depend>fanuc_m16ib_moveit_plugins</exec_depend>
+  <exec_depend>fanuc_m16ib_support</exec_depend>
+  <exec_depend>fanuc_m20ia10l_moveit_config</exec_depend>
+  <exec_depend>fanuc_m20ia_moveit_config</exec_depend>
+  <exec_depend>fanuc_m20ia_moveit_plugins</exec_depend>
+  <exec_depend>fanuc_m20ia_support</exec_depend>
+  <exec_depend>fanuc_m430ia2f_moveit_config</exec_depend>
+  <exec_depend>fanuc_m430ia2p_moveit_config</exec_depend>
+  <exec_depend>fanuc_m430ia_moveit_plugins</exec_depend>
+  <exec_depend>fanuc_m430ia_support</exec_depend>
+  <exec_depend>fanuc_resources</exec_depend>
 
   <export>
     <metapackage/>
+    <architecture_independent/>
   </export>
 </package>

--- a/fanuc_driver/package.xml
+++ b/fanuc_driver/package.xml
@@ -1,4 +1,4 @@
-<package>
+<package format="2">
   <name>fanuc_driver</name>
   <version>0.3.2</version>
   <description>
@@ -21,8 +21,7 @@
 
   <buildtool_depend>catkin</buildtool_depend>
 
-  <build_depend>industrial_robot_client</build_depend>
-  <build_depend version_gte="1.9.55">roslaunch</build_depend>
+  <depend>industrial_robot_client</depend>
 
-  <run_depend>industrial_robot_client</run_depend>
+  <test_depend version_gte="1.9.55">roslaunch</test_depend>
 </package>

--- a/fanuc_lrmate200ic5h_moveit_config/package.xml
+++ b/fanuc_lrmate200ic5h_moveit_config/package.xml
@@ -1,4 +1,4 @@
-<package>
+<package format="2">
   <name>fanuc_lrmate200ic5h_moveit_config</name>
   <version>0.3.2</version>
   <description>
@@ -28,19 +28,19 @@
 
   <buildtool_depend>catkin</buildtool_depend>
 
-  <run_depend>moveit_fake_controller_manager</run_depend>
-  <run_depend>moveit_simple_controller_manager</run_depend>
-  <run_depend>moveit_planners_ompl</run_depend>
-  <run_depend>moveit_ros_visualization</run_depend>
-  <run_depend>joint_state_publisher</run_depend>
-  <run_depend>robot_state_publisher</run_depend>
-  <run_depend>moveit_ros_move_group</run_depend>
+  <exec_depend>moveit_fake_controller_manager</exec_depend>
+  <exec_depend>moveit_simple_controller_manager</exec_depend>
+  <exec_depend>moveit_planners_ompl</exec_depend>
+  <exec_depend>moveit_ros_visualization</exec_depend>
+  <exec_depend>joint_state_publisher</exec_depend>
+  <exec_depend>robot_state_publisher</exec_depend>
+  <exec_depend>moveit_ros_move_group</exec_depend>
 
-  <run_depend>xacro</run_depend>
+  <exec_depend>xacro</exec_depend>
 
-  <run_depend>industrial_robot_simulator</run_depend>
-  <run_depend>fanuc_lrmate200ic_support</run_depend>
-  <run_depend>fanuc_lrmate200ic_moveit_plugins</run_depend>
+  <exec_depend>industrial_robot_simulator</exec_depend>
+  <exec_depend>fanuc_lrmate200ic_support</exec_depend>
+  <exec_depend>fanuc_lrmate200ic_moveit_plugins</exec_depend>
 
   <export>
     <architecture_independent />

--- a/fanuc_lrmate200ic5l_moveit_config/package.xml
+++ b/fanuc_lrmate200ic5l_moveit_config/package.xml
@@ -1,4 +1,4 @@
-<package>
+<package format="2">
   <name>fanuc_lrmate200ic5l_moveit_config</name>
   <version>0.3.2</version>
   <description>
@@ -28,19 +28,19 @@
 
   <buildtool_depend>catkin</buildtool_depend>
 
-  <run_depend>moveit_fake_controller_manager</run_depend>
-  <run_depend>moveit_simple_controller_manager</run_depend>
-  <run_depend>moveit_planners_ompl</run_depend>
-  <run_depend>moveit_ros_visualization</run_depend>
-  <run_depend>joint_state_publisher</run_depend>
-  <run_depend>robot_state_publisher</run_depend>
-  <run_depend>moveit_ros_move_group</run_depend>
+  <exec_depend>moveit_fake_controller_manager</exec_depend>
+  <exec_depend>moveit_simple_controller_manager</exec_depend>
+  <exec_depend>moveit_planners_ompl</exec_depend>
+  <exec_depend>moveit_ros_visualization</exec_depend>
+  <exec_depend>joint_state_publisher</exec_depend>
+  <exec_depend>robot_state_publisher</exec_depend>
+  <exec_depend>moveit_ros_move_group</exec_depend>
 
-  <run_depend>xacro</run_depend>
+  <exec_depend>xacro</exec_depend>
 
-  <run_depend>industrial_robot_simulator</run_depend>
-  <run_depend>fanuc_lrmate200ic_support</run_depend>
-  <run_depend>fanuc_lrmate200ic_moveit_plugins</run_depend>
+  <exec_depend>industrial_robot_simulator</exec_depend>
+  <exec_depend>fanuc_lrmate200ic_support</exec_depend>
+  <exec_depend>fanuc_lrmate200ic_moveit_plugins</exec_depend>
 
   <export>
     <architecture_independent />

--- a/fanuc_lrmate200ic_moveit_config/package.xml
+++ b/fanuc_lrmate200ic_moveit_config/package.xml
@@ -1,4 +1,4 @@
-<package>
+<package format="2">
   <name>fanuc_lrmate200ic_moveit_config</name>
   <version>0.3.2</version>
   <description>
@@ -28,19 +28,19 @@
 
   <buildtool_depend>catkin</buildtool_depend>
 
-  <run_depend>moveit_fake_controller_manager</run_depend>
-  <run_depend>moveit_simple_controller_manager</run_depend>
-  <run_depend>moveit_planners_ompl</run_depend>
-  <run_depend>moveit_ros_visualization</run_depend>
-  <run_depend>joint_state_publisher</run_depend>
-  <run_depend>robot_state_publisher</run_depend>
-  <run_depend>moveit_ros_move_group</run_depend>
+  <exec_depend>moveit_fake_controller_manager</exec_depend>
+  <exec_depend>moveit_simple_controller_manager</exec_depend>
+  <exec_depend>moveit_planners_ompl</exec_depend>
+  <exec_depend>moveit_ros_visualization</exec_depend>
+  <exec_depend>joint_state_publisher</exec_depend>
+  <exec_depend>robot_state_publisher</exec_depend>
+  <exec_depend>moveit_ros_move_group</exec_depend>
 
-  <run_depend>xacro</run_depend>
+  <exec_depend>xacro</exec_depend>
 
-  <run_depend>industrial_robot_simulator</run_depend>
-  <run_depend>fanuc_lrmate200ic_support</run_depend>
-  <run_depend>fanuc_lrmate200ic_moveit_plugins</run_depend>
+  <exec_depend>industrial_robot_simulator</exec_depend>
+  <exec_depend>fanuc_lrmate200ic_support</exec_depend>
+  <exec_depend>fanuc_lrmate200ic_moveit_plugins</exec_depend>
 
   <export>
     <architecture_independent />

--- a/fanuc_lrmate200ic_moveit_plugins/package.xml
+++ b/fanuc_lrmate200ic_moveit_plugins/package.xml
@@ -1,5 +1,5 @@
 <?xml version='1.0' encoding='ASCII'?>
-<package>
+<package format="2">
   <name>fanuc_lrmate200ic_moveit_plugins</name>
   <version>0.3.2</version>
   <description>
@@ -29,17 +29,12 @@
   <url type="repository">https://github.com/ros-industrial/fanuc</url>
 
   <buildtool_depend>catkin</buildtool_depend>
-  <build_depend>liblapack-dev</build_depend>
-  <build_depend>moveit_core</build_depend>
-  <build_depend>pluginlib</build_depend>
-  <build_depend>roscpp</build_depend>
-  <build_depend>tf_conversions</build_depend>
 
-  <run_depend>liblapack-dev</run_depend>
-  <run_depend>moveit_core</run_depend>
-  <run_depend>pluginlib</run_depend>
-  <run_depend>roscpp</run_depend>
-  <run_depend>tf_conversions</run_depend>
+  <depend>liblapack-dev</depend>
+  <depend>moveit_core</depend>
+  <depend>pluginlib</depend>
+  <depend>roscpp</depend>
+  <depend>tf_conversions</depend>
 
   <export>
     <moveit_core plugin="${prefix}/lrmate200ic_kinematics/fanuc_lrmate200ic_manipulator_moveit_ikfast_plugin_description.xml"/>

--- a/fanuc_lrmate200ic_support/package.xml
+++ b/fanuc_lrmate200ic_support/package.xml
@@ -1,4 +1,4 @@
-<package>
+<package format="2">
   <name>fanuc_lrmate200ic_support</name>
   <version>0.3.2</version>
   <description>
@@ -41,14 +41,14 @@
 
   <buildtool_depend>catkin</buildtool_depend>
 
-  <build_depend version_gte="1.9.55">roslaunch</build_depend>
+  <test_depend version_gte="1.9.55">roslaunch</test_depend>
 
-  <run_depend>robot_state_publisher</run_depend>
-  <run_depend>joint_state_publisher</run_depend>
-  <run_depend>rviz</run_depend>
-  <run_depend>xacro</run_depend>
-  <run_depend>fanuc_resources</run_depend>
-  <run_depend>fanuc_driver</run_depend>
+  <exec_depend>robot_state_publisher</exec_depend>
+  <exec_depend>joint_state_publisher</exec_depend>
+  <exec_depend>rviz</exec_depend>
+  <exec_depend>xacro</exec_depend>
+  <exec_depend>fanuc_resources</exec_depend>
+  <exec_depend>fanuc_driver</exec_depend>
 
   <export>
     <architecture_independent />

--- a/fanuc_m10ia_moveit_config/package.xml
+++ b/fanuc_m10ia_moveit_config/package.xml
@@ -1,4 +1,4 @@
-<package>
+<package format="2">
   <name>fanuc_m10ia_moveit_config</name>
   <version>0.3.2</version>
   <description>
@@ -28,19 +28,19 @@
 
   <buildtool_depend>catkin</buildtool_depend>
 
-  <run_depend>moveit_fake_controller_manager</run_depend>
-  <run_depend>moveit_simple_controller_manager</run_depend>
-  <run_depend>moveit_planners_ompl</run_depend>
-  <run_depend>moveit_ros_visualization</run_depend>
-  <run_depend>joint_state_publisher</run_depend>
-  <run_depend>robot_state_publisher</run_depend>
-  <run_depend>moveit_ros_move_group</run_depend>
+  <exec_depend>moveit_fake_controller_manager</exec_depend>
+  <exec_depend>moveit_simple_controller_manager</exec_depend>
+  <exec_depend>moveit_planners_ompl</exec_depend>
+  <exec_depend>moveit_ros_visualization</exec_depend>
+  <exec_depend>joint_state_publisher</exec_depend>
+  <exec_depend>robot_state_publisher</exec_depend>
+  <exec_depend>moveit_ros_move_group</exec_depend>
 
-  <run_depend>xacro</run_depend>
+  <exec_depend>xacro</exec_depend>
 
-  <run_depend>industrial_robot_simulator</run_depend>
-  <run_depend>fanuc_m10ia_support</run_depend>
-  <run_depend>fanuc_m10ia_moveit_plugins</run_depend>
+  <exec_depend>industrial_robot_simulator</exec_depend>
+  <exec_depend>fanuc_m10ia_support</exec_depend>
+  <exec_depend>fanuc_m10ia_moveit_plugins</exec_depend>
 
   <export>
     <architecture_independent />

--- a/fanuc_m10ia_moveit_plugins/package.xml
+++ b/fanuc_m10ia_moveit_plugins/package.xml
@@ -1,5 +1,5 @@
 <?xml version='1.0' encoding='ASCII'?>
-<package>
+<package format="2">
   <name>fanuc_m10ia_moveit_plugins</name>
   <version>0.3.2</version>
   <description>
@@ -27,17 +27,12 @@
   <url type="repository">https://github.com/ros-industrial/fanuc</url>
 
   <buildtool_depend>catkin</buildtool_depend>
-  <build_depend>liblapack-dev</build_depend>
-  <build_depend>moveit_core</build_depend>
-  <build_depend>pluginlib</build_depend>
-  <build_depend>roscpp</build_depend>
-  <build_depend>tf_conversions</build_depend>
 
-  <run_depend>liblapack-dev</run_depend>
-  <run_depend>moveit_core</run_depend>
-  <run_depend>pluginlib</run_depend>
-  <run_depend>roscpp</run_depend>
-  <run_depend>tf_conversions</run_depend>
+  <depend>liblapack-dev</depend>
+  <depend>moveit_core</depend>
+  <depend>pluginlib</depend>
+  <depend>roscpp</depend>
+  <depend>tf_conversions</depend>
 
   <export>
     <moveit_core plugin="${prefix}/m10ia_kinematics/fanuc_m10ia_manipulator_moveit_ikfast_plugin_description.xml"/>

--- a/fanuc_m10ia_support/package.xml
+++ b/fanuc_m10ia_support/package.xml
@@ -1,4 +1,4 @@
-<package>
+<package format="2">
   <name>fanuc_m10ia_support</name>
   <version>0.3.2</version>
   <description>
@@ -37,14 +37,14 @@
 
   <buildtool_depend>catkin</buildtool_depend>
 
-  <build_depend version_gte="1.9.55">roslaunch</build_depend>
+  <test_depend version_gte="1.9.55">roslaunch</test_depend>
 
-  <run_depend>fanuc_resources</run_depend>
-  <run_depend>fanuc_driver</run_depend>
-  <run_depend>joint_state_publisher</run_depend>
-  <run_depend>robot_state_publisher</run_depend>
-  <run_depend>rviz</run_depend>
-  <run_depend>xacro</run_depend>
+  <exec_depend>fanuc_resources</exec_depend>
+  <exec_depend>fanuc_driver</exec_depend>
+  <exec_depend>joint_state_publisher</exec_depend>
+  <exec_depend>robot_state_publisher</exec_depend>
+  <exec_depend>rviz</exec_depend>
+  <exec_depend>xacro</exec_depend>
 
   <export>
     <architecture_independent />

--- a/fanuc_m16ib20_moveit_config/package.xml
+++ b/fanuc_m16ib20_moveit_config/package.xml
@@ -1,4 +1,4 @@
-<package>
+<package format="2">
   <name>fanuc_m16ib20_moveit_config</name>
   <version>0.3.2</version>
   <description>
@@ -28,19 +28,19 @@
 
   <buildtool_depend>catkin</buildtool_depend>
 
-  <run_depend>moveit_fake_controller_manager</run_depend>
-  <run_depend>moveit_simple_controller_manager</run_depend>
-  <run_depend>moveit_planners_ompl</run_depend>
-  <run_depend>moveit_ros_visualization</run_depend>
-  <run_depend>joint_state_publisher</run_depend>
-  <run_depend>robot_state_publisher</run_depend>
-  <run_depend>moveit_ros_move_group</run_depend>
+  <exec_depend>moveit_fake_controller_manager</exec_depend>
+  <exec_depend>moveit_simple_controller_manager</exec_depend>
+  <exec_depend>moveit_planners_ompl</exec_depend>
+  <exec_depend>moveit_ros_visualization</exec_depend>
+  <exec_depend>joint_state_publisher</exec_depend>
+  <exec_depend>robot_state_publisher</exec_depend>
+  <exec_depend>moveit_ros_move_group</exec_depend>
 
-  <run_depend>xacro</run_depend>
+  <exec_depend>xacro</exec_depend>
 
-  <run_depend>industrial_robot_simulator</run_depend>
-  <run_depend>fanuc_m16ib_support</run_depend>
-  <run_depend>fanuc_m16ib_moveit_plugins</run_depend>
+  <exec_depend>industrial_robot_simulator</exec_depend>
+  <exec_depend>fanuc_m16ib_support</exec_depend>
+  <exec_depend>fanuc_m16ib_moveit_plugins</exec_depend>
 
   <export>
     <architecture_independent />

--- a/fanuc_m16ib_moveit_plugins/package.xml
+++ b/fanuc_m16ib_moveit_plugins/package.xml
@@ -1,5 +1,5 @@
 <?xml version='1.0' encoding='ASCII'?>
-<package>
+<package format="2">
   <name>fanuc_m16ib_moveit_plugins</name>
   <version>0.3.2</version>
   <description>
@@ -27,17 +27,12 @@
   <url type="repository">https://github.com/ros-industrial/fanuc</url>
 
   <buildtool_depend>catkin</buildtool_depend>
-  <build_depend>liblapack-dev</build_depend>
-  <build_depend>moveit_core</build_depend>
-  <build_depend>pluginlib</build_depend>
-  <build_depend>roscpp</build_depend>
-  <build_depend>tf_conversions</build_depend>
 
-  <run_depend>liblapack-dev</run_depend>
-  <run_depend>moveit_core</run_depend>
-  <run_depend>pluginlib</run_depend>
-  <run_depend>roscpp</run_depend>
-  <run_depend>tf_conversions</run_depend>
+  <depend>liblapack-dev</depend>
+  <depend>moveit_core</depend>
+  <depend>pluginlib</depend>
+  <depend>roscpp</depend>
+  <depend>tf_conversions</depend>
 
   <export>
     <moveit_core plugin="${prefix}/m16ib20_kinematics/fanuc_m16ib20_manipulator_moveit_ikfast_plugin_description.xml"/>

--- a/fanuc_m16ib_support/package.xml
+++ b/fanuc_m16ib_support/package.xml
@@ -1,4 +1,4 @@
-<package>
+<package format="2">
   <name>fanuc_m16ib_support</name>
   <version>0.3.2</version>
   <description>
@@ -38,14 +38,14 @@
 
   <buildtool_depend>catkin</buildtool_depend>
 
-  <build_depend version_gte="1.9.55">roslaunch</build_depend>
+  <test_depend version_gte="1.9.55">roslaunch</test_depend>
 
-  <run_depend>fanuc_resources</run_depend>
-  <run_depend>fanuc_driver</run_depend>
-  <run_depend>joint_state_publisher</run_depend>
-  <run_depend>robot_state_publisher</run_depend>
-  <run_depend>rviz</run_depend>
-  <run_depend>xacro</run_depend>
+  <exec_depend>fanuc_resources</exec_depend>
+  <exec_depend>fanuc_driver</exec_depend>
+  <exec_depend>joint_state_publisher</exec_depend>
+  <exec_depend>robot_state_publisher</exec_depend>
+  <exec_depend>rviz</exec_depend>
+  <exec_depend>xacro</exec_depend>
 
   <export>
     <architecture_independent />

--- a/fanuc_m20ia10l_moveit_config/package.xml
+++ b/fanuc_m20ia10l_moveit_config/package.xml
@@ -1,4 +1,4 @@
-<package>
+<package format="2">
   <name>fanuc_m20ia10l_moveit_config</name>
   <version>0.3.2</version>
   <description>
@@ -28,19 +28,19 @@
 
   <buildtool_depend>catkin</buildtool_depend>
 
-  <run_depend>moveit_fake_controller_manager</run_depend>
-  <run_depend>moveit_simple_controller_manager</run_depend>
-  <run_depend>moveit_planners_ompl</run_depend>
-  <run_depend>moveit_ros_visualization</run_depend>
-  <run_depend>joint_state_publisher</run_depend>
-  <run_depend>robot_state_publisher</run_depend>
-  <run_depend>moveit_ros_move_group</run_depend>
+  <exec_depend>moveit_fake_controller_manager</exec_depend>
+  <exec_depend>moveit_simple_controller_manager</exec_depend>
+  <exec_depend>moveit_planners_ompl</exec_depend>
+  <exec_depend>moveit_ros_visualization</exec_depend>
+  <exec_depend>joint_state_publisher</exec_depend>
+  <exec_depend>robot_state_publisher</exec_depend>
+  <exec_depend>moveit_ros_move_group</exec_depend>
 
-  <run_depend>xacro</run_depend>
+  <exec_depend>xacro</exec_depend>
 
-  <run_depend>industrial_robot_simulator</run_depend>
-  <run_depend>fanuc_m20ia_support</run_depend>
-  <run_depend>fanuc_m20ia_moveit_plugins</run_depend>
+  <exec_depend>industrial_robot_simulator</exec_depend>
+  <exec_depend>fanuc_m20ia_support</exec_depend>
+  <exec_depend>fanuc_m20ia_moveit_plugins</exec_depend>
 
   <export>
     <architecture_independent />

--- a/fanuc_m20ia_moveit_config/package.xml
+++ b/fanuc_m20ia_moveit_config/package.xml
@@ -1,4 +1,4 @@
-<package>
+<package format="2">
   <name>fanuc_m20ia_moveit_config</name>
   <version>0.3.2</version>
   <description>
@@ -28,19 +28,19 @@
 
   <buildtool_depend>catkin</buildtool_depend>
 
-  <run_depend>moveit_fake_controller_manager</run_depend>
-  <run_depend>moveit_simple_controller_manager</run_depend>
-  <run_depend>moveit_planners_ompl</run_depend>
-  <run_depend>moveit_ros_visualization</run_depend>
-  <run_depend>joint_state_publisher</run_depend>
-  <run_depend>robot_state_publisher</run_depend>
-  <run_depend>moveit_ros_move_group</run_depend>
+  <exec_depend>moveit_fake_controller_manager</exec_depend>
+  <exec_depend>moveit_simple_controller_manager</exec_depend>
+  <exec_depend>moveit_planners_ompl</exec_depend>
+  <exec_depend>moveit_ros_visualization</exec_depend>
+  <exec_depend>joint_state_publisher</exec_depend>
+  <exec_depend>robot_state_publisher</exec_depend>
+  <exec_depend>moveit_ros_move_group</exec_depend>
 
-  <run_depend>xacro</run_depend>
+  <exec_depend>xacro</exec_depend>
 
-  <run_depend>industrial_robot_simulator</run_depend>
-  <run_depend>fanuc_m20ia_support</run_depend>
-  <run_depend>fanuc_m20ia_moveit_plugins</run_depend>
+  <exec_depend>industrial_robot_simulator</exec_depend>
+  <exec_depend>fanuc_m20ia_support</exec_depend>
+  <exec_depend>fanuc_m20ia_moveit_plugins</exec_depend>
 
   <export>
     <architecture_independent />

--- a/fanuc_m20ia_moveit_plugins/package.xml
+++ b/fanuc_m20ia_moveit_plugins/package.xml
@@ -1,5 +1,5 @@
 <?xml version='1.0' encoding='ASCII'?>
-<package>
+<package format="2">
   <name>fanuc_m20ia_moveit_plugins</name>
   <version>0.3.2</version>
   <description>
@@ -31,17 +31,12 @@
   <url type="repository">https://github.com/ros-industrial/fanuc</url>
 
   <buildtool_depend>catkin</buildtool_depend>
-  <build_depend>liblapack-dev</build_depend>
-  <build_depend>moveit_core</build_depend>
-  <build_depend>pluginlib</build_depend>
-  <build_depend>roscpp</build_depend>
-  <build_depend>tf_conversions</build_depend>
 
-  <run_depend>liblapack-dev</run_depend>
-  <run_depend>moveit_core</run_depend>
-  <run_depend>pluginlib</run_depend>
-  <run_depend>roscpp</run_depend>
-  <run_depend>tf_conversions</run_depend>
+  <depend>liblapack-dev</depend>
+  <depend>moveit_core</depend>
+  <depend>pluginlib</depend>
+  <depend>roscpp</depend>
+  <depend>tf_conversions</depend>
 
   <export>
     <moveit_core plugin="${prefix}/m20ia_kinematics/fanuc_m20ia_manipulator_moveit_ikfast_plugin_description.xml"/>

--- a/fanuc_m20ia_support/package.xml
+++ b/fanuc_m20ia_support/package.xml
@@ -1,4 +1,4 @@
-<package>
+<package format="2">
   <name>fanuc_m20ia_support</name>
   <version>0.3.2</version>
   <description>
@@ -43,14 +43,14 @@
 
   <buildtool_depend>catkin</buildtool_depend>
 
-  <build_depend version_gte="1.9.55">roslaunch</build_depend>
+  <test_depend version_gte="1.9.55">roslaunch</test_depend>
 
-  <run_depend>robot_state_publisher</run_depend>
-  <run_depend>joint_state_publisher</run_depend>
-  <run_depend>rviz</run_depend>
-  <run_depend>xacro</run_depend>
-  <run_depend>fanuc_resources</run_depend>
-  <run_depend>fanuc_driver</run_depend>
+  <exec_depend>robot_state_publisher</exec_depend>
+  <exec_depend>joint_state_publisher</exec_depend>
+  <exec_depend>rviz</exec_depend>
+  <exec_depend>xacro</exec_depend>
+  <exec_depend>fanuc_resources</exec_depend>
+  <exec_depend>fanuc_driver</exec_depend>
 
   <export>
     <architecture_independent />

--- a/fanuc_m430ia2f_moveit_config/package.xml
+++ b/fanuc_m430ia2f_moveit_config/package.xml
@@ -1,4 +1,4 @@
-<package>
+<package format="2">
   <name>fanuc_m430ia2f_moveit_config</name>
   <version>0.3.2</version>
   <description>
@@ -28,19 +28,19 @@
 
   <buildtool_depend>catkin</buildtool_depend>
 
-  <run_depend>moveit_fake_controller_manager</run_depend>
-  <run_depend>moveit_simple_controller_manager</run_depend>
-  <run_depend>moveit_planners_ompl</run_depend>
-  <run_depend>moveit_ros_visualization</run_depend>
-  <run_depend>joint_state_publisher</run_depend>
-  <run_depend>robot_state_publisher</run_depend>
-  <run_depend>moveit_ros_move_group</run_depend>
+  <exec_depend>moveit_fake_controller_manager</exec_depend>
+  <exec_depend>moveit_simple_controller_manager</exec_depend>
+  <exec_depend>moveit_planners_ompl</exec_depend>
+  <exec_depend>moveit_ros_visualization</exec_depend>
+  <exec_depend>joint_state_publisher</exec_depend>
+  <exec_depend>robot_state_publisher</exec_depend>
+  <exec_depend>moveit_ros_move_group</exec_depend>
 
-  <run_depend>xacro</run_depend>
+  <exec_depend>xacro</exec_depend>
 
-  <run_depend>industrial_robot_simulator</run_depend>
-  <run_depend>fanuc_m430ia_support</run_depend>
-  <run_depend>fanuc_m430ia_moveit_plugins</run_depend>
+  <exec_depend>industrial_robot_simulator</exec_depend>
+  <exec_depend>fanuc_m430ia_support</exec_depend>
+  <exec_depend>fanuc_m430ia_moveit_plugins</exec_depend>
 
   <export>
     <architecture_independent />

--- a/fanuc_m430ia2p_moveit_config/package.xml
+++ b/fanuc_m430ia2p_moveit_config/package.xml
@@ -1,4 +1,4 @@
-<package>
+<package format="2">
   <name>fanuc_m430ia2p_moveit_config</name>
   <version>0.3.2</version>
   <description>
@@ -28,19 +28,19 @@
 
   <buildtool_depend>catkin</buildtool_depend>
 
-  <run_depend>moveit_fake_controller_manager</run_depend>
-  <run_depend>moveit_simple_controller_manager</run_depend>
-  <run_depend>moveit_planners_ompl</run_depend>
-  <run_depend>moveit_ros_visualization</run_depend>
-  <run_depend>joint_state_publisher</run_depend>
-  <run_depend>robot_state_publisher</run_depend>
-  <run_depend>moveit_ros_move_group</run_depend>
+  <exec_depend>moveit_fake_controller_manager</exec_depend>
+  <exec_depend>moveit_simple_controller_manager</exec_depend>
+  <exec_depend>moveit_planners_ompl</exec_depend>
+  <exec_depend>moveit_ros_visualization</exec_depend>
+  <exec_depend>joint_state_publisher</exec_depend>
+  <exec_depend>robot_state_publisher</exec_depend>
+  <exec_depend>moveit_ros_move_group</exec_depend>
 
-  <run_depend>xacro</run_depend>
+  <exec_depend>xacro</exec_depend>
 
-  <run_depend>industrial_robot_simulator</run_depend>
-  <run_depend>fanuc_m430ia_support</run_depend>
-  <run_depend>fanuc_m430ia_moveit_plugins</run_depend>
+  <exec_depend>industrial_robot_simulator</exec_depend>
+  <exec_depend>fanuc_m430ia_support</exec_depend>
+  <exec_depend>fanuc_m430ia_moveit_plugins</exec_depend>
 
   <export>
     <architecture_independent />

--- a/fanuc_m430ia_moveit_plugins/package.xml
+++ b/fanuc_m430ia_moveit_plugins/package.xml
@@ -1,5 +1,5 @@
 <?xml version='1.0' encoding='ASCII'?>
-<package>
+<package format="2">
   <name>fanuc_m430ia_moveit_plugins</name>
   <version>0.3.2</version>
   <description>
@@ -27,17 +27,12 @@
   <url type="repository">https://github.com/ros-industrial/fanuc</url>
 
   <buildtool_depend>catkin</buildtool_depend>
-  <build_depend>liblapack-dev</build_depend>
-  <build_depend>moveit_core</build_depend>
-  <build_depend>pluginlib</build_depend>
-  <build_depend>roscpp</build_depend>
-  <build_depend>tf_conversions</build_depend>
 
-  <run_depend>liblapack-dev</run_depend>
-  <run_depend>moveit_core</run_depend>
-  <run_depend>pluginlib</run_depend>
-  <run_depend>roscpp</run_depend>
-  <run_depend>tf_conversions</run_depend>
+  <depend>liblapack-dev</depend>
+  <depend>moveit_core</depend>
+  <depend>pluginlib</depend>
+  <depend>roscpp</depend>
+  <depend>tf_conversions</depend>
 
   <export>
     <moveit_core plugin="${prefix}/m430ia2f_kinematics/fanuc_m430ia2f_manipulator_moveit_ikfast_plugin_description.xml"/>

--- a/fanuc_m430ia_support/package.xml
+++ b/fanuc_m430ia_support/package.xml
@@ -1,4 +1,4 @@
-<package>
+<package format="2">
   <name>fanuc_m430ia_support</name>
   <version>0.3.2</version>
   <description>
@@ -37,14 +37,14 @@
 
   <buildtool_depend>catkin</buildtool_depend>
 
-  <build_depend version_gte="1.9.55">roslaunch</build_depend>
+  <test_depend version_gte="1.9.55">roslaunch</test_depend>
 
-  <run_depend>fanuc_resources</run_depend>
-  <run_depend>fanuc_driver</run_depend>
-  <run_depend>joint_state_publisher</run_depend>
-  <run_depend>robot_state_publisher</run_depend>
-  <run_depend>rviz</run_depend>
-  <run_depend>xacro</run_depend>
+  <exec_depend>fanuc_resources</exec_depend>
+  <exec_depend>fanuc_driver</exec_depend>
+  <exec_depend>joint_state_publisher</exec_depend>
+  <exec_depend>robot_state_publisher</exec_depend>
+  <exec_depend>rviz</exec_depend>
+  <exec_depend>xacro</exec_depend>
 
   <export>
     <architecture_independent />

--- a/fanuc_resources/package.xml
+++ b/fanuc_resources/package.xml
@@ -1,17 +1,17 @@
-<package>
+<package format="2">
   <name>fanuc_resources</name>
   <version>0.3.2</version>
   <description>
     <p>
-      Shared configuration data, 3D models and launch files for Fanuc 
+      Shared configuration data, 3D models and launch files for Fanuc
       manipulators.
     </p>
     <p>
-      This package contains configuration data, 3D models and launch files 
-      that are shared between different Fanuc robot support packages 
+      This package contains configuration data, 3D models and launch files
+      that are shared between different Fanuc robot support packages
       within the ROS-Industrial program.
 
-      This package also contains common URDF / XACRO resources used by 
+      This package also contains common urdf / xacro resources used by
       other Fanuc related packages.
     </p>
   </description>


### PR DESCRIPTION
All manifests upgraded to _package format 2_, as described in REP-140.

More info: [catkin 0.6.14 documentation » How to do common tasks » Package format 2 (recommended) » Migrating from format 1 to format 2](http://docs.ros.org/indigo/api/catkin/html/howto/format2/migrating_from_format_1.html#migrating-from-format1-to-format2).

No functional changes to any of the nodes.

Checked with `catkin_lint`. No errors/warnings. 

All `roslaunch` tests still pass.
