### PR TITLE
Fix for issue 147: add rosindex compatible tag sections to manifests

### DIFF
--- a/fanuc/package.xml
+++ b/fanuc/package.xml
@@ -37,5 +37,13 @@
   <export>
     <metapackage/>
     <architecture_independent/>
+    <rosindex>
+      <tags>
+        <tag>metapackage</tag>
+        <tag>fanuc</tag>
+        <tag>industrial</tag>
+        <tag>ros-industrial</tag>
+      </tags>
+    </rosindex>
   </export>
 </package>

--- a/fanuc_driver/package.xml
+++ b/fanuc_driver/package.xml
@@ -24,4 +24,19 @@
   <depend>industrial_robot_client</depend>
 
   <test_depend version_gte="1.9.55">roslaunch</test_depend>
+
+  <export>
+    <rosindex>
+      <tags>
+        <tag>driver</tag>
+        <tag>simple_message</tag>
+        <tag>fanuc</tag>
+        <tag>industrial</tag>
+        <tag>ros-industrial</tag>
+        <tag>KAREL</tag>
+        <tag>R-30iA</tag>
+        <tag>R-30iB</tag>
+      </tags>
+    </rosindex>
+  </export>
 </package>

--- a/fanuc_lrmate200ic5h_moveit_config/package.xml
+++ b/fanuc_lrmate200ic5h_moveit_config/package.xml
@@ -44,5 +44,14 @@
 
   <export>
     <architecture_independent />
+    <rosindex>
+      <tags>
+        <tag>moveit</tag>
+        <tag>fanuc</tag>
+        <tag>industrial</tag>
+        <tag>ros-industrial</tag>
+        <tag>lrmate200ic</tag>
+      </tags>
+    </rosindex>
   </export>
 </package>

--- a/fanuc_lrmate200ic5l_moveit_config/package.xml
+++ b/fanuc_lrmate200ic5l_moveit_config/package.xml
@@ -44,5 +44,14 @@
 
   <export>
     <architecture_independent />
+    <rosindex>
+      <tags>
+        <tag>moveit</tag>
+        <tag>fanuc</tag>
+        <tag>industrial</tag>
+        <tag>ros-industrial</tag>
+        <tag>lrmate200ic</tag>
+      </tags>
+    </rosindex>
   </export>
 </package>

--- a/fanuc_lrmate200ic_moveit_config/package.xml
+++ b/fanuc_lrmate200ic_moveit_config/package.xml
@@ -44,5 +44,14 @@
 
   <export>
     <architecture_independent />
+    <rosindex>
+      <tags>
+        <tag>moveit</tag>
+        <tag>fanuc</tag>
+        <tag>industrial</tag>
+        <tag>ros-industrial</tag>
+        <tag>lrmate200ic</tag>
+      </tags>
+    </rosindex>
   </export>
 </package>

--- a/fanuc_lrmate200ic_moveit_plugins/package.xml
+++ b/fanuc_lrmate200ic_moveit_plugins/package.xml
@@ -41,5 +41,16 @@
     <moveit_core plugin="${prefix}/lrmate200ic5f_kinematics/fanuc_lrmate200ic5f_manipulator_moveit_ikfast_plugin_description.xml"/>
     <moveit_core plugin="${prefix}/lrmate200ic5h_kinematics/fanuc_lrmate200ic5h_manipulator_moveit_ikfast_plugin_description.xml"/>
     <moveit_core plugin="${prefix}/lrmate200ic5l_kinematics/fanuc_lrmate200ic5l_manipulator_moveit_ikfast_plugin_description.xml"/>
+    <rosindex>
+      <tags>
+        <tag>moveit</tag>
+        <tag>ikfast</tag>
+        <tag>kinematics</tag>
+        <tag>fanuc</tag>
+        <tag>industrial</tag>
+        <tag>ros-industrial</tag>
+        <tag>lrmate200ic</tag>
+      </tags>
+    </rosindex>
   </export>
 </package>

--- a/fanuc_lrmate200ic_support/package.xml
+++ b/fanuc_lrmate200ic_support/package.xml
@@ -52,5 +52,15 @@
 
   <export>
     <architecture_independent />
+    <rosindex>
+      <tags>
+        <tag>support_package</tag>
+        <tag>description</tag>
+        <tag>fanuc</tag>
+        <tag>industrial</tag>
+        <tag>ros-industrial</tag>
+        <tag>lrmate200ic</tag>
+      </tags>
+    </rosindex>
   </export>
 </package>

--- a/fanuc_m10ia_moveit_config/package.xml
+++ b/fanuc_m10ia_moveit_config/package.xml
@@ -44,5 +44,14 @@
 
   <export>
     <architecture_independent />
+    <rosindex>
+      <tags>
+        <tag>moveit</tag>
+        <tag>fanuc</tag>
+        <tag>industrial</tag>
+        <tag>ros-industrial</tag>
+        <tag>m10ia</tag>
+      </tags>
+    </rosindex>
   </export>
 </package>

--- a/fanuc_m10ia_moveit_plugins/package.xml
+++ b/fanuc_m10ia_moveit_plugins/package.xml
@@ -36,5 +36,16 @@
 
   <export>
     <moveit_core plugin="${prefix}/m10ia_kinematics/fanuc_m10ia_manipulator_moveit_ikfast_plugin_description.xml"/>
+    <rosindex>
+      <tags>
+        <tag>moveit</tag>
+        <tag>ikfast</tag>
+        <tag>kinematics</tag>
+        <tag>fanuc</tag>
+        <tag>industrial</tag>
+        <tag>ros-industrial</tag>
+        <tag>m10ia</tag>
+      </tags>
+    </rosindex>
   </export>
 </package>

--- a/fanuc_m10ia_support/package.xml
+++ b/fanuc_m10ia_support/package.xml
@@ -48,5 +48,15 @@
 
   <export>
     <architecture_independent />
+    <rosindex>
+      <tags>
+        <tag>support_package</tag>
+        <tag>description</tag>
+        <tag>fanuc</tag>
+        <tag>industrial</tag>
+        <tag>ros-industrial</tag>
+        <tag>m10ia</tag>
+      </tags>
+    </rosindex>
   </export>
 </package>

--- a/fanuc_m16ib20_moveit_config/package.xml
+++ b/fanuc_m16ib20_moveit_config/package.xml
@@ -44,5 +44,14 @@
 
   <export>
     <architecture_independent />
+    <rosindex>
+      <tags>
+        <tag>moveit</tag>
+        <tag>fanuc</tag>
+        <tag>industrial</tag>
+        <tag>ros-industrial</tag>
+        <tag>m16ib</tag>
+      </tags>
+    </rosindex>
   </export>
 </package>

--- a/fanuc_m16ib_moveit_plugins/package.xml
+++ b/fanuc_m16ib_moveit_plugins/package.xml
@@ -36,5 +36,16 @@
 
   <export>
     <moveit_core plugin="${prefix}/m16ib20_kinematics/fanuc_m16ib20_manipulator_moveit_ikfast_plugin_description.xml"/>
+    <rosindex>
+      <tags>
+        <tag>moveit</tag>
+        <tag>ikfast</tag>
+        <tag>kinematics</tag>
+        <tag>fanuc</tag>
+        <tag>industrial</tag>
+        <tag>ros-industrial</tag>
+        <tag>m16ib</tag>
+      </tags>
+    </rosindex>
   </export>
 </package>

--- a/fanuc_m16ib_support/package.xml
+++ b/fanuc_m16ib_support/package.xml
@@ -49,5 +49,15 @@
 
   <export>
     <architecture_independent />
+    <rosindex>
+      <tags>
+        <tag>support_package</tag>
+        <tag>description</tag>
+        <tag>fanuc</tag>
+        <tag>industrial</tag>
+        <tag>ros-industrial</tag>
+        <tag>m16ib</tag>
+      </tags>
+    </rosindex>
   </export>
 </package>

--- a/fanuc_m20ia10l_moveit_config/package.xml
+++ b/fanuc_m20ia10l_moveit_config/package.xml
@@ -44,5 +44,14 @@
 
   <export>
     <architecture_independent />
+    <rosindex>
+      <tags>
+        <tag>moveit</tag>
+        <tag>fanuc</tag>
+        <tag>industrial</tag>
+        <tag>ros-industrial</tag>
+        <tag>m20ia</tag>
+      </tags>
+    </rosindex>
   </export>
 </package>

--- a/fanuc_m20ia_moveit_config/package.xml
+++ b/fanuc_m20ia_moveit_config/package.xml
@@ -44,5 +44,14 @@
 
   <export>
     <architecture_independent />
+    <rosindex>
+      <tags>
+        <tag>moveit</tag>
+        <tag>fanuc</tag>
+        <tag>industrial</tag>
+        <tag>ros-industrial</tag>
+        <tag>m20ia</tag>
+      </tags>
+    </rosindex>
   </export>
 </package>

--- a/fanuc_m20ia_moveit_plugins/package.xml
+++ b/fanuc_m20ia_moveit_plugins/package.xml
@@ -41,5 +41,16 @@
   <export>
     <moveit_core plugin="${prefix}/m20ia_kinematics/fanuc_m20ia_manipulator_moveit_ikfast_plugin_description.xml"/>
     <moveit_core plugin="${prefix}/m20ia10l_kinematics/fanuc_m20ia10l_manipulator_moveit_ikfast_plugin_description.xml"/>
+    <rosindex>
+      <tags>
+        <tag>moveit</tag>
+        <tag>ikfast</tag>
+        <tag>kinematics</tag>
+        <tag>fanuc</tag>
+        <tag>industrial</tag>
+        <tag>ros-industrial</tag>
+        <tag>m20ia</tag>
+      </tags>
+    </rosindex>
   </export>
 </package>

--- a/fanuc_m20ia_support/package.xml
+++ b/fanuc_m20ia_support/package.xml
@@ -54,5 +54,15 @@
 
   <export>
     <architecture_independent />
+    <rosindex>
+      <tags>
+        <tag>support_package</tag>
+        <tag>description</tag>
+        <tag>fanuc</tag>
+        <tag>industrial</tag>
+        <tag>ros-industrial</tag>
+        <tag>m20ia</tag>
+      </tags>
+    </rosindex>
   </export>
 </package>

--- a/fanuc_m430ia2f_moveit_config/package.xml
+++ b/fanuc_m430ia2f_moveit_config/package.xml
@@ -44,5 +44,14 @@
 
   <export>
     <architecture_independent />
+    <rosindex>
+      <tags>
+        <tag>moveit</tag>
+        <tag>fanuc</tag>
+        <tag>industrial</tag>
+        <tag>ros-industrial</tag>
+        <tag>m430ia</tag>
+      </tags>
+    </rosindex>
   </export>
 </package>

--- a/fanuc_m430ia2p_moveit_config/package.xml
+++ b/fanuc_m430ia2p_moveit_config/package.xml
@@ -44,5 +44,14 @@
 
   <export>
     <architecture_independent />
+    <rosindex>
+      <tags>
+        <tag>moveit</tag>
+        <tag>fanuc</tag>
+        <tag>industrial</tag>
+        <tag>ros-industrial</tag>
+        <tag>m430ia</tag>
+      </tags>
+    </rosindex>
   </export>
 </package>

--- a/fanuc_m430ia_moveit_plugins/package.xml
+++ b/fanuc_m430ia_moveit_plugins/package.xml
@@ -37,5 +37,16 @@
   <export>
     <moveit_core plugin="${prefix}/m430ia2f_kinematics/fanuc_m430ia2f_manipulator_moveit_ikfast_plugin_description.xml"/>
     <moveit_core plugin="${prefix}/m430ia2p_kinematics/fanuc_m430ia2p_manipulator_moveit_ikfast_plugin_description.xml"/>
+    <rosindex>
+      <tags>
+        <tag>moveit</tag>
+        <tag>ikfast</tag>
+        <tag>kinematics</tag>
+        <tag>fanuc</tag>
+        <tag>industrial</tag>
+        <tag>ros-industrial</tag>
+        <tag>m430ia</tag>
+      </tags>
+    </rosindex>
   </export>
 </package>

--- a/fanuc_m430ia_support/package.xml
+++ b/fanuc_m430ia_support/package.xml
@@ -48,5 +48,15 @@
 
   <export>
     <architecture_independent />
+    <rosindex>
+      <tags>
+        <tag>support_package</tag>
+        <tag>description</tag>
+        <tag>fanuc</tag>
+        <tag>industrial</tag>
+        <tag>ros-industrial</tag>
+        <tag>m430ia</tag>
+      </tags>
+    </rosindex>
   </export>
 </package>

--- a/fanuc_resources/package.xml
+++ b/fanuc_resources/package.xml
@@ -27,5 +27,18 @@
 
   <export>
     <architecture_independent />
+    <rosindex>
+      <tags>
+        <tag>urdf</tag>
+        <tag>xacro</tag>
+        <tag>colour</tag>
+        <tag>material</tag>
+        <tag>mesh</tag>
+        <tag>resources</tag>
+        <tag>fanuc</tag>
+        <tag>industrial</tag>
+        <tag>ros-industrial</tag>
+      </tags>
+    </rosindex>
   </export>
 </package>


### PR DESCRIPTION
As there is no standardised set of tags afaik, I've just 'made something up'. I did try to stay consistent, at least between this small set of packages.

See [ROS Index Metadata](http://rosindex.github.io/contribute/metadata/) for more info.

No functional changes to any nodes. `roslaunch` tests still pass. `catkin_lint` still passes.
