### PR TITLE
Fix for issue #165: add doc strings to launch file args

### DIFF
--- a/fanuc_driver/launch/motion_streaming_interface.launch
+++ b/fanuc_driver/launch/motion_streaming_interface.launch
@@ -3,17 +3,17 @@
 -->
 <launch>
   <!-- IP of robot (or PC running simulation) -->
-  <arg name="robot_ip" />
+  <arg name="robot_ip" doc="IP of controller" />
 
   <!-- J23_factor: set to correct factor to compensate for J23 coupling:
               -1 : negative coupling (J3' = J3 - J2)
                0 : no coupling       (J3' = J3)
                1 : positive coupling (J3' = J3 + J2)
   -->
-  <arg name="J23_factor" />
+  <arg name="J23_factor" doc="Compensation factor for joint 2-3 coupling (-1, 0 or 1)" />
 
   <!-- Load the byte-swapping version of robot_state if required -->
-  <arg name="use_bswap" />
+  <arg name="use_bswap" doc="If true, driver will byte-swap all incoming and outgoing data" />
 
   <!-- put them on the parameter server -->
   <param name="robot_ip_address" type="str" value="$(arg robot_ip)" />

--- a/fanuc_driver/launch/robot_interface_streaming.launch
+++ b/fanuc_driver/launch/robot_interface_streaming.launch
@@ -16,17 +16,17 @@
 -->
 
   <!-- robot_ip: IP-address of the robot's socket-messaging server -->
-  <arg name="robot_ip" />
+  <arg name="robot_ip" doc="IP of controller" />
 
   <!-- J23_factor: set to correct factor to compensate for J23 coupling:
               -1 : negative coupling (J3' = J3 - J2)
                0 : no coupling (J3' == J3)
                1 : positive coupling (J3' = J3 + J2)
   -->
-  <arg name="J23_factor" />
+  <arg name="J23_factor" doc="Compensation factor for joint 2-3 coupling (-1, 0 or 1)" />
 
   <!-- Load the byte-swapping versions of Fanuc nodes if required -->
-  <arg name="use_bswap" />
+  <arg name="use_bswap" doc="If true, driver will byte-swap all incoming and outgoing data" />
 
   <!-- copy the specified parameters to the Parameter Server, for 
        use by nodes below -->

--- a/fanuc_driver/launch/robot_state.launch
+++ b/fanuc_driver/launch/robot_state.launch
@@ -3,17 +3,17 @@
 -->
 <launch>
   <!-- IP of robot (or PC running simulation) -->
-  <arg name="robot_ip" />
+  <arg name="robot_ip" doc="IP of controller" />
 
   <!-- J23_factor: set to correct factor to compensate for J23 coupling:
               -1 : negative coupling (J3' = J3 - J2)
                0 : no coupling       (J3' = J3)
                1 : positive coupling (J3' = J3 + J2)
   -->
-  <arg name="J23_factor" />
+  <arg name="J23_factor" doc="Compensation factor for joint 2-3 coupling (-1, 0 or 1)" />
 
   <!-- Load the byte-swapping version of robot_state if required -->
-  <arg name="use_bswap" />
+  <arg name="use_bswap" doc="If true, driver will byte-swap all incoming and outgoing data" />
 
   <!-- put them on the parameter server -->
   <param name="robot_ip_address" type="str" value="$(arg robot_ip)" />

--- a/fanuc_lrmate200ic5h_moveit_config/launch/moveit_planning_execution.launch
+++ b/fanuc_lrmate200ic5h_moveit_config/launch/moveit_planning_execution.launch
@@ -11,14 +11,14 @@
  
   <!-- the "sim" argument controls whether we connect to a Simulated or Real robot -->
   <!--  - if sim=false, a robot_ip argument is required -->
-  <arg name="sim" default="true" />
-  <arg name="robot_ip" unless="$(arg sim)" />
-  <arg name="use_bswap" unless="$(arg sim)" default="true" />
+  <arg name="sim" default="true" doc="Use industrial robot simulator instead of real robot" />
+  <arg name="robot_ip" unless="$(arg sim)" doc="IP of controller (only required if not using industrial simulator)" />
+  <arg name="use_bswap" unless="$(arg sim)" default="true" doc="If true, robot driver will byte-swap all incoming and outgoing data (only required if not using industrial simulator)" />
 
   <!-- By default, we do not start a database (it can be large) -->
-  <arg name="db" default="false" />
+  <arg name="db" default="false" doc="Start the MoveIt database" />
   <!-- Allow user to specify database location -->
-  <arg name="db_path" default="$(find fanuc_lrmate200ic5h_moveit_config)/default_warehouse_mongo_db" />
+  <arg name="db_path" default="$(find fanuc_lrmate200ic5h_moveit_config)/default_warehouse_mongo_db" doc="Path to database files" />
 
   <!-- load the robot_description parameter before launching ROS-I nodes -->
   <include file="$(find fanuc_lrmate200ic5h_moveit_config)/launch/planning_context.launch" >

--- a/fanuc_lrmate200ic5l_moveit_config/launch/moveit_planning_execution.launch
+++ b/fanuc_lrmate200ic5l_moveit_config/launch/moveit_planning_execution.launch
@@ -11,14 +11,14 @@
  
   <!-- the "sim" argument controls whether we connect to a Simulated or Real robot -->
   <!--  - if sim=false, a robot_ip argument is required -->
-  <arg name="sim" default="true" />
-  <arg name="robot_ip" unless="$(arg sim)" />
-  <arg name="use_bswap" unless="$(arg sim)" default="true" />
+  <arg name="sim" default="true" doc="Use industrial robot simulator instead of real robot" />
+  <arg name="robot_ip" unless="$(arg sim)" doc="IP of controller (only required if not using industrial simulator)" />
+  <arg name="use_bswap" unless="$(arg sim)" default="true" doc="If true, robot driver will byte-swap all incoming and outgoing data (only required if not using industrial simulator)" />
 
   <!-- By default, we do not start a database (it can be large) -->
-  <arg name="db" default="false" />
+  <arg name="db" default="false" doc="Start the MoveIt database" />
   <!-- Allow user to specify database location -->
-  <arg name="db_path" default="$(find fanuc_lrmate200ic5l_moveit_config)/default_warehouse_mongo_db" />
+  <arg name="db_path" default="$(find fanuc_lrmate200ic5l_moveit_config)/default_warehouse_mongo_db" doc="Path to database files" />
 
   <!-- load the robot_description parameter before launching ROS-I nodes -->
   <include file="$(find fanuc_lrmate200ic5l_moveit_config)/launch/planning_context.launch" >

--- a/fanuc_lrmate200ic_moveit_config/launch/moveit_planning_execution.launch
+++ b/fanuc_lrmate200ic_moveit_config/launch/moveit_planning_execution.launch
@@ -11,14 +11,14 @@
  
   <!-- the "sim" argument controls whether we connect to a Simulated or Real robot -->
   <!--  - if sim=false, a robot_ip argument is required -->
-  <arg name="sim" default="true" />
-  <arg name="robot_ip" unless="$(arg sim)" />
-  <arg name="use_bswap" unless="$(arg sim)" default="true" />
+  <arg name="sim" default="true" doc="Use industrial robot simulator instead of real robot" />
+  <arg name="robot_ip" unless="$(arg sim)" doc="IP of controller (only required if not using industrial simulator)" />
+  <arg name="use_bswap" unless="$(arg sim)" default="true" doc="If true, robot driver will byte-swap all incoming and outgoing data (only required if not using industrial simulator)" />
 
   <!-- By default, we do not start a database (it can be large) -->
-  <arg name="db" default="false" />
+  <arg name="db" default="false" doc="Start the MoveIt database" />
   <!-- Allow user to specify database location -->
-  <arg name="db_path" default="$(find fanuc_lrmate200ic_moveit_config)/default_warehouse_mongo_db" />
+  <arg name="db_path" default="$(find fanuc_lrmate200ic_moveit_config)/default_warehouse_mongo_db" doc="Path to database files" />
 
   <!-- load the robot_description parameter before launching ROS-I nodes -->
   <include file="$(find fanuc_lrmate200ic_moveit_config)/launch/planning_context.launch" >

--- a/fanuc_lrmate200ic_support/launch/robot_interface_streaming_lrmate200ic.launch
+++ b/fanuc_lrmate200ic_support/launch/robot_interface_streaming_lrmate200ic.launch
@@ -10,9 +10,9 @@
     robot_interface_streaming_lrmate200ic.launch robot_ip:=<value>
 -->
 <launch>
-  <arg name="robot_ip" />
-  <arg name="J23_factor" default="1" />
-  <arg name="use_bswap" default="true" />
+  <arg name="robot_ip" doc="IP of controller" />
+  <arg name="J23_factor" default="1" doc="Compensation factor for joint 2-3 coupling (-1, 0 or 1)" />
+  <arg name="use_bswap" default="true" doc="If true, robot driver will byte-swap all incoming and outgoing data" />
 
   <rosparam command="load" file="$(find fanuc_lrmate200ic_support)/config/joint_names_lrmate200ic.yaml" />
 

--- a/fanuc_lrmate200ic_support/launch/robot_interface_streaming_lrmate200ic5f.launch
+++ b/fanuc_lrmate200ic_support/launch/robot_interface_streaming_lrmate200ic5f.launch
@@ -10,9 +10,9 @@
     robot_interface_streaming_lrmate200ic5f.launch robot_ip:=<value>
 -->
 <launch>
-  <arg name="robot_ip" />
-  <arg name="J23_factor" default="1" />
-  <arg name="use_bswap" default="true" />
+  <arg name="robot_ip" doc="IP of controller" />
+  <arg name="J23_factor" default="1" doc="Compensation factor for joint 2-3 coupling (-1, 0 or 1)" />
+  <arg name="use_bswap" default="true" doc="If true, robot driver will byte-swap all incoming and outgoing data" />
 
   <rosparam command="load" file="$(find fanuc_lrmate200ic_support)/config/joint_names_lrmate200ic5f.yaml" />
 

--- a/fanuc_lrmate200ic_support/launch/robot_interface_streaming_lrmate200ic5h.launch
+++ b/fanuc_lrmate200ic_support/launch/robot_interface_streaming_lrmate200ic5h.launch
@@ -10,9 +10,9 @@
     robot_interface_streaming_lrmate200ic5h.launch robot_ip:=<value>
 -->
 <launch>
-  <arg name="robot_ip" />
-  <arg name="J23_factor" default="1" />
-  <arg name="use_bswap" default="true" />
+  <arg name="robot_ip" doc="IP of controller" />
+  <arg name="J23_factor" default="1" doc="Compensation factor for joint 2-3 coupling (-1, 0 or 1)" />
+  <arg name="use_bswap" default="true" doc="If true, robot driver will byte-swap all incoming and outgoing data" />
 
   <rosparam command="load" file="$(find fanuc_lrmate200ic_support)/config/joint_names_lrmate200ic5h.yaml" />
 

--- a/fanuc_lrmate200ic_support/launch/robot_interface_streaming_lrmate200ic5hs.launch
+++ b/fanuc_lrmate200ic_support/launch/robot_interface_streaming_lrmate200ic5hs.launch
@@ -10,9 +10,9 @@
     robot_interface_streaming_lrmate200ic5hs.launch robot_ip:=<value>
 -->
 <launch>
-  <arg name="robot_ip" />
-  <arg name="J23_factor" default="1" />
-  <arg name="use_bswap" default="true" />
+  <arg name="robot_ip" doc="IP of controller" />
+  <arg name="J23_factor" default="1" doc="Compensation factor for joint 2-3 coupling (-1, 0 or 1)" />
+  <arg name="use_bswap" default="true" doc="If true, robot driver will byte-swap all incoming and outgoing data" />
 
   <rosparam command="load" file="$(find fanuc_lrmate200ic_support)/config/joint_names_lrmate200ic5hs.yaml" />
 

--- a/fanuc_lrmate200ic_support/launch/robot_interface_streaming_lrmate200ic5l.launch
+++ b/fanuc_lrmate200ic_support/launch/robot_interface_streaming_lrmate200ic5l.launch
@@ -10,9 +10,9 @@
     robot_interface_streaming_lrmate200ic5l.launch robot_ip:=<value>
 -->
 <launch>
-  <arg name="robot_ip" />
-  <arg name="J23_factor" default="1" />
-  <arg name="use_bswap" default="true" />
+  <arg name="robot_ip" doc="IP of controller" />
+  <arg name="J23_factor" default="1" doc="Compensation factor for joint 2-3 coupling (-1, 0 or 1)" />
+  <arg name="use_bswap" default="true" doc="If true, robot driver will byte-swap all incoming and outgoing data" />
 
   <rosparam command="load" file="$(find fanuc_lrmate200ic_support)/config/joint_names_lrmate200ic5l.yaml" />
 

--- a/fanuc_lrmate200ic_support/launch/robot_state_visualize_lrmate200ic.launch
+++ b/fanuc_lrmate200ic_support/launch/robot_state_visualize_lrmate200ic.launch
@@ -10,9 +10,9 @@
     robot_state_visualize_lrmate200ic.launch robot_ip:=<value>
 -->
 <launch>
-  <arg name="robot_ip" />
-  <arg name="J23_factor" default="1" />
-  <arg name="use_bswap" default="true" />
+  <arg name="robot_ip" doc="IP of controller" />
+  <arg name="J23_factor" default="1" doc="Compensation factor for joint 2-3 coupling (-1, 0 or 1)" />
+  <arg name="use_bswap" default="true" doc="If true, robot driver will byte-swap all incoming and outgoing data" />
 
   <rosparam command="load" file="$(find fanuc_lrmate200ic_support)/config/joint_names_lrmate200ic.yaml" />
 

--- a/fanuc_lrmate200ic_support/launch/robot_state_visualize_lrmate200ic5f.launch
+++ b/fanuc_lrmate200ic_support/launch/robot_state_visualize_lrmate200ic5f.launch
@@ -10,9 +10,9 @@
     robot_state_visualize_lrmate200ic5f.launch robot_ip:=<value>
 -->
 <launch>
-  <arg name="robot_ip" />
-  <arg name="J23_factor" default="1" />
-  <arg name="use_bswap" default="true" />
+  <arg name="robot_ip" doc="IP of controller" />
+  <arg name="J23_factor" default="1" doc="Compensation factor for joint 2-3 coupling (-1, 0 or 1)" />
+  <arg name="use_bswap" default="true" doc="If true, robot driver will byte-swap all incoming and outgoing data" />
 
   <rosparam command="load" file="$(find fanuc_lrmate200ic_support)/config/joint_names_lrmate200ic5f.yaml" />
 

--- a/fanuc_lrmate200ic_support/launch/robot_state_visualize_lrmate200ic5h.launch
+++ b/fanuc_lrmate200ic_support/launch/robot_state_visualize_lrmate200ic5h.launch
@@ -10,9 +10,9 @@
     robot_state_visualize_lrmate200ic5h.launch robot_ip:=<value>
 -->
 <launch>
-  <arg name="robot_ip" />
-  <arg name="J23_factor" default="1" />
-  <arg name="use_bswap" default="true" />
+  <arg name="robot_ip" doc="IP of controller" />
+  <arg name="J23_factor" default="1" doc="Compensation factor for joint 2-3 coupling (-1, 0 or 1)" />
+  <arg name="use_bswap" default="true" doc="If true, robot driver will byte-swap all incoming and outgoing data" />
 
   <rosparam command="load" file="$(find fanuc_lrmate200ic_support)/config/joint_names_lrmate200ic5h.yaml" />
 

--- a/fanuc_lrmate200ic_support/launch/robot_state_visualize_lrmate200ic5hs.launch
+++ b/fanuc_lrmate200ic_support/launch/robot_state_visualize_lrmate200ic5hs.launch
@@ -10,9 +10,9 @@
     robot_state_visualize_lrmate200ic5hs.launch robot_ip:=<value>
 -->
 <launch>
-  <arg name="robot_ip" />
-  <arg name="J23_factor" default="1" />
-  <arg name="use_bswap" default="true" />
+  <arg name="robot_ip" doc="IP of controller" />
+  <arg name="J23_factor" default="1" doc="Compensation factor for joint 2-3 coupling (-1, 0 or 1)" />
+  <arg name="use_bswap" default="true" doc="If true, robot driver will byte-swap all incoming and outgoing data" />
 
   <rosparam command="load" file="$(find fanuc_lrmate200ic_support)/config/joint_names_lrmate200ic5hs.yaml" />
 

--- a/fanuc_lrmate200ic_support/launch/robot_state_visualize_lrmate200ic5l.launch
+++ b/fanuc_lrmate200ic_support/launch/robot_state_visualize_lrmate200ic5l.launch
@@ -10,9 +10,9 @@
     robot_state_visualize_lrmate200ic5l.launch robot_ip:=<value>
 -->
 <launch>
-  <arg name="robot_ip" />
-  <arg name="J23_factor" default="1" />
-  <arg name="use_bswap" default="true" />
+  <arg name="robot_ip" doc="IP of controller" />
+  <arg name="J23_factor" default="1" doc="Compensation factor for joint 2-3 coupling (-1, 0 or 1)" />
+  <arg name="use_bswap" default="true" doc="If true, robot driver will byte-swap all incoming and outgoing data" />
 
   <rosparam command="load" file="$(find fanuc_lrmate200ic_support)/config/joint_names_lrmate200ic5l.yaml" />
 

--- a/fanuc_m10ia_moveit_config/launch/moveit_planning_execution.launch
+++ b/fanuc_m10ia_moveit_config/launch/moveit_planning_execution.launch
@@ -11,14 +11,14 @@
  
   <!-- the "sim" argument controls whether we connect to a Simulated or Real robot -->
   <!--  - if sim=false, a robot_ip argument is required -->
-  <arg name="sim" default="true" />
-  <arg name="robot_ip" unless="$(arg sim)" />
-  <arg name="use_bswap" unless="$(arg sim)" default="true" />
+  <arg name="sim" default="true" doc="Use industrial robot simulator instead of real robot" />
+  <arg name="robot_ip" unless="$(arg sim)" doc="IP of controller (only required if not using industrial simulator)" />
+  <arg name="use_bswap" unless="$(arg sim)" default="true" doc="If true, robot driver will byte-swap all incoming and outgoing data (only required if not using industrial simulator)" />
 
   <!-- By default, we do not start a database (it can be large) -->
-  <arg name="db" default="false" />
+  <arg name="db" default="false" doc="Start the MoveIt database" />
   <!-- Allow user to specify database location -->
-  <arg name="db_path" default="$(find fanuc_m10ia_moveit_config)/default_warehouse_mongo_db" />
+  <arg name="db_path" default="$(find fanuc_m10ia_moveit_config)/default_warehouse_mongo_db" doc="Path to database files" />
 
   <!-- load the robot_description parameter before launching ROS-I nodes -->
   <include file="$(find fanuc_m10ia_moveit_config)/launch/planning_context.launch" >

--- a/fanuc_m10ia_support/launch/robot_interface_streaming_m10ia.launch
+++ b/fanuc_m10ia_support/launch/robot_interface_streaming_m10ia.launch
@@ -10,9 +10,9 @@
     robot_interface_streaming_m10ia.launch robot_ip:=<value>
 -->
 <launch>
-  <arg name="robot_ip" />
-  <arg name="J23_factor" default="1" />
-  <arg name="use_bswap" default="true" />
+  <arg name="robot_ip" doc="IP of controller" />
+  <arg name="J23_factor" default="1" doc="Compensation factor for joint 2-3 coupling (-1, 0 or 1)" />
+  <arg name="use_bswap" default="true" doc="If true, robot driver will byte-swap all incoming and outgoing data" />
 
   <rosparam command="load" file="$(find fanuc_m10ia_support)/config/joint_names_m10ia.yaml" />
 

--- a/fanuc_m10ia_support/launch/robot_state_visualize_m10ia.launch
+++ b/fanuc_m10ia_support/launch/robot_state_visualize_m10ia.launch
@@ -10,9 +10,9 @@
     robot_state_visualize_m10ia.launch robot_ip:=<value>
 -->
 <launch>
-  <arg name="robot_ip" />
-  <arg name="J23_factor" default="1" />
-  <arg name="use_bswap" default="true" />
+  <arg name="robot_ip" doc="IP of controller" />
+  <arg name="J23_factor" default="1" doc="Compensation factor for joint 2-3 coupling (-1, 0 or 1)" />
+  <arg name="use_bswap" default="true" doc="If true, robot driver will byte-swap all incoming and outgoing data" />
 
   <rosparam command="load" file="$(find fanuc_m10ia_support)/config/joint_names_m10ia.yaml" />
 

--- a/fanuc_m16ib20_moveit_config/launch/moveit_planning_execution.launch
+++ b/fanuc_m16ib20_moveit_config/launch/moveit_planning_execution.launch
@@ -11,14 +11,14 @@
  
   <!-- the "sim" argument controls whether we connect to a Simulated or Real robot -->
   <!--  - if sim=false, a robot_ip argument is required -->
-  <arg name="sim" default="true" />
-  <arg name="robot_ip" unless="$(arg sim)" />
-  <arg name="use_bswap" unless="$(arg sim)" default="true" />
+  <arg name="sim" default="true" doc="Use industrial robot simulator instead of real robot" />
+  <arg name="robot_ip" unless="$(arg sim)" doc="IP of controller (only required if not using industrial simulator)" />
+  <arg name="use_bswap" unless="$(arg sim)" default="true" doc="If true, robot driver will byte-swap all incoming and outgoing data (only required if not using industrial simulator)" />
 
   <!-- By default, we do not start a database (it can be large) -->
-  <arg name="db" default="false" />
+  <arg name="db" default="false" doc="Start the MoveIt database" />
   <!-- Allow user to specify database location -->
-  <arg name="db_path" default="$(find fanuc_m16ib20_moveit_config)/default_warehouse_mongo_db" />
+  <arg name="db_path" default="$(find fanuc_m16ib20_moveit_config)/default_warehouse_mongo_db" doc="Path to database files" />
 
   <!-- load the robot_description parameter before launching ROS-I nodes -->
   <include file="$(find fanuc_m16ib20_moveit_config)/launch/planning_context.launch" >

--- a/fanuc_m16ib_support/launch/robot_interface_streaming_m16ib20.launch
+++ b/fanuc_m16ib_support/launch/robot_interface_streaming_m16ib20.launch
@@ -10,9 +10,9 @@
     robot_interface_streaming_m16ib20.launch robot_ip:=<value>
 -->
 <launch>
-  <arg name="robot_ip" />
-  <arg name="J23_factor" default="1" />
-  <arg name="use_bswap" default="true" />
+  <arg name="robot_ip" doc="IP of controller" />
+  <arg name="J23_factor" default="1" doc="Compensation factor for joint 2-3 coupling (-1, 0 or 1)" />
+  <arg name="use_bswap" default="true" doc="If true, robot driver will byte-swap all incoming and outgoing data" />
 
   <rosparam command="load" file="$(find fanuc_m16ib_support)/config/joint_names_m16ib20.yaml" />
 

--- a/fanuc_m16ib_support/launch/robot_state_visualize_m16ib20.launch
+++ b/fanuc_m16ib_support/launch/robot_state_visualize_m16ib20.launch
@@ -10,9 +10,9 @@
     robot_state_visualize_m16ib20.launch robot_ip:=<value>
 -->
 <launch>
-  <arg name="robot_ip" />
-  <arg name="J23_factor" default="1" />
-  <arg name="use_bswap" default="true" />
+  <arg name="robot_ip" doc="IP of controller" />
+  <arg name="J23_factor" default="1" doc="Compensation factor for joint 2-3 coupling (-1, 0 or 1)" />
+  <arg name="use_bswap" default="true" doc="If true, robot driver will byte-swap all incoming and outgoing data" />
 
   <rosparam command="load" file="$(find fanuc_m16ib_support)/config/joint_names_m16ib20.yaml" />
 

--- a/fanuc_m20ia10l_moveit_config/launch/moveit_planning_execution.launch
+++ b/fanuc_m20ia10l_moveit_config/launch/moveit_planning_execution.launch
@@ -11,14 +11,14 @@
  
   <!-- the "sim" argument controls whether we connect to a Simulated or Real robot -->
   <!--  - if sim=false, a robot_ip argument is required -->
-  <arg name="sim" default="true" />
-  <arg name="robot_ip" unless="$(arg sim)" />
-  <arg name="use_bswap" unless="$(arg sim)" default="true" />
+  <arg name="sim" default="true" doc="Use industrial robot simulator instead of real robot" />
+  <arg name="robot_ip" unless="$(arg sim)" doc="IP of controller (only required if not using industrial simulator)" />
+  <arg name="use_bswap" unless="$(arg sim)" default="true" doc="If true, robot driver will byte-swap all incoming and outgoing data (only required if not using industrial simulator)" />
 
   <!-- By default, we do not start a database (it can be large) -->
-  <arg name="db" default="false" />
+  <arg name="db" default="false" doc="Start the MoveIt database" />
   <!-- Allow user to specify database location -->
-  <arg name="db_path" default="$(find fanuc_m20ia10l_moveit_config)/default_warehouse_mongo_db" />
+  <arg name="db_path" default="$(find fanuc_m20ia10l_moveit_config)/default_warehouse_mongo_db" doc="Path to database files" />
 
   <!-- load the robot_description parameter before launching ROS-I nodes -->
   <include file="$(find fanuc_m20ia10l_moveit_config)/launch/planning_context.launch" >

--- a/fanuc_m20ia_moveit_config/launch/moveit_planning_execution.launch
+++ b/fanuc_m20ia_moveit_config/launch/moveit_planning_execution.launch
@@ -11,14 +11,14 @@
  
   <!-- the "sim" argument controls whether we connect to a Simulated or Real robot -->
   <!--  - if sim=false, a robot_ip argument is required -->
-  <arg name="sim" default="true" />
-  <arg name="robot_ip" unless="$(arg sim)" />
-  <arg name="use_bswap" unless="$(arg sim)" default="true" />
+  <arg name="sim" default="true" doc="Use industrial robot simulator instead of real robot" />
+  <arg name="robot_ip" unless="$(arg sim)" doc="IP of controller (only required if not using industrial simulator)" />
+  <arg name="use_bswap" unless="$(arg sim)" default="true" doc="If true, robot driver will byte-swap all incoming and outgoing data (only required if not using industrial simulator)" />
 
   <!-- By default, we do not start a database (it can be large) -->
-  <arg name="db" default="false" />
+  <arg name="db" default="false" doc="Start the MoveIt database" />
   <!-- Allow user to specify database location -->
-  <arg name="db_path" default="$(find fanuc_m20ia_moveit_config)/default_warehouse_mongo_db" />
+  <arg name="db_path" default="$(find fanuc_m20ia_moveit_config)/default_warehouse_mongo_db" doc="Path to database files" />
 
   <!-- load the robot_description parameter before launching ROS-I nodes -->
   <include file="$(find fanuc_m20ia_moveit_config)/launch/planning_context.launch" >

--- a/fanuc_m20ia_support/launch/robot_interface_streaming_m20ia.launch
+++ b/fanuc_m20ia_support/launch/robot_interface_streaming_m20ia.launch
@@ -10,9 +10,9 @@
     robot_interface_streaming_m20ia.launch robot_ip:=<value>
 -->
 <launch>
-  <arg name="robot_ip" />
-  <arg name="J23_factor" default="1" />
-  <arg name="use_bswap" default="true" />
+  <arg name="robot_ip" doc="IP of controller" />
+  <arg name="J23_factor" default="1" doc="Compensation factor for joint 2-3 coupling (-1, 0 or 1)" />
+  <arg name="use_bswap" default="true" doc="If true, robot driver will byte-swap all incoming and outgoing data" />
 
   <rosparam command="load" file="$(find fanuc_m20ia_support)/config/joint_names_m20ia.yaml" />
 

--- a/fanuc_m20ia_support/launch/robot_interface_streaming_m20ia10l.launch
+++ b/fanuc_m20ia_support/launch/robot_interface_streaming_m20ia10l.launch
@@ -10,9 +10,9 @@
     robot_interface_streaming_m20ia10l.launch robot_ip:=<value>
 -->
 <launch>
-  <arg name="robot_ip" />
-  <arg name="J23_factor" default="1" />
-  <arg name="use_bswap" default="true" />
+  <arg name="robot_ip" doc="IP of controller" />
+  <arg name="J23_factor" default="1" doc="Compensation factor for joint 2-3 coupling (-1, 0 or 1)" />
+  <arg name="use_bswap" default="true" doc="If true, robot driver will byte-swap all incoming and outgoing data" />
 
   <rosparam command="load" file="$(find fanuc_m20ia_support)/config/joint_names_m20ia10l.yaml" />
 

--- a/fanuc_m20ia_support/launch/robot_state_visualize_m20ia.launch
+++ b/fanuc_m20ia_support/launch/robot_state_visualize_m20ia.launch
@@ -10,9 +10,9 @@
     robot_state_visualize_m20ia.launch robot_ip:=<value>
 -->
 <launch>
-  <arg name="robot_ip" />
-  <arg name="J23_factor" default="1" />
-  <arg name="use_bswap" default="true" />
+  <arg name="robot_ip" doc="IP of controller" />
+  <arg name="J23_factor" default="1" doc="Compensation factor for joint 2-3 coupling (-1, 0 or 1)" />
+  <arg name="use_bswap" default="true" doc="If true, robot driver will byte-swap all incoming and outgoing data" />
 
   <rosparam command="load" file="$(find fanuc_m20ia_support)/config/joint_names_m20ia.yaml" />
 

--- a/fanuc_m20ia_support/launch/robot_state_visualize_m20ia10l.launch
+++ b/fanuc_m20ia_support/launch/robot_state_visualize_m20ia10l.launch
@@ -10,9 +10,9 @@
     robot_state_visualize_m20ia10l.launch robot_ip:=<value>
 -->
 <launch>
-  <arg name="robot_ip" />
-  <arg name="J23_factor" default="1" />
-  <arg name="use_bswap" default="true" />
+  <arg name="robot_ip" doc="IP of controller" />
+  <arg name="J23_factor" default="1" doc="Compensation factor for joint 2-3 coupling (-1, 0 or 1)" />
+  <arg name="use_bswap" default="true" doc="If true, robot driver will byte-swap all incoming and outgoing data" />
 
   <rosparam command="load" file="$(find fanuc_m20ia_support)/config/joint_names_m20ia10l.yaml" />
 

--- a/fanuc_m430ia2f_moveit_config/launch/moveit_planning_execution.launch
+++ b/fanuc_m430ia2f_moveit_config/launch/moveit_planning_execution.launch
@@ -11,14 +11,14 @@
  
   <!-- the "sim" argument controls whether we connect to a Simulated or Real robot -->
   <!--  - if sim=false, a robot_ip argument is required -->
-  <arg name="sim" default="true" />
-  <arg name="robot_ip" unless="$(arg sim)" />
-  <arg name="use_bswap" unless="$(arg sim)" default="true" />
+  <arg name="sim" default="true" doc="Use industrial robot simulator instead of real robot" />
+  <arg name="robot_ip" unless="$(arg sim)" doc="IP of controller (only required if not using industrial simulator)" />
+  <arg name="use_bswap" unless="$(arg sim)" default="true" doc="If true, robot driver will byte-swap all incoming and outgoing data (only required if not using industrial simulator)" />
 
   <!-- By default, we do not start a database (it can be large) -->
-  <arg name="db" default="false" />
+  <arg name="db" default="false" doc="Start the MoveIt database" />
   <!-- Allow user to specify database location -->
-  <arg name="db_path" default="$(find fanuc_m430ia2f_moveit_config)/default_warehouse_mongo_db" />
+  <arg name="db_path" default="$(find fanuc_m430ia2f_moveit_config)/default_warehouse_mongo_db" doc="Path to database files" />
 
   <!-- load the robot_description parameter before launching ROS-I nodes -->
   <include file="$(find fanuc_m430ia2f_moveit_config)/launch/planning_context.launch" >

--- a/fanuc_m430ia2p_moveit_config/launch/moveit_planning_execution.launch
+++ b/fanuc_m430ia2p_moveit_config/launch/moveit_planning_execution.launch
@@ -11,14 +11,14 @@
  
   <!-- the "sim" argument controls whether we connect to a Simulated or Real robot -->
   <!--  - if sim=false, a robot_ip argument is required -->
-  <arg name="sim" default="true" />
-  <arg name="robot_ip" unless="$(arg sim)" />
-  <arg name="use_bswap" unless="$(arg sim)" default="true" />
+  <arg name="sim" default="true" doc="Use industrial robot simulator instead of real robot" />
+  <arg name="robot_ip" unless="$(arg sim)" doc="IP of controller (only required if not using industrial simulator)" />
+  <arg name="use_bswap" unless="$(arg sim)" default="true" doc="If true, robot driver will byte-swap all incoming and outgoing data (only required if not using industrial simulator)" />
 
   <!-- By default, we do not start a database (it can be large) -->
-  <arg name="db" default="false" />
+  <arg name="db" default="false" doc="Start the MoveIt database" />
   <!-- Allow user to specify database location -->
-  <arg name="db_path" default="$(find fanuc_m430ia2p_moveit_config)/default_warehouse_mongo_db" />
+  <arg name="db_path" default="$(find fanuc_m430ia2p_moveit_config)/default_warehouse_mongo_db" doc="Path to database files" />
 
   <!-- load the robot_description parameter before launching ROS-I nodes -->
   <include file="$(find fanuc_m430ia2p_moveit_config)/launch/planning_context.launch" >

--- a/fanuc_m430ia_support/launch/robot_interface_streaming_m430ia2f.launch
+++ b/fanuc_m430ia_support/launch/robot_interface_streaming_m430ia2f.launch
@@ -10,9 +10,9 @@
     robot_interface_streaming_m430ia2f.launch robot_ip:=<value>
 -->
 <launch>
-  <arg name="robot_ip" />
-  <arg name="J23_factor" default="-1" />
-  <arg name="use_bswap" default="true" />
+  <arg name="robot_ip" doc="IP of controller" />
+  <arg name="J23_factor" default="-1" doc="Compensation factor for joint 2 & 3 coupling (-1, 0 or 1)" />
+  <arg name="use_bswap" default="true" doc="If true, robot driver will byte-swap all incoming and outgoing data" />
 
   <rosparam command="load" file="$(find fanuc_m430ia_support)/config/joint_names_m430ia2f.yaml" />
 

--- a/fanuc_m430ia_support/launch/robot_interface_streaming_m430ia2p.launch
+++ b/fanuc_m430ia_support/launch/robot_interface_streaming_m430ia2p.launch
@@ -10,9 +10,9 @@
     robot_interface_streaming_m430ia2p.launch robot_ip:=<value>
 -->
 <launch>
-  <arg name="robot_ip" />
-  <arg name="J23_factor" default="-1" />
-  <arg name="use_bswap" default="true" />
+  <arg name="robot_ip" doc="IP of controller" />
+  <arg name="J23_factor" default="-1" doc="Compensation factor for joint 2 & 3 coupling (-1, 0 or 1)" />
+  <arg name="use_bswap" default="true" doc="If true, robot driver will byte-swap all incoming and outgoing data" />
 
   <rosparam command="load" file="$(find fanuc_m430ia_support)/config/joint_names_m430ia2p.yaml" />
 

--- a/fanuc_m430ia_support/launch/robot_state_visualize_m430ia2f.launch
+++ b/fanuc_m430ia_support/launch/robot_state_visualize_m430ia2f.launch
@@ -10,9 +10,9 @@
     robot_state_visualize_m430ia2f.launch robot_ip:=<value>
 -->
 <launch>
-  <arg name="robot_ip" />
-  <arg name="J23_factor" default="-1" />
-  <arg name="use_bswap" default="true" />
+  <arg name="robot_ip" doc="IP of controller" />
+  <arg name="J23_factor" default="-1" doc="Compensation factor for joint 2 & 3 coupling (-1, 0 or 1)" />
+  <arg name="use_bswap" default="true" doc="If true, robot driver will byte-swap all incoming and outgoing data" />
 
   <rosparam command="load" file="$(find fanuc_m430ia_support)/config/joint_names_m430ia2f.yaml" />
 

--- a/fanuc_m430ia_support/launch/robot_state_visualize_m430ia2p.launch
+++ b/fanuc_m430ia_support/launch/robot_state_visualize_m430ia2p.launch
@@ -10,9 +10,9 @@
     robot_state_visualize_m430ia2p.launch robot_ip:=<value>
 -->
 <launch>
-  <arg name="robot_ip" />
-  <arg name="J23_factor" default="-1" />
-  <arg name="use_bswap" default="true" />
+  <arg name="robot_ip" doc="IP of controller" />
+  <arg name="J23_factor" default="-1" doc="Compensation factor for joint 2 & 3 coupling (-1, 0 or 1)" />
+  <arg name="use_bswap" default="true" doc="If true, robot driver will byte-swap all incoming and outgoing data" />
 
   <rosparam command="load" file="$(find fanuc_m430ia_support)/config/joint_names_m430ia2p.yaml" />
 


### PR DESCRIPTION
As per subject.

No functional changes, only adds documentation. Support for this was added to `roslaunch` in `v1.11.1`.
