### PR TITLE
Fix for issue #169: load xacros in MoveIt cfgs instead of urdfs

### DIFF
--- a/fanuc_lrmate200ic5h_moveit_config/.setup_assistant
+++ b/fanuc_lrmate200ic5h_moveit_config/.setup_assistant
@@ -1,7 +1,7 @@
 moveit_setup_assistant_config:
   URDF:
     package: fanuc_lrmate200ic_support
-    relative_path: urdf/lrmate200ic5h.urdf
+    relative_path: urdf/lrmate200ic5h.xacro
   SRDF:
     relative_path: config/fanuc_lrmate200ic5h.srdf
   CONFIG:

--- a/fanuc_lrmate200ic5h_moveit_config/launch/demo.launch
+++ b/fanuc_lrmate200ic5h_moveit_config/launch/demo.launch
@@ -9,8 +9,9 @@
   <arg name="debug" default="false" />
 
   <!-- Load the URDF, SRDF and other .yaml configuration files on the param server -->
+  <include file="$(find fanuc_lrmate200ic_support)/launch/load_lrmate200ic5h.launch" />
   <include file="$(find fanuc_lrmate200ic5h_moveit_config)/launch/planning_context.launch">
-    <arg name="load_robot_description" value="true"/>
+    <arg name="load_robot_description" value="false"/>
   </include>
 
   <!-- If needed, broadcast static tf for robot root -->

--- a/fanuc_lrmate200ic5h_moveit_config/launch/moveit_planning_execution.launch
+++ b/fanuc_lrmate200ic5h_moveit_config/launch/moveit_planning_execution.launch
@@ -21,8 +21,9 @@
   <arg name="db_path" default="$(find fanuc_lrmate200ic5h_moveit_config)/default_warehouse_mongo_db" doc="Path to database files" />
 
   <!-- load the robot_description parameter before launching ROS-I nodes -->
-  <include file="$(find fanuc_lrmate200ic5h_moveit_config)/launch/planning_context.launch" >
-    <arg name="load_robot_description" value="true" />
+  <include file="$(find fanuc_lrmate200ic_support)/launch/load_lrmate200ic5h.launch" />
+  <include file="$(find fanuc_lrmate200ic5h_moveit_config)/launch/planning_context.launch">
+    <arg name="load_robot_description" value="false" />
   </include>
 
   <!-- run the robot simulator and action interface nodes -->

--- a/fanuc_lrmate200ic5h_moveit_config/launch/planning_context.launch
+++ b/fanuc_lrmate200ic5h_moveit_config/launch/planning_context.launch
@@ -6,7 +6,7 @@
   <arg name="robot_description" default="robot_description"/>
 
   <!-- Load universal robot description format (URDF) -->
-  <include file="$(find fanuc_lrmate200ic_support)/launch/load_lrmate200ic5h.launch" />
+  <param if="$(arg load_robot_description)" name="$(arg robot_description)" command="$(find xacro)/xacro.py '$(find fanuc_lrmate200ic_support)/urdf/lrmate200ic5h.xacro'"/>
 
   <!-- The semantic description that corresponds to the URDF -->
   <param name="$(arg robot_description)_semantic" textfile="$(find fanuc_lrmate200ic5h_moveit_config)/config/fanuc_lrmate200ic5h.srdf" />

--- a/fanuc_lrmate200ic5h_moveit_config/launch/planning_context.launch
+++ b/fanuc_lrmate200ic5h_moveit_config/launch/planning_context.launch
@@ -6,7 +6,7 @@
   <arg name="robot_description" default="robot_description"/>
 
   <!-- Load universal robot description format (URDF) -->
-  <param if="$(arg load_robot_description)" name="$(arg robot_description)" textfile="$(find fanuc_lrmate200ic_support)/urdf/lrmate200ic5h.urdf"/>
+  <include file="$(find fanuc_lrmate200ic_support)/launch/load_lrmate200ic5h.launch" />
 
   <!-- The semantic description that corresponds to the URDF -->
   <param name="$(arg robot_description)_semantic" textfile="$(find fanuc_lrmate200ic5h_moveit_config)/config/fanuc_lrmate200ic5h.srdf" />

--- a/fanuc_lrmate200ic5l_moveit_config/.setup_assistant
+++ b/fanuc_lrmate200ic5l_moveit_config/.setup_assistant
@@ -1,7 +1,7 @@
 moveit_setup_assistant_config:
   URDF:
     package: fanuc_lrmate200ic_support
-    relative_path: urdf/lrmate200ic5l.urdf
+    relative_path: urdf/lrmate200ic5l.xacro
   SRDF:
     relative_path: config/fanuc_lrmate200ic5l.srdf
   CONFIG:

--- a/fanuc_lrmate200ic5l_moveit_config/launch/demo.launch
+++ b/fanuc_lrmate200ic5l_moveit_config/launch/demo.launch
@@ -9,8 +9,9 @@
   <arg name="debug" default="false" />
 
   <!-- Load the URDF, SRDF and other .yaml configuration files on the param server -->
+  <include file="$(find fanuc_lrmate200ic_support)/launch/load_lrmate200ic5l.launch" />
   <include file="$(find fanuc_lrmate200ic5l_moveit_config)/launch/planning_context.launch">
-    <arg name="load_robot_description" value="true"/>
+    <arg name="load_robot_description" value="false"/>
   </include>
 
   <!-- If needed, broadcast static tf for robot root -->

--- a/fanuc_lrmate200ic5l_moveit_config/launch/moveit_planning_execution.launch
+++ b/fanuc_lrmate200ic5l_moveit_config/launch/moveit_planning_execution.launch
@@ -21,8 +21,9 @@
   <arg name="db_path" default="$(find fanuc_lrmate200ic5l_moveit_config)/default_warehouse_mongo_db" doc="Path to database files" />
 
   <!-- load the robot_description parameter before launching ROS-I nodes -->
-  <include file="$(find fanuc_lrmate200ic5l_moveit_config)/launch/planning_context.launch" >
-    <arg name="load_robot_description" value="true" />
+  <include file="$(find fanuc_lrmate200ic_support)/launch/load_lrmate200ic5l.launch" />
+  <include file="$(find fanuc_lrmate200ic5l_moveit_config)/launch/planning_context.launch">
+    <arg name="load_robot_description" value="false" />
   </include>
 
   <!-- run the robot simulator and action interface nodes -->

--- a/fanuc_lrmate200ic5l_moveit_config/launch/planning_context.launch
+++ b/fanuc_lrmate200ic5l_moveit_config/launch/planning_context.launch
@@ -6,7 +6,7 @@
   <arg name="robot_description" default="robot_description"/>
 
   <!-- Load universal robot description format (URDF) -->
-  <param if="$(arg load_robot_description)" name="$(arg robot_description)" textfile="$(find fanuc_lrmate200ic_support)/urdf/lrmate200ic5l.urdf"/>
+  <include file="$(find fanuc_lrmate200ic_support)/launch/load_lrmate200ic5l.launch" />
 
   <!-- The semantic description that corresponds to the URDF -->
   <param name="$(arg robot_description)_semantic" textfile="$(find fanuc_lrmate200ic5l_moveit_config)/config/fanuc_lrmate200ic5l.srdf" />

--- a/fanuc_lrmate200ic5l_moveit_config/launch/planning_context.launch
+++ b/fanuc_lrmate200ic5l_moveit_config/launch/planning_context.launch
@@ -6,7 +6,7 @@
   <arg name="robot_description" default="robot_description"/>
 
   <!-- Load universal robot description format (URDF) -->
-  <include file="$(find fanuc_lrmate200ic_support)/launch/load_lrmate200ic5l.launch" />
+  <param if="$(arg load_robot_description)" name="$(arg robot_description)" command="$(find xacro)/xacro.py '$(find fanuc_lrmate200ic_support)/urdf/lrmate200ic5l.xacro'"/>
 
   <!-- The semantic description that corresponds to the URDF -->
   <param name="$(arg robot_description)_semantic" textfile="$(find fanuc_lrmate200ic5l_moveit_config)/config/fanuc_lrmate200ic5l.srdf" />

--- a/fanuc_lrmate200ic_moveit_config/.setup_assistant
+++ b/fanuc_lrmate200ic_moveit_config/.setup_assistant
@@ -1,7 +1,7 @@
 moveit_setup_assistant_config:
   URDF:
     package: fanuc_lrmate200ic_support
-    relative_path: urdf/lrmate200ic.urdf
+    relative_path: urdf/lrmate200ic.xacro
   SRDF:
     relative_path: config/fanuc_lrmate200ic.srdf
   CONFIG:

--- a/fanuc_lrmate200ic_moveit_config/launch/demo.launch
+++ b/fanuc_lrmate200ic_moveit_config/launch/demo.launch
@@ -9,8 +9,9 @@
   <arg name="debug" default="false" />
 
   <!-- Load the URDF, SRDF and other .yaml configuration files on the param server -->
+  <include file="$(find fanuc_lrmate200ic_support)/launch/load_lrmate200ic.launch" />
   <include file="$(find fanuc_lrmate200ic_moveit_config)/launch/planning_context.launch">
-    <arg name="load_robot_description" value="true"/>
+    <arg name="load_robot_description" value="false"/>
   </include>
 
   <!-- If needed, broadcast static tf for robot root -->

--- a/fanuc_lrmate200ic_moveit_config/launch/moveit_planning_execution.launch
+++ b/fanuc_lrmate200ic_moveit_config/launch/moveit_planning_execution.launch
@@ -21,8 +21,9 @@
   <arg name="db_path" default="$(find fanuc_lrmate200ic_moveit_config)/default_warehouse_mongo_db" doc="Path to database files" />
 
   <!-- load the robot_description parameter before launching ROS-I nodes -->
-  <include file="$(find fanuc_lrmate200ic_moveit_config)/launch/planning_context.launch" >
-    <arg name="load_robot_description" value="true" />
+  <include file="$(find fanuc_lrmate200ic_support)/launch/load_lrmate200ic.launch" />
+  <include file="$(find fanuc_lrmate200ic_moveit_config)/launch/planning_context.launch">
+    <arg name="load_robot_description" value="false"/>
   </include>
 
   <!-- run the robot simulator and action interface nodes -->

--- a/fanuc_lrmate200ic_moveit_config/launch/planning_context.launch
+++ b/fanuc_lrmate200ic_moveit_config/launch/planning_context.launch
@@ -6,7 +6,7 @@
   <arg name="robot_description" default="robot_description"/>
 
   <!-- Load universal robot description format (URDF) -->
-  <include file="$(find fanuc_lrmate200ic_support)/launch/load_lrmate200ic.launch" />
+  <param if="$(arg load_robot_description)" name="$(arg robot_description)" command="$(find xacro)/xacro.py '$(find fanuc_lrmate200ic_support)/urdf/lrmate200ic.xacro'"/>
 
   <!-- The semantic description that corresponds to the URDF -->
   <param name="$(arg robot_description)_semantic" textfile="$(find fanuc_lrmate200ic_moveit_config)/config/fanuc_lrmate200ic.srdf" />

--- a/fanuc_lrmate200ic_moveit_config/launch/planning_context.launch
+++ b/fanuc_lrmate200ic_moveit_config/launch/planning_context.launch
@@ -6,7 +6,7 @@
   <arg name="robot_description" default="robot_description"/>
 
   <!-- Load universal robot description format (URDF) -->
-  <param if="$(arg load_robot_description)" name="$(arg robot_description)" textfile="$(find fanuc_lrmate200ic_support)/urdf/lrmate200ic.urdf"/>
+  <include file="$(find fanuc_lrmate200ic_support)/launch/load_lrmate200ic.launch" />
 
   <!-- The semantic description that corresponds to the URDF -->
   <param name="$(arg robot_description)_semantic" textfile="$(find fanuc_lrmate200ic_moveit_config)/config/fanuc_lrmate200ic.srdf" />

--- a/fanuc_m10ia_moveit_config/.setup_assistant
+++ b/fanuc_m10ia_moveit_config/.setup_assistant
@@ -1,7 +1,7 @@
 moveit_setup_assistant_config:
   URDF:
     package: fanuc_m10ia_support
-    relative_path: urdf/m10ia.urdf
+    relative_path: urdf/m10ia.xacro
   SRDF:
     relative_path: config/fanuc_m10ia.srdf
   CONFIG:

--- a/fanuc_m10ia_moveit_config/launch/demo.launch
+++ b/fanuc_m10ia_moveit_config/launch/demo.launch
@@ -9,8 +9,9 @@
   <arg name="debug" default="false" />
 
   <!-- Load the URDF, SRDF and other .yaml configuration files on the param server -->
+  <include file="$(find fanuc_m10ia_support)/launch/load_m10ia.launch" />
   <include file="$(find fanuc_m10ia_moveit_config)/launch/planning_context.launch">
-    <arg name="load_robot_description" value="true"/>
+    <arg name="load_robot_description" value="false"/>
   </include>
 
   <!-- If needed, broadcast static tf for robot root -->

--- a/fanuc_m10ia_moveit_config/launch/moveit_planning_execution.launch
+++ b/fanuc_m10ia_moveit_config/launch/moveit_planning_execution.launch
@@ -21,8 +21,9 @@
   <arg name="db_path" default="$(find fanuc_m10ia_moveit_config)/default_warehouse_mongo_db" doc="Path to database files" />
 
   <!-- load the robot_description parameter before launching ROS-I nodes -->
-  <include file="$(find fanuc_m10ia_moveit_config)/launch/planning_context.launch" >
-    <arg name="load_robot_description" value="true" />
+  <include file="$(find fanuc_m10ia_support)/launch/load_m10ia.launch" />
+  <include file="$(find fanuc_m10ia_moveit_config)/launch/planning_context.launch">
+    <arg name="load_robot_description" value="false" />
   </include>
 
   <!-- run the robot simulator and action interface nodes -->

--- a/fanuc_m10ia_moveit_config/launch/planning_context.launch
+++ b/fanuc_m10ia_moveit_config/launch/planning_context.launch
@@ -6,7 +6,7 @@
   <arg name="robot_description" default="robot_description"/>
 
   <!-- Load universal robot description format (URDF) -->
-  <param if="$(arg load_robot_description)" name="$(arg robot_description)" textfile="$(find fanuc_m10ia_support)/urdf/m10ia.urdf"/>
+  <include file="$(find fanuc_m10ia_support)/launch/load_m10ia.launch" />
 
   <!-- The semantic description that corresponds to the URDF -->
   <param name="$(arg robot_description)_semantic" textfile="$(find fanuc_m10ia_moveit_config)/config/fanuc_m10ia.srdf" />

--- a/fanuc_m10ia_moveit_config/launch/planning_context.launch
+++ b/fanuc_m10ia_moveit_config/launch/planning_context.launch
@@ -6,7 +6,7 @@
   <arg name="robot_description" default="robot_description"/>
 
   <!-- Load universal robot description format (URDF) -->
-  <include file="$(find fanuc_m10ia_support)/launch/load_m10ia.launch" />
+  <param if="$(arg load_robot_description)" name="$(arg robot_description)" command="$(find xacro)/xacro.py '$(find fanuc_m10ia_support)/urdf/m10ia.xacro'"/>
 
   <!-- The semantic description that corresponds to the URDF -->
   <param name="$(arg robot_description)_semantic" textfile="$(find fanuc_m10ia_moveit_config)/config/fanuc_m10ia.srdf" />

--- a/fanuc_m16ib20_moveit_config/.setup_assistant
+++ b/fanuc_m16ib20_moveit_config/.setup_assistant
@@ -1,7 +1,7 @@
 moveit_setup_assistant_config:
   URDF:
     package: fanuc_m16ib_support
-    relative_path: urdf/m16ib20.urdf
+    relative_path: urdf/m16ib20.xacro
   SRDF:
     relative_path: config/fanuc_m16ib20.srdf
   CONFIG:

--- a/fanuc_m16ib20_moveit_config/launch/demo.launch
+++ b/fanuc_m16ib20_moveit_config/launch/demo.launch
@@ -9,8 +9,9 @@
   <arg name="debug" default="false" />
 
   <!-- Load the URDF, SRDF and other .yaml configuration files on the param server -->
+  <include file="$(find fanuc_m16ib_support)/launch/load_m16ib20.launch" />
   <include file="$(find fanuc_m16ib20_moveit_config)/launch/planning_context.launch">
-    <arg name="load_robot_description" value="true"/>
+    <arg name="load_robot_description" value="false"/>
   </include>
 
   <!-- If needed, broadcast static tf for robot root -->

--- a/fanuc_m16ib20_moveit_config/launch/moveit_planning_execution.launch
+++ b/fanuc_m16ib20_moveit_config/launch/moveit_planning_execution.launch
@@ -21,8 +21,9 @@
   <arg name="db_path" default="$(find fanuc_m16ib20_moveit_config)/default_warehouse_mongo_db" doc="Path to database files" />
 
   <!-- load the robot_description parameter before launching ROS-I nodes -->
-  <include file="$(find fanuc_m16ib20_moveit_config)/launch/planning_context.launch" >
-    <arg name="load_robot_description" value="true" />
+  <include file="$(find fanuc_m16ib_support)/launch/load_m16ib20.launch" />
+  <include file="$(find fanuc_m16ib20_moveit_config)/launch/planning_context.launch">
+    <arg name="load_robot_description" value="false" />
   </include>
 
   <!-- run the robot simulator and action interface nodes -->

--- a/fanuc_m16ib20_moveit_config/launch/planning_context.launch
+++ b/fanuc_m16ib20_moveit_config/launch/planning_context.launch
@@ -6,7 +6,7 @@
   <arg name="robot_description" default="robot_description"/>
 
   <!-- Load universal robot description format (URDF) -->
-  <param if="$(arg load_robot_description)" name="$(arg robot_description)" textfile="$(find fanuc_m16ib_support)/urdf/m16ib20.urdf"/>
+  <include file="$(find fanuc_m16ib_support)/launch/load_m16ib20.launch" />
 
   <!-- The semantic description that corresponds to the URDF -->
   <param name="$(arg robot_description)_semantic" textfile="$(find fanuc_m16ib20_moveit_config)/config/fanuc_m16ib20.srdf" />

--- a/fanuc_m16ib20_moveit_config/launch/planning_context.launch
+++ b/fanuc_m16ib20_moveit_config/launch/planning_context.launch
@@ -6,7 +6,7 @@
   <arg name="robot_description" default="robot_description"/>
 
   <!-- Load universal robot description format (URDF) -->
-  <include file="$(find fanuc_m16ib_support)/launch/load_m16ib20.launch" />
+  <param if="$(arg load_robot_description)" name="$(arg robot_description)" command="$(find xacro)/xacro.py '$(find fanuc_m16ib_support)/urdf/m16ib20.xacro'"/>
 
   <!-- The semantic description that corresponds to the URDF -->
   <param name="$(arg robot_description)_semantic" textfile="$(find fanuc_m16ib20_moveit_config)/config/fanuc_m16ib20.srdf" />

--- a/fanuc_m20ia10l_moveit_config/.setup_assistant
+++ b/fanuc_m20ia10l_moveit_config/.setup_assistant
@@ -1,7 +1,7 @@
 moveit_setup_assistant_config:
   URDF:
     package: fanuc_m20ia_support
-    relative_path: urdf/m20ia10l.urdf
+    relative_path: urdf/m20ia10l.xacro
   SRDF:
     relative_path: config/fanuc_m20ia10l.srdf
   CONFIG:

--- a/fanuc_m20ia10l_moveit_config/launch/demo.launch
+++ b/fanuc_m20ia10l_moveit_config/launch/demo.launch
@@ -9,8 +9,9 @@
   <arg name="debug" default="false" />
 
   <!-- Load the URDF, SRDF and other .yaml configuration files on the param server -->
+  <include file="$(find fanuc_m20ia_support)/launch/load_m20ia10l.launch" />
   <include file="$(find fanuc_m20ia10l_moveit_config)/launch/planning_context.launch">
-    <arg name="load_robot_description" value="true"/>
+    <arg name="load_robot_description" value="false"/>
   </include>
 
   <!-- If needed, broadcast static tf for robot root -->

--- a/fanuc_m20ia10l_moveit_config/launch/moveit_planning_execution.launch
+++ b/fanuc_m20ia10l_moveit_config/launch/moveit_planning_execution.launch
@@ -21,8 +21,9 @@
   <arg name="db_path" default="$(find fanuc_m20ia10l_moveit_config)/default_warehouse_mongo_db" doc="Path to database files" />
 
   <!-- load the robot_description parameter before launching ROS-I nodes -->
-  <include file="$(find fanuc_m20ia10l_moveit_config)/launch/planning_context.launch" >
-    <arg name="load_robot_description" value="true" />
+  <include file="$(find fanuc_m20ia_support)/launch/load_m20ia10l.launch" />
+  <include file="$(find fanuc_m20ia10l_moveit_config)/launch/planning_context.launch">
+    <arg name="load_robot_description" value="false" />
   </include>
 
   <!-- run the robot simulator and action interface nodes -->

--- a/fanuc_m20ia10l_moveit_config/launch/planning_context.launch
+++ b/fanuc_m20ia10l_moveit_config/launch/planning_context.launch
@@ -6,7 +6,7 @@
   <arg name="robot_description" default="robot_description"/>
 
   <!-- Load universal robot description format (URDF) -->
-  <param if="$(arg load_robot_description)" name="$(arg robot_description)" textfile="$(find fanuc_m20ia_support)/urdf/m20ia10l.urdf"/>
+  <include file="$(find fanuc_m20ia_support)/launch/load_m20ia10l.launch" />
 
   <!-- The semantic description that corresponds to the URDF -->
   <param name="$(arg robot_description)_semantic" textfile="$(find fanuc_m20ia10l_moveit_config)/config/fanuc_m20ia10l.srdf" />

--- a/fanuc_m20ia10l_moveit_config/launch/planning_context.launch
+++ b/fanuc_m20ia10l_moveit_config/launch/planning_context.launch
@@ -6,7 +6,7 @@
   <arg name="robot_description" default="robot_description"/>
 
   <!-- Load universal robot description format (URDF) -->
-  <include file="$(find fanuc_m20ia_support)/launch/load_m20ia10l.launch" />
+  <param if="$(arg load_robot_description)" name="$(arg robot_description)" command="$(find xacro)/xacro.py '$(find fanuc_m20ia_support)/urdf/m20ia10l.xacro'"/>
 
   <!-- The semantic description that corresponds to the URDF -->
   <param name="$(arg robot_description)_semantic" textfile="$(find fanuc_m20ia10l_moveit_config)/config/fanuc_m20ia10l.srdf" />

--- a/fanuc_m20ia_moveit_config/.setup_assistant
+++ b/fanuc_m20ia_moveit_config/.setup_assistant
@@ -1,7 +1,7 @@
 moveit_setup_assistant_config:
   URDF:
     package: fanuc_m20ia_support
-    relative_path: urdf/m20ia.urdf
+    relative_path: urdf/m20ia.xacro
   SRDF:
     relative_path: config/fanuc_m20ia.srdf
   CONFIG:

--- a/fanuc_m20ia_moveit_config/launch/demo.launch
+++ b/fanuc_m20ia_moveit_config/launch/demo.launch
@@ -9,8 +9,9 @@
   <arg name="debug" default="false" />
 
   <!-- Load the URDF, SRDF and other .yaml configuration files on the param server -->
+  <include file="$(find fanuc_m20ia_support)/launch/load_m20ia.launch" />
   <include file="$(find fanuc_m20ia_moveit_config)/launch/planning_context.launch">
-    <arg name="load_robot_description" value="true"/>
+    <arg name="load_robot_description" value="false"/>
   </include>
 
   <!-- If needed, broadcast static tf for robot root -->

--- a/fanuc_m20ia_moveit_config/launch/moveit_planning_execution.launch
+++ b/fanuc_m20ia_moveit_config/launch/moveit_planning_execution.launch
@@ -21,8 +21,9 @@
   <arg name="db_path" default="$(find fanuc_m20ia_moveit_config)/default_warehouse_mongo_db" doc="Path to database files" />
 
   <!-- load the robot_description parameter before launching ROS-I nodes -->
-  <include file="$(find fanuc_m20ia_moveit_config)/launch/planning_context.launch" >
-    <arg name="load_robot_description" value="true" />
+  <include file="$(find fanuc_m20ia_support)/launch/load_m20ia.launch" />
+  <include file="$(find fanuc_m20ia_moveit_config)/launch/planning_context.launch">
+    <arg name="load_robot_description" value="false" />
   </include>
 
   <!-- run the robot simulator and action interface nodes -->

--- a/fanuc_m20ia_moveit_config/launch/planning_context.launch
+++ b/fanuc_m20ia_moveit_config/launch/planning_context.launch
@@ -6,7 +6,7 @@
   <arg name="robot_description" default="robot_description"/>
 
   <!-- Load universal robot description format (URDF) -->
-  <include file="$(find fanuc_m20ia_support)/launch/load_m20ia.launch" />
+  <param if="$(arg load_robot_description)" name="$(arg robot_description)" command="$(find xacro)/xacro.py '$(find fanuc_m20ia_support)/urdf/m20ia.xacro'"/>
 
   <!-- The semantic description that corresponds to the URDF -->
   <param name="$(arg robot_description)_semantic" textfile="$(find fanuc_m20ia_moveit_config)/config/fanuc_m20ia.srdf" />

--- a/fanuc_m20ia_moveit_config/launch/planning_context.launch
+++ b/fanuc_m20ia_moveit_config/launch/planning_context.launch
@@ -6,7 +6,7 @@
   <arg name="robot_description" default="robot_description"/>
 
   <!-- Load universal robot description format (URDF) -->
-  <param if="$(arg load_robot_description)" name="$(arg robot_description)" textfile="$(find fanuc_m20ia_support)/urdf/m20ia.urdf"/>
+  <include file="$(find fanuc_m20ia_support)/launch/load_m20ia.launch" />
 
   <!-- The semantic description that corresponds to the URDF -->
   <param name="$(arg robot_description)_semantic" textfile="$(find fanuc_m20ia_moveit_config)/config/fanuc_m20ia.srdf" />

--- a/fanuc_m430ia2f_moveit_config/.setup_assistant
+++ b/fanuc_m430ia2f_moveit_config/.setup_assistant
@@ -1,7 +1,7 @@
 moveit_setup_assistant_config:
   URDF:
     package: fanuc_m430ia_support
-    relative_path: urdf/m430ia2f.urdf
+    relative_path: urdf/m430ia2f.xacro
   SRDF:
     relative_path: config/fanuc_m430ia2f.srdf
   CONFIG:

--- a/fanuc_m430ia2f_moveit_config/launch/demo.launch
+++ b/fanuc_m430ia2f_moveit_config/launch/demo.launch
@@ -9,8 +9,9 @@
   <arg name="debug" default="false" />
 
   <!-- Load the URDF, SRDF and other .yaml configuration files on the param server -->
+  <include file="$(find fanuc_m430ia_support)/launch/load_m430ia2f.launch" />
   <include file="$(find fanuc_m430ia2f_moveit_config)/launch/planning_context.launch">
-    <arg name="load_robot_description" value="true"/>
+    <arg name="load_robot_description" value="false"/>
   </include>
 
   <!-- If needed, broadcast static tf for robot root -->

--- a/fanuc_m430ia2f_moveit_config/launch/moveit_planning_execution.launch
+++ b/fanuc_m430ia2f_moveit_config/launch/moveit_planning_execution.launch
@@ -21,8 +21,9 @@
   <arg name="db_path" default="$(find fanuc_m430ia2f_moveit_config)/default_warehouse_mongo_db" doc="Path to database files" />
 
   <!-- load the robot_description parameter before launching ROS-I nodes -->
-  <include file="$(find fanuc_m430ia2f_moveit_config)/launch/planning_context.launch" >
-    <arg name="load_robot_description" value="true" />
+  <include file="$(find fanuc_m430ia_support)/launch/load_m430ia2f.launch" />
+  <include file="$(find fanuc_m430ia2f_moveit_config)/launch/planning_context.launch">
+    <arg name="load_robot_description" value="false" />
   </include>
 
   <!-- run the robot simulator and action interface nodes -->

--- a/fanuc_m430ia2f_moveit_config/launch/planning_context.launch
+++ b/fanuc_m430ia2f_moveit_config/launch/planning_context.launch
@@ -6,7 +6,7 @@
   <arg name="robot_description" default="robot_description"/>
 
   <!-- Load universal robot description format (URDF) -->
-  <param if="$(arg load_robot_description)" name="$(arg robot_description)" textfile="$(find fanuc_m430ia_support)/urdf/m430ia2f.urdf"/>
+  <include file="$(find fanuc_m430ia_support)/launch/load_m430ia2f.launch" />
 
   <!-- The semantic description that corresponds to the URDF -->
   <param name="$(arg robot_description)_semantic" textfile="$(find fanuc_m430ia2f_moveit_config)/config/fanuc_m430ia2f.srdf" />

--- a/fanuc_m430ia2f_moveit_config/launch/planning_context.launch
+++ b/fanuc_m430ia2f_moveit_config/launch/planning_context.launch
@@ -6,7 +6,7 @@
   <arg name="robot_description" default="robot_description"/>
 
   <!-- Load universal robot description format (URDF) -->
-  <include file="$(find fanuc_m430ia_support)/launch/load_m430ia2f.launch" />
+  <param if="$(arg load_robot_description)" name="$(arg robot_description)" command="$(find xacro)/xacro.py '$(find fanuc_m430ia_support)/urdf/m430ia2f.xacro'"/>
 
   <!-- The semantic description that corresponds to the URDF -->
   <param name="$(arg robot_description)_semantic" textfile="$(find fanuc_m430ia2f_moveit_config)/config/fanuc_m430ia2f.srdf" />

--- a/fanuc_m430ia2p_moveit_config/.setup_assistant
+++ b/fanuc_m430ia2p_moveit_config/.setup_assistant
@@ -1,7 +1,7 @@
 moveit_setup_assistant_config:
   URDF:
     package: fanuc_m430ia_support
-    relative_path: urdf/m430ia2p.urdf
+    relative_path: urdf/m430ia2p.xacro
   SRDF:
     relative_path: config/fanuc_m430ia2p.srdf
   CONFIG:

--- a/fanuc_m430ia2p_moveit_config/launch/demo.launch
+++ b/fanuc_m430ia2p_moveit_config/launch/demo.launch
@@ -9,8 +9,9 @@
   <arg name="debug" default="false" />
 
   <!-- Load the URDF, SRDF and other .yaml configuration files on the param server -->
+  <include file="$(find fanuc_m430ia_support)/launch/load_m430ia2p.launch" />
   <include file="$(find fanuc_m430ia2p_moveit_config)/launch/planning_context.launch">
-    <arg name="load_robot_description" value="true"/>
+    <arg name="load_robot_description" value="false"/>
   </include>
 
   <!-- If needed, broadcast static tf for robot root -->

--- a/fanuc_m430ia2p_moveit_config/launch/moveit_planning_execution.launch
+++ b/fanuc_m430ia2p_moveit_config/launch/moveit_planning_execution.launch
@@ -21,8 +21,9 @@
   <arg name="db_path" default="$(find fanuc_m430ia2p_moveit_config)/default_warehouse_mongo_db" doc="Path to database files" />
 
   <!-- load the robot_description parameter before launching ROS-I nodes -->
-  <include file="$(find fanuc_m430ia2p_moveit_config)/launch/planning_context.launch" >
-    <arg name="load_robot_description" value="true" />
+  <include file="$(find fanuc_m430ia_support)/launch/load_m430ia2p.launch" />
+  <include file="$(find fanuc_m430ia2p_moveit_config)/launch/planning_context.launch">
+    <arg name="load_robot_description" value="false" />
   </include>
 
   <!-- run the robot simulator and action interface nodes -->

--- a/fanuc_m430ia2p_moveit_config/launch/planning_context.launch
+++ b/fanuc_m430ia2p_moveit_config/launch/planning_context.launch
@@ -6,7 +6,7 @@
   <arg name="robot_description" default="robot_description"/>
 
   <!-- Load universal robot description format (URDF) -->
-  <include file="$(find fanuc_m430ia_support)/launch/load_m430ia2p.launch" />
+  <param if="$(arg load_robot_description)" name="$(arg robot_description)" command="$(find xacro)/xacro.py '$(find fanuc_m430ia_support)/urdf/m430ia2p.xacro'"/>
 
   <!-- The semantic description that corresponds to the URDF -->
   <param name="$(arg robot_description)_semantic" textfile="$(find fanuc_m430ia2p_moveit_config)/config/fanuc_m430ia2p.srdf" />

--- a/fanuc_m430ia2p_moveit_config/launch/planning_context.launch
+++ b/fanuc_m430ia2p_moveit_config/launch/planning_context.launch
@@ -6,7 +6,7 @@
   <arg name="robot_description" default="robot_description"/>
 
   <!-- Load universal robot description format (URDF) -->
-  <param if="$(arg load_robot_description)" name="$(arg robot_description)" textfile="$(find fanuc_m430ia_support)/urdf/m430ia2p.urdf"/>
+  <include file="$(find fanuc_m430ia_support)/launch/load_m430ia2p.launch" />
 
   <!-- The semantic description that corresponds to the URDF -->
   <param name="$(arg robot_description)_semantic" textfile="$(find fanuc_m430ia2p_moveit_config)/config/fanuc_m430ia2p.srdf" />


### PR DESCRIPTION
As per subject.

Makes MoveIt load top-level xacros instead of the urdfs. This should make editing / updating support pkgs a bit more convenient, as the `xacro xacro.py ..` step is not needed then.
