### PR TITLE
support: use multi-arg install rule instead of for-loop.

### DIFF
--- a/fanuc_driver/CMakeLists.txt
+++ b/fanuc_driver/CMakeLists.txt
@@ -94,10 +94,7 @@ install(TARGETS
   DESTINATION ${CATKIN_PACKAGE_BIN_DESTINATION}
 )
 
-foreach(dir karel launch tpe)
-  install(
-    DIRECTORY ${dir}/
-    DESTINATION ${CATKIN_PACKAGE_SHARE_DESTINATION}/${dir})
-endforeach()
+install(DIRECTORY karel launch tpe
+  DESTINATION ${CATKIN_PACKAGE_SHARE_DESTINATION})
 
 install(FILES readme.md DESTINATION ${CATKIN_PACKAGE_SHARE_DESTINATION})

--- a/fanuc_lrmate200ic_support/CMakeLists.txt
+++ b/fanuc_lrmate200ic_support/CMakeLists.txt
@@ -18,10 +18,7 @@ if (CATKIN_ENABLE_TESTING)
       fanuc_driver_motion_streaming_interface_bswap)
 endif()
 
-foreach(dir config launch meshes urdf)
-  install(
-    DIRECTORY ${dir}/
-    DESTINATION ${CATKIN_PACKAGE_SHARE_DESTINATION}/${dir})
-endforeach()
+install(DIRECTORY config launch meshes urdf
+  DESTINATION ${CATKIN_PACKAGE_SHARE_DESTINATION})
 
 install(FILES readme.md DESTINATION ${CATKIN_PACKAGE_SHARE_DESTINATION})

--- a/fanuc_m10ia_support/CMakeLists.txt
+++ b/fanuc_m10ia_support/CMakeLists.txt
@@ -18,10 +18,7 @@ if (CATKIN_ENABLE_TESTING)
       fanuc_driver_motion_streaming_interface_bswap)
 endif()
 
-foreach(dir config launch meshes urdf)
-  install(
-    DIRECTORY ${dir}/
-    DESTINATION ${CATKIN_PACKAGE_SHARE_DESTINATION}/${dir})
-endforeach()
+install(DIRECTORY config launch meshes urdf
+  DESTINATION ${CATKIN_PACKAGE_SHARE_DESTINATION})
 
 install(FILES readme.md DESTINATION ${CATKIN_PACKAGE_SHARE_DESTINATION})

--- a/fanuc_m16ib_support/CMakeLists.txt
+++ b/fanuc_m16ib_support/CMakeLists.txt
@@ -18,10 +18,7 @@ if (CATKIN_ENABLE_TESTING)
       fanuc_driver_motion_streaming_interface_bswap)
 endif()
 
-foreach(dir config launch meshes urdf)
-  install(
-    DIRECTORY ${dir}/
-    DESTINATION ${CATKIN_PACKAGE_SHARE_DESTINATION}/${dir})
-endforeach()
+install(DIRECTORY config launch meshes urdf
+  DESTINATION ${CATKIN_PACKAGE_SHARE_DESTINATION})
 
 install(FILES readme.md DESTINATION ${CATKIN_PACKAGE_SHARE_DESTINATION})

--- a/fanuc_m20ia_support/CMakeLists.txt
+++ b/fanuc_m20ia_support/CMakeLists.txt
@@ -18,10 +18,7 @@ if (CATKIN_ENABLE_TESTING)
       fanuc_driver_motion_streaming_interface_bswap)
 endif()
 
-foreach(dir config launch meshes urdf)
-  install(
-    DIRECTORY ${dir}/
-    DESTINATION ${CATKIN_PACKAGE_SHARE_DESTINATION}/${dir})
-endforeach()
+install(DIRECTORY config launch meshes urdf
+  DESTINATION ${CATKIN_PACKAGE_SHARE_DESTINATION})
 
 install(FILES readme.md DESTINATION ${CATKIN_PACKAGE_SHARE_DESTINATION})

--- a/fanuc_m430ia_support/CMakeLists.txt
+++ b/fanuc_m430ia_support/CMakeLists.txt
@@ -18,10 +18,7 @@ if (CATKIN_ENABLE_TESTING)
       fanuc_driver_motion_streaming_interface_bswap)
 endif()
 
-foreach(dir config launch meshes urdf)
-  install(
-    DIRECTORY ${dir}/
-    DESTINATION ${CATKIN_PACKAGE_SHARE_DESTINATION}/${dir})
-endforeach()
+install(DIRECTORY config launch meshes urdf
+  DESTINATION ${CATKIN_PACKAGE_SHARE_DESTINATION})
 
 install(FILES readme.md DESTINATION ${CATKIN_PACKAGE_SHARE_DESTINATION})

--- a/fanuc_resources/CMakeLists.txt
+++ b/fanuc_resources/CMakeLists.txt
@@ -6,9 +6,7 @@ find_package(catkin REQUIRED)
 
 catkin_package()
 
-foreach(dir urdf)
-  install(DIRECTORY ${dir}/
-    DESTINATION ${CATKIN_PACKAGE_SHARE_DESTINATION}/${dir})
-endforeach()
+install(DIRECTORY urdf
+  DESTINATION ${CATKIN_PACKAGE_SHARE_DESTINATION})
 
 install(FILES readme.md DESTINATION ${CATKIN_PACKAGE_SHARE_DESTINATION})


### PR DESCRIPTION
This updates the install rules in all packages that are not auto-generated to use a single-line, multi-argument form.

No functional changes.
