### PR TITLE
Fix for issue #160: update MoveIt configs to Indigo

### DIFF
--- a/fanuc_lrmate200ic5h_moveit_config/.setup_assistant
+++ b/fanuc_lrmate200ic5h_moveit_config/.setup_assistant
@@ -5,4 +5,4 @@ moveit_setup_assistant_config:
   SRDF:
     relative_path: config/fanuc_lrmate200ic5h.srdf
   CONFIG:
-    generated_timestamp: 1397375497
+    generated_timestamp: 1432414727

--- a/fanuc_lrmate200ic5h_moveit_config/config/joint_limits.yaml
+++ b/fanuc_lrmate200ic5h_moveit_config/config/joint_limits.yaml
@@ -1,3 +1,6 @@
+# joint_limits.yaml allows the dynamics properties specified in the URDF to be overwritten or augmented as needed
+# Specific joint properties can be changed with the keys [max_position, min_position, max_velocity, max_acceleration]
+# Joint limits can be turned off with [has_velocity_limits, has_acceleration_limits]
 joint_limits:
   joint_1:
     has_velocity_limits: true

--- a/fanuc_lrmate200ic5h_moveit_config/config/ompl_planning.yaml
+++ b/fanuc_lrmate200ic5h_moveit_config/config/ompl_planning.yaml
@@ -1,24 +1,55 @@
 planner_configs:
   SBLkConfigDefault:
     type: geometric::SBL
+    range: 0.0  # Max motion added to tree. ==> maxDistance_ default: 0.0, if 0.0, set on setup()
   ESTkConfigDefault:
     type: geometric::EST
+    range: 0.0  # Max motion added to tree. ==> maxDistance_ default: 0.0, if 0.0 setup()
+    goal_bias: 0.05  # When close to goal select goal, with this probability. default: 0.05
   LBKPIECEkConfigDefault:
     type: geometric::LBKPIECE
+    range: 0.0  # Max motion added to tree. ==> maxDistance_ default: 0.0, if 0.0, set on setup()
+    border_fraction: 0.9  # Fraction of time focused on boarder default: 0.9
+    min_valid_path_fraction: 0.5  # Accept partially valid moves above fraction. default: 0.5
   BKPIECEkConfigDefault:
     type: geometric::BKPIECE
+    range: 0.0  # Max motion added to tree. ==> maxDistance_ default: 0.0, if 0.0, set on setup()
+    border_fraction: 0.9  # Fraction of time focused on boarder default: 0.9
+    failed_expansion_score_factor: 0.5  # When extending motion fails, scale score by factor. default: 0.5
+    min_valid_path_fraction: 0.5  # Accept partially valid moves above fraction. default: 0.5
   KPIECEkConfigDefault:
     type: geometric::KPIECE
+    range: 0.0  # Max motion added to tree. ==> maxDistance_ default: 0.0, if 0.0, set on setup()
+    goal_bias: 0.05  # When close to goal select goal, with this probability. default: 0.05 
+    border_fraction: 0.9  # Fraction of time focused on boarder default: 0.9 (0.0,1.]
+    failed_expansion_score_factor: 0.5  # When extending motion fails, scale score by factor. default: 0.5
+    min_valid_path_fraction: 0.5  # Accept partially valid moves above fraction. default: 0.5
   RRTkConfigDefault:
     type: geometric::RRT
+    range: 0.0  # Max motion added to tree. ==> maxDistance_ default: 0.0, if 0.0, set on setup()
+    goal_bias: 0.05  # When close to goal select goal, with this probability? default: 0.05
   RRTConnectkConfigDefault:
     type: geometric::RRTConnect
+    range: 0.0  # Max motion added to tree. ==> maxDistance_ default: 0.0, if 0.0, set on setup()
   RRTstarkConfigDefault:
     type: geometric::RRTstar
+    range: 0.0  # Max motion added to tree. ==> maxDistance_ default: 0.0, if 0.0, set on setup()
+    goal_bias: 0.05  # When close to goal select goal, with this probability? default: 0.05
+    delay_collision_checking: 1  # Stop collision checking as soon as C-free parent found. default 1
   TRRTkConfigDefault:
     type: geometric::TRRT
+    range: 0.0  # Max motion added to tree. ==> maxDistance_ default: 0.0, if 0.0, set on setup()
+    goal_bias: 0.05  # When close to goal select goal, with this probability? default: 0.05
+    max_states_failed: 10  # when to start increasing temp. default: 10
+    temp_change_factor: 2.0  # how much to increase or decrease temp. default: 2.0
+    min_temperature: 10e-10  # lower limit of temp change. default: 10e-10
+    init_temperature: 10e-6  # initial temperature. default: 10e-6
+    frountier_threshold: 0.0  # dist new state to nearest neighbor to disqualify as frontier. default: 0.0 set in setup() 
+    frountierNodeRatio: 0.1  # 1/10, or 1 nonfrontier for every 10 frontier. default: 0.1
+    k_constant: 0.0  # value used to normalize expresssion. default: 0.0 set in setup()
   PRMkConfigDefault:
     type: geometric::PRM
+    max_nearest_neighbors: 10  # use k nearest neighbors. default: 10
   PRMstarkConfigDefault:
     type: geometric::PRMstar
 manipulator:

--- a/fanuc_lrmate200ic5h_moveit_config/launch/default_warehouse_db.launch
+++ b/fanuc_lrmate200ic5h_moveit_config/launch/default_warehouse_db.launch
@@ -1,11 +1,10 @@
 <launch>
 
   <arg name="reset" default="false"/>
-
   <!-- If not specified, we'll use a default database location -->
   <arg name="moveit_warehouse_database_path" default="$(find fanuc_lrmate200ic5h_moveit_config)/default_warehouse_mongo_db" />
 
-  <!-- Launch the warehouse with a default database location -->  
+  <!-- Launch the warehouse with the configured database location -->
   <include file="$(find fanuc_lrmate200ic5h_moveit_config)/launch/warehouse.launch">
     <arg name="moveit_warehouse_database_path" value="$(arg moveit_warehouse_database_path)" />
   </include>

--- a/fanuc_lrmate200ic5h_moveit_config/launch/demo.launch
+++ b/fanuc_lrmate200ic5h_moveit_config/launch/demo.launch
@@ -18,16 +18,16 @@
 
   <!-- We do not have a robot connected, so publish fake joint states -->
   <node name="joint_state_publisher" pkg="joint_state_publisher" type="joint_state_publisher">
-    <param name="/use_gui" value="false"/> 
+    <param name="/use_gui" value="false"/>
     <rosparam param="/source_list">[/move_group/fake_controller_joint_states]</rosparam>
   </node>
-  
+
   <!-- Given the published joint states, publish tf for the robot links -->
   <node name="robot_state_publisher" pkg="robot_state_publisher" type="robot_state_publisher" respawn="true" output="screen" />
 
   <!-- Run the main MoveIt executable without trajectory execution (we do not have controllers configured by default) -->
   <include file="$(find fanuc_lrmate200ic5h_moveit_config)/launch/move_group.launch">
-    <arg name="allow_trajectory_execution" value="true"/>  
+    <arg name="allow_trajectory_execution" value="true"/>
     <arg name="fake_execution" value="true"/>
     <arg name="info" value="true"/>
     <arg name="debug" value="$(arg debug)"/>

--- a/fanuc_lrmate200ic5h_moveit_config/launch/joystick_control.launch
+++ b/fanuc_lrmate200ic5h_moveit_config/launch/joystick_control.launch
@@ -1,0 +1,17 @@
+<launch>
+  <!-- See moveit_ros/visualization/doc/joystick.rst for documentation -->
+
+  <arg name="dev" default="/dev/input/js0" />
+
+  <!-- Launch joy node -->
+  <node pkg="joy" type="joy_node" name="joy">
+    <param name="dev" value="$(arg dev)" /> <!-- Customize this to match the location your joystick is plugged in on-->
+    <param name="deadzone" value="0.2" />
+    <param name="autorepeat_rate" value="40" />
+    <param name="coalesce_interval" value="0.025" />
+  </node>
+
+  <!-- Launch python interface -->
+  <node pkg="moveit_ros_visualization" type="moveit_joy.py" output="screen" name="moveit_joy"/>
+        
+</launch>

--- a/fanuc_lrmate200ic5h_moveit_config/launch/move_group.launch
+++ b/fanuc_lrmate200ic5h_moveit_config/launch/move_group.launch
@@ -5,15 +5,16 @@
   <!-- GDB Debug Option -->
   <arg name="debug" default="false" />
   <arg unless="$(arg debug)" name="launch_prefix" value="" />
-  <arg     if="$(arg debug)" name="launch_prefix" value="gdb --ex run --args" />
+  <arg     if="$(arg debug)" name="launch_prefix"
+	   value="gdb -x $(find fanuc_lrmate200ic5h_moveit_config)/launch/gdb_settings.gdb --ex run --args" />
 
   <!-- Verbose Mode Option -->
-  <arg name="info" default="$(arg debug)" />  
+  <arg name="info" default="$(arg debug)" />
   <arg unless="$(arg info)" name="command_args" value="" />
   <arg     if="$(arg info)" name="command_args" value="--debug" />
 
   <!-- move_group settings -->
-  <arg name="allow_trajectory_execution" default="true"/> 
+  <arg name="allow_trajectory_execution" default="true"/>
   <arg name="fake_execution" default="false"/>
   <arg name="max_safe_path_cost" default="1"/>
   <arg name="jiggle_fraction" default="0.05" />
@@ -33,7 +34,7 @@
 
   <!-- Sensors Functionality -->
   <include ns="move_group" file="$(find fanuc_lrmate200ic5h_moveit_config)/launch/sensor_manager.launch.xml" if="$(arg allow_trajectory_execution)">
-    <arg name="moveit_sensor_manager" value="fanuc_lrmate200ic5h" /> 
+    <arg name="moveit_sensor_manager" value="fanuc_lrmate200ic5h" />
   </include>
 
   <!-- Start the actual move_group node/action server -->
@@ -55,6 +56,7 @@
 				      move_group/MoveGroupQueryPlannersService
 				      move_group/MoveGroupStateValidationService
 				      move_group/MoveGroupGetPlanningSceneService
+				      move_group/ClearOctomapService
 				      " />
 
     <!-- Publish the planning scene of the physical robot so that rviz plugin can know actual robot -->
@@ -63,5 +65,5 @@
     <param name="planning_scene_monitor/publish_state_updates" value="$(arg publish_monitored_planning_scene)" />
     <param name="planning_scene_monitor/publish_transforms_updates" value="$(arg publish_monitored_planning_scene)" />
   </node>
-  
+
 </launch>

--- a/fanuc_lrmate200ic5l_moveit_config/.setup_assistant
+++ b/fanuc_lrmate200ic5l_moveit_config/.setup_assistant
@@ -5,4 +5,4 @@ moveit_setup_assistant_config:
   SRDF:
     relative_path: config/fanuc_lrmate200ic5l.srdf
   CONFIG:
-    generated_timestamp: 1405585592
+    generated_timestamp: 1432415389

--- a/fanuc_lrmate200ic5l_moveit_config/config/joint_limits.yaml
+++ b/fanuc_lrmate200ic5l_moveit_config/config/joint_limits.yaml
@@ -1,3 +1,6 @@
+# joint_limits.yaml allows the dynamics properties specified in the URDF to be overwritten or augmented as needed
+# Specific joint properties can be changed with the keys [max_position, min_position, max_velocity, max_acceleration]
+# Joint limits can be turned off with [has_velocity_limits, has_acceleration_limits]
 joint_limits:
   joint_1:
     has_velocity_limits: true

--- a/fanuc_lrmate200ic5l_moveit_config/config/kinematics.yaml
+++ b/fanuc_lrmate200ic5l_moveit_config/config/kinematics.yaml
@@ -1,5 +1,5 @@
 manipulator:
   kinematics_solver: fanuc_lrmate200ic5l_manipulator_kinematics/IKFastKinematicsPlugin
-  kinematics_solver_attempts: 3
   kinematics_solver_search_resolution: 0.005
   kinematics_solver_timeout: 0.005
+  kinematics_solver_attempts: 3

--- a/fanuc_lrmate200ic5l_moveit_config/config/ompl_planning.yaml
+++ b/fanuc_lrmate200ic5l_moveit_config/config/ompl_planning.yaml
@@ -1,24 +1,55 @@
 planner_configs:
   SBLkConfigDefault:
     type: geometric::SBL
+    range: 0.0  # Max motion added to tree. ==> maxDistance_ default: 0.0, if 0.0, set on setup()
   ESTkConfigDefault:
     type: geometric::EST
+    range: 0.0  # Max motion added to tree. ==> maxDistance_ default: 0.0, if 0.0 setup()
+    goal_bias: 0.05  # When close to goal select goal, with this probability. default: 0.05
   LBKPIECEkConfigDefault:
     type: geometric::LBKPIECE
+    range: 0.0  # Max motion added to tree. ==> maxDistance_ default: 0.0, if 0.0, set on setup()
+    border_fraction: 0.9  # Fraction of time focused on boarder default: 0.9
+    min_valid_path_fraction: 0.5  # Accept partially valid moves above fraction. default: 0.5
   BKPIECEkConfigDefault:
     type: geometric::BKPIECE
+    range: 0.0  # Max motion added to tree. ==> maxDistance_ default: 0.0, if 0.0, set on setup()
+    border_fraction: 0.9  # Fraction of time focused on boarder default: 0.9
+    failed_expansion_score_factor: 0.5  # When extending motion fails, scale score by factor. default: 0.5
+    min_valid_path_fraction: 0.5  # Accept partially valid moves above fraction. default: 0.5
   KPIECEkConfigDefault:
     type: geometric::KPIECE
+    range: 0.0  # Max motion added to tree. ==> maxDistance_ default: 0.0, if 0.0, set on setup()
+    goal_bias: 0.05  # When close to goal select goal, with this probability. default: 0.05 
+    border_fraction: 0.9  # Fraction of time focused on boarder default: 0.9 (0.0,1.]
+    failed_expansion_score_factor: 0.5  # When extending motion fails, scale score by factor. default: 0.5
+    min_valid_path_fraction: 0.5  # Accept partially valid moves above fraction. default: 0.5
   RRTkConfigDefault:
     type: geometric::RRT
+    range: 0.0  # Max motion added to tree. ==> maxDistance_ default: 0.0, if 0.0, set on setup()
+    goal_bias: 0.05  # When close to goal select goal, with this probability? default: 0.05
   RRTConnectkConfigDefault:
     type: geometric::RRTConnect
+    range: 0.0  # Max motion added to tree. ==> maxDistance_ default: 0.0, if 0.0, set on setup()
   RRTstarkConfigDefault:
     type: geometric::RRTstar
+    range: 0.0  # Max motion added to tree. ==> maxDistance_ default: 0.0, if 0.0, set on setup()
+    goal_bias: 0.05  # When close to goal select goal, with this probability? default: 0.05
+    delay_collision_checking: 1  # Stop collision checking as soon as C-free parent found. default 1
   TRRTkConfigDefault:
     type: geometric::TRRT
+    range: 0.0  # Max motion added to tree. ==> maxDistance_ default: 0.0, if 0.0, set on setup()
+    goal_bias: 0.05  # When close to goal select goal, with this probability? default: 0.05
+    max_states_failed: 10  # when to start increasing temp. default: 10
+    temp_change_factor: 2.0  # how much to increase or decrease temp. default: 2.0
+    min_temperature: 10e-10  # lower limit of temp change. default: 10e-10
+    init_temperature: 10e-6  # initial temperature. default: 10e-6
+    frountier_threshold: 0.0  # dist new state to nearest neighbor to disqualify as frontier. default: 0.0 set in setup() 
+    frountierNodeRatio: 0.1  # 1/10, or 1 nonfrontier for every 10 frontier. default: 0.1
+    k_constant: 0.0  # value used to normalize expresssion. default: 0.0 set in setup()
   PRMkConfigDefault:
     type: geometric::PRM
+    max_nearest_neighbors: 10  # use k nearest neighbors. default: 10
   PRMstarkConfigDefault:
     type: geometric::PRMstar
 manipulator:

--- a/fanuc_lrmate200ic5l_moveit_config/launch/default_warehouse_db.launch
+++ b/fanuc_lrmate200ic5l_moveit_config/launch/default_warehouse_db.launch
@@ -1,11 +1,10 @@
 <launch>
 
   <arg name="reset" default="false"/>
-
   <!-- If not specified, we'll use a default database location -->
   <arg name="moveit_warehouse_database_path" default="$(find fanuc_lrmate200ic5l_moveit_config)/default_warehouse_mongo_db" />
 
-  <!-- Launch the warehouse with a default database location -->  
+  <!-- Launch the warehouse with the configured database location -->
   <include file="$(find fanuc_lrmate200ic5l_moveit_config)/launch/warehouse.launch">
     <arg name="moveit_warehouse_database_path" value="$(arg moveit_warehouse_database_path)" />
   </include>

--- a/fanuc_lrmate200ic5l_moveit_config/launch/demo.launch
+++ b/fanuc_lrmate200ic5l_moveit_config/launch/demo.launch
@@ -18,16 +18,16 @@
 
   <!-- We do not have a robot connected, so publish fake joint states -->
   <node name="joint_state_publisher" pkg="joint_state_publisher" type="joint_state_publisher">
-    <param name="/use_gui" value="false"/> 
+    <param name="/use_gui" value="false"/>
     <rosparam param="/source_list">[/move_group/fake_controller_joint_states]</rosparam>
   </node>
-  
+
   <!-- Given the published joint states, publish tf for the robot links -->
   <node name="robot_state_publisher" pkg="robot_state_publisher" type="robot_state_publisher" respawn="true" output="screen" />
 
   <!-- Run the main MoveIt executable without trajectory execution (we do not have controllers configured by default) -->
   <include file="$(find fanuc_lrmate200ic5l_moveit_config)/launch/move_group.launch">
-    <arg name="allow_trajectory_execution" value="true"/>  
+    <arg name="allow_trajectory_execution" value="true"/>
     <arg name="fake_execution" value="true"/>
     <arg name="info" value="true"/>
     <arg name="debug" value="$(arg debug)"/>

--- a/fanuc_lrmate200ic5l_moveit_config/launch/joystick_control.launch
+++ b/fanuc_lrmate200ic5l_moveit_config/launch/joystick_control.launch
@@ -1,0 +1,17 @@
+<launch>
+  <!-- See moveit_ros/visualization/doc/joystick.rst for documentation -->
+
+  <arg name="dev" default="/dev/input/js0" />
+
+  <!-- Launch joy node -->
+  <node pkg="joy" type="joy_node" name="joy">
+    <param name="dev" value="$(arg dev)" /> <!-- Customize this to match the location your joystick is plugged in on-->
+    <param name="deadzone" value="0.2" />
+    <param name="autorepeat_rate" value="40" />
+    <param name="coalesce_interval" value="0.025" />
+  </node>
+
+  <!-- Launch python interface -->
+  <node pkg="moveit_ros_visualization" type="moveit_joy.py" output="screen" name="moveit_joy"/>
+        
+</launch>

--- a/fanuc_lrmate200ic5l_moveit_config/launch/move_group.launch
+++ b/fanuc_lrmate200ic5l_moveit_config/launch/move_group.launch
@@ -5,15 +5,16 @@
   <!-- GDB Debug Option -->
   <arg name="debug" default="false" />
   <arg unless="$(arg debug)" name="launch_prefix" value="" />
-  <arg     if="$(arg debug)" name="launch_prefix" value="gdb --ex run --args" />
+  <arg     if="$(arg debug)" name="launch_prefix"
+	   value="gdb -x $(find fanuc_lrmate200ic5l_moveit_config)/launch/gdb_settings.gdb --ex run --args" />
 
   <!-- Verbose Mode Option -->
-  <arg name="info" default="$(arg debug)" />  
+  <arg name="info" default="$(arg debug)" />
   <arg unless="$(arg info)" name="command_args" value="" />
   <arg     if="$(arg info)" name="command_args" value="--debug" />
 
   <!-- move_group settings -->
-  <arg name="allow_trajectory_execution" default="true"/> 
+  <arg name="allow_trajectory_execution" default="true"/>
   <arg name="fake_execution" default="false"/>
   <arg name="max_safe_path_cost" default="1"/>
   <arg name="jiggle_fraction" default="0.05" />
@@ -33,7 +34,7 @@
 
   <!-- Sensors Functionality -->
   <include ns="move_group" file="$(find fanuc_lrmate200ic5l_moveit_config)/launch/sensor_manager.launch.xml" if="$(arg allow_trajectory_execution)">
-    <arg name="moveit_sensor_manager" value="fanuc_lrmate200ic5l" /> 
+    <arg name="moveit_sensor_manager" value="fanuc_lrmate200ic5l" />
   </include>
 
   <!-- Start the actual move_group node/action server -->
@@ -55,6 +56,7 @@
 				      move_group/MoveGroupQueryPlannersService
 				      move_group/MoveGroupStateValidationService
 				      move_group/MoveGroupGetPlanningSceneService
+				      move_group/ClearOctomapService
 				      " />
 
     <!-- Publish the planning scene of the physical robot so that rviz plugin can know actual robot -->
@@ -63,5 +65,5 @@
     <param name="planning_scene_monitor/publish_state_updates" value="$(arg publish_monitored_planning_scene)" />
     <param name="planning_scene_monitor/publish_transforms_updates" value="$(arg publish_monitored_planning_scene)" />
   </node>
-  
+
 </launch>

--- a/fanuc_lrmate200ic_moveit_config/.setup_assistant
+++ b/fanuc_lrmate200ic_moveit_config/.setup_assistant
@@ -5,4 +5,4 @@ moveit_setup_assistant_config:
   SRDF:
     relative_path: config/fanuc_lrmate200ic.srdf
   CONFIG:
-    generated_timestamp: 1397374148
+    generated_timestamp: 1432414529

--- a/fanuc_lrmate200ic_moveit_config/config/joint_limits.yaml
+++ b/fanuc_lrmate200ic_moveit_config/config/joint_limits.yaml
@@ -1,3 +1,6 @@
+# joint_limits.yaml allows the dynamics properties specified in the URDF to be overwritten or augmented as needed
+# Specific joint properties can be changed with the keys [max_position, min_position, max_velocity, max_acceleration]
+# Joint limits can be turned off with [has_velocity_limits, has_acceleration_limits]
 joint_limits:
   joint_1:
     has_velocity_limits: true

--- a/fanuc_lrmate200ic_moveit_config/config/ompl_planning.yaml
+++ b/fanuc_lrmate200ic_moveit_config/config/ompl_planning.yaml
@@ -1,24 +1,55 @@
 planner_configs:
   SBLkConfigDefault:
     type: geometric::SBL
+    range: 0.0  # Max motion added to tree. ==> maxDistance_ default: 0.0, if 0.0, set on setup()
   ESTkConfigDefault:
     type: geometric::EST
+    range: 0.0  # Max motion added to tree. ==> maxDistance_ default: 0.0, if 0.0 setup()
+    goal_bias: 0.05  # When close to goal select goal, with this probability. default: 0.05
   LBKPIECEkConfigDefault:
     type: geometric::LBKPIECE
+    range: 0.0  # Max motion added to tree. ==> maxDistance_ default: 0.0, if 0.0, set on setup()
+    border_fraction: 0.9  # Fraction of time focused on boarder default: 0.9
+    min_valid_path_fraction: 0.5  # Accept partially valid moves above fraction. default: 0.5
   BKPIECEkConfigDefault:
     type: geometric::BKPIECE
+    range: 0.0  # Max motion added to tree. ==> maxDistance_ default: 0.0, if 0.0, set on setup()
+    border_fraction: 0.9  # Fraction of time focused on boarder default: 0.9
+    failed_expansion_score_factor: 0.5  # When extending motion fails, scale score by factor. default: 0.5
+    min_valid_path_fraction: 0.5  # Accept partially valid moves above fraction. default: 0.5
   KPIECEkConfigDefault:
     type: geometric::KPIECE
+    range: 0.0  # Max motion added to tree. ==> maxDistance_ default: 0.0, if 0.0, set on setup()
+    goal_bias: 0.05  # When close to goal select goal, with this probability. default: 0.05 
+    border_fraction: 0.9  # Fraction of time focused on boarder default: 0.9 (0.0,1.]
+    failed_expansion_score_factor: 0.5  # When extending motion fails, scale score by factor. default: 0.5
+    min_valid_path_fraction: 0.5  # Accept partially valid moves above fraction. default: 0.5
   RRTkConfigDefault:
     type: geometric::RRT
+    range: 0.0  # Max motion added to tree. ==> maxDistance_ default: 0.0, if 0.0, set on setup()
+    goal_bias: 0.05  # When close to goal select goal, with this probability? default: 0.05
   RRTConnectkConfigDefault:
     type: geometric::RRTConnect
+    range: 0.0  # Max motion added to tree. ==> maxDistance_ default: 0.0, if 0.0, set on setup()
   RRTstarkConfigDefault:
     type: geometric::RRTstar
+    range: 0.0  # Max motion added to tree. ==> maxDistance_ default: 0.0, if 0.0, set on setup()
+    goal_bias: 0.05  # When close to goal select goal, with this probability? default: 0.05
+    delay_collision_checking: 1  # Stop collision checking as soon as C-free parent found. default 1
   TRRTkConfigDefault:
     type: geometric::TRRT
+    range: 0.0  # Max motion added to tree. ==> maxDistance_ default: 0.0, if 0.0, set on setup()
+    goal_bias: 0.05  # When close to goal select goal, with this probability? default: 0.05
+    max_states_failed: 10  # when to start increasing temp. default: 10
+    temp_change_factor: 2.0  # how much to increase or decrease temp. default: 2.0
+    min_temperature: 10e-10  # lower limit of temp change. default: 10e-10
+    init_temperature: 10e-6  # initial temperature. default: 10e-6
+    frountier_threshold: 0.0  # dist new state to nearest neighbor to disqualify as frontier. default: 0.0 set in setup() 
+    frountierNodeRatio: 0.1  # 1/10, or 1 nonfrontier for every 10 frontier. default: 0.1
+    k_constant: 0.0  # value used to normalize expresssion. default: 0.0 set in setup()
   PRMkConfigDefault:
     type: geometric::PRM
+    max_nearest_neighbors: 10  # use k nearest neighbors. default: 10
   PRMstarkConfigDefault:
     type: geometric::PRMstar
 manipulator:

--- a/fanuc_lrmate200ic_moveit_config/launch/default_warehouse_db.launch
+++ b/fanuc_lrmate200ic_moveit_config/launch/default_warehouse_db.launch
@@ -1,11 +1,10 @@
 <launch>
 
   <arg name="reset" default="false"/>
-
   <!-- If not specified, we'll use a default database location -->
   <arg name="moveit_warehouse_database_path" default="$(find fanuc_lrmate200ic_moveit_config)/default_warehouse_mongo_db" />
 
-  <!-- Launch the warehouse with a default database location -->  
+  <!-- Launch the warehouse with the configured database location -->
   <include file="$(find fanuc_lrmate200ic_moveit_config)/launch/warehouse.launch">
     <arg name="moveit_warehouse_database_path" value="$(arg moveit_warehouse_database_path)" />
   </include>

--- a/fanuc_lrmate200ic_moveit_config/launch/demo.launch
+++ b/fanuc_lrmate200ic_moveit_config/launch/demo.launch
@@ -18,16 +18,16 @@
 
   <!-- We do not have a robot connected, so publish fake joint states -->
   <node name="joint_state_publisher" pkg="joint_state_publisher" type="joint_state_publisher">
-    <param name="/use_gui" value="false"/> 
+    <param name="/use_gui" value="false"/>
     <rosparam param="/source_list">[/move_group/fake_controller_joint_states]</rosparam>
   </node>
-  
+
   <!-- Given the published joint states, publish tf for the robot links -->
   <node name="robot_state_publisher" pkg="robot_state_publisher" type="robot_state_publisher" respawn="true" output="screen" />
 
   <!-- Run the main MoveIt executable without trajectory execution (we do not have controllers configured by default) -->
   <include file="$(find fanuc_lrmate200ic_moveit_config)/launch/move_group.launch">
-    <arg name="allow_trajectory_execution" value="true"/>  
+    <arg name="allow_trajectory_execution" value="true"/>
     <arg name="fake_execution" value="true"/>
     <arg name="info" value="true"/>
     <arg name="debug" value="$(arg debug)"/>

--- a/fanuc_lrmate200ic_moveit_config/launch/joystick_control.launch
+++ b/fanuc_lrmate200ic_moveit_config/launch/joystick_control.launch
@@ -1,0 +1,17 @@
+<launch>
+  <!-- See moveit_ros/visualization/doc/joystick.rst for documentation -->
+
+  <arg name="dev" default="/dev/input/js0" />
+
+  <!-- Launch joy node -->
+  <node pkg="joy" type="joy_node" name="joy">
+    <param name="dev" value="$(arg dev)" /> <!-- Customize this to match the location your joystick is plugged in on-->
+    <param name="deadzone" value="0.2" />
+    <param name="autorepeat_rate" value="40" />
+    <param name="coalesce_interval" value="0.025" />
+  </node>
+
+  <!-- Launch python interface -->
+  <node pkg="moveit_ros_visualization" type="moveit_joy.py" output="screen" name="moveit_joy"/>
+        
+</launch>

--- a/fanuc_lrmate200ic_moveit_config/launch/move_group.launch
+++ b/fanuc_lrmate200ic_moveit_config/launch/move_group.launch
@@ -5,15 +5,16 @@
   <!-- GDB Debug Option -->
   <arg name="debug" default="false" />
   <arg unless="$(arg debug)" name="launch_prefix" value="" />
-  <arg     if="$(arg debug)" name="launch_prefix" value="gdb --ex run --args" />
+  <arg     if="$(arg debug)" name="launch_prefix"
+	   value="gdb -x $(find fanuc_lrmate200ic_moveit_config)/launch/gdb_settings.gdb --ex run --args" />
 
   <!-- Verbose Mode Option -->
-  <arg name="info" default="$(arg debug)" />  
+  <arg name="info" default="$(arg debug)" />
   <arg unless="$(arg info)" name="command_args" value="" />
   <arg     if="$(arg info)" name="command_args" value="--debug" />
 
   <!-- move_group settings -->
-  <arg name="allow_trajectory_execution" default="true"/> 
+  <arg name="allow_trajectory_execution" default="true"/>
   <arg name="fake_execution" default="false"/>
   <arg name="max_safe_path_cost" default="1"/>
   <arg name="jiggle_fraction" default="0.05" />
@@ -33,7 +34,7 @@
 
   <!-- Sensors Functionality -->
   <include ns="move_group" file="$(find fanuc_lrmate200ic_moveit_config)/launch/sensor_manager.launch.xml" if="$(arg allow_trajectory_execution)">
-    <arg name="moveit_sensor_manager" value="fanuc_lrmate200ic" /> 
+    <arg name="moveit_sensor_manager" value="fanuc_lrmate200ic" />
   </include>
 
   <!-- Start the actual move_group node/action server -->
@@ -55,6 +56,7 @@
 				      move_group/MoveGroupQueryPlannersService
 				      move_group/MoveGroupStateValidationService
 				      move_group/MoveGroupGetPlanningSceneService
+				      move_group/ClearOctomapService
 				      " />
 
     <!-- Publish the planning scene of the physical robot so that rviz plugin can know actual robot -->
@@ -63,5 +65,5 @@
     <param name="planning_scene_monitor/publish_state_updates" value="$(arg publish_monitored_planning_scene)" />
     <param name="planning_scene_monitor/publish_transforms_updates" value="$(arg publish_monitored_planning_scene)" />
   </node>
-  
+
 </launch>

--- a/fanuc_m10ia_moveit_config/.setup_assistant
+++ b/fanuc_m10ia_moveit_config/.setup_assistant
@@ -5,4 +5,4 @@ moveit_setup_assistant_config:
   SRDF:
     relative_path: config/fanuc_m10ia.srdf
   CONFIG:
-    generated_timestamp: 1397055368
+    generated_timestamp: 1432404153

--- a/fanuc_m10ia_moveit_config/config/joint_limits.yaml
+++ b/fanuc_m10ia_moveit_config/config/joint_limits.yaml
@@ -1,29 +1,32 @@
+# joint_limits.yaml allows the dynamics properties specified in the URDF to be overwritten or augmented as needed
+# Specific joint properties can be changed with the keys [max_position, min_position, max_velocity, max_acceleration]
+# Joint limits can be turned off with [has_velocity_limits, has_acceleration_limits]
 joint_limits:
-  joint_4:
-    has_velocity_limits: true
-    max_velocity: 6.98
-    has_acceleration_limits: true
-    max_acceleration: 1.396
-  joint_3:
-    has_velocity_limits: true
-    max_velocity: 3.67
-    has_acceleration_limits: true
-    max_acceleration: 0.734
   joint_1:
     has_velocity_limits: true
     max_velocity: 3.67
     has_acceleration_limits: true
     max_acceleration: 0.734
-  joint_5:
-    has_velocity_limits: true
-    max_velocity: 6.98
-    has_acceleration_limits: true
-    max_acceleration: 1.396
   joint_2:
     has_velocity_limits: true
     max_velocity: 3.32
     has_acceleration_limits: true
     max_acceleration: 0.664
+  joint_3:
+    has_velocity_limits: true
+    max_velocity: 3.67
+    has_acceleration_limits: true
+    max_acceleration: 0.734
+  joint_4:
+    has_velocity_limits: true
+    max_velocity: 6.98
+    has_acceleration_limits: true
+    max_acceleration: 1.396
+  joint_5:
+    has_velocity_limits: true
+    max_velocity: 6.98
+    has_acceleration_limits: true
+    max_acceleration: 1.396
   joint_6:
     has_velocity_limits: true
     max_velocity: 10.47

--- a/fanuc_m10ia_moveit_config/config/ompl_planning.yaml
+++ b/fanuc_m10ia_moveit_config/config/ompl_planning.yaml
@@ -1,24 +1,55 @@
 planner_configs:
   SBLkConfigDefault:
     type: geometric::SBL
+    range: 0.0  # Max motion added to tree. ==> maxDistance_ default: 0.0, if 0.0, set on setup()
   ESTkConfigDefault:
     type: geometric::EST
+    range: 0.0  # Max motion added to tree. ==> maxDistance_ default: 0.0, if 0.0 setup()
+    goal_bias: 0.05  # When close to goal select goal, with this probability. default: 0.05
   LBKPIECEkConfigDefault:
     type: geometric::LBKPIECE
+    range: 0.0  # Max motion added to tree. ==> maxDistance_ default: 0.0, if 0.0, set on setup()
+    border_fraction: 0.9  # Fraction of time focused on boarder default: 0.9
+    min_valid_path_fraction: 0.5  # Accept partially valid moves above fraction. default: 0.5
   BKPIECEkConfigDefault:
     type: geometric::BKPIECE
+    range: 0.0  # Max motion added to tree. ==> maxDistance_ default: 0.0, if 0.0, set on setup()
+    border_fraction: 0.9  # Fraction of time focused on boarder default: 0.9
+    failed_expansion_score_factor: 0.5  # When extending motion fails, scale score by factor. default: 0.5
+    min_valid_path_fraction: 0.5  # Accept partially valid moves above fraction. default: 0.5
   KPIECEkConfigDefault:
     type: geometric::KPIECE
+    range: 0.0  # Max motion added to tree. ==> maxDistance_ default: 0.0, if 0.0, set on setup()
+    goal_bias: 0.05  # When close to goal select goal, with this probability. default: 0.05 
+    border_fraction: 0.9  # Fraction of time focused on boarder default: 0.9 (0.0,1.]
+    failed_expansion_score_factor: 0.5  # When extending motion fails, scale score by factor. default: 0.5
+    min_valid_path_fraction: 0.5  # Accept partially valid moves above fraction. default: 0.5
   RRTkConfigDefault:
     type: geometric::RRT
+    range: 0.0  # Max motion added to tree. ==> maxDistance_ default: 0.0, if 0.0, set on setup()
+    goal_bias: 0.05  # When close to goal select goal, with this probability? default: 0.05
   RRTConnectkConfigDefault:
     type: geometric::RRTConnect
+    range: 0.0  # Max motion added to tree. ==> maxDistance_ default: 0.0, if 0.0, set on setup()
   RRTstarkConfigDefault:
     type: geometric::RRTstar
+    range: 0.0  # Max motion added to tree. ==> maxDistance_ default: 0.0, if 0.0, set on setup()
+    goal_bias: 0.05  # When close to goal select goal, with this probability? default: 0.05
+    delay_collision_checking: 1  # Stop collision checking as soon as C-free parent found. default 1
   TRRTkConfigDefault:
     type: geometric::TRRT
+    range: 0.0  # Max motion added to tree. ==> maxDistance_ default: 0.0, if 0.0, set on setup()
+    goal_bias: 0.05  # When close to goal select goal, with this probability? default: 0.05
+    max_states_failed: 10  # when to start increasing temp. default: 10
+    temp_change_factor: 2.0  # how much to increase or decrease temp. default: 2.0
+    min_temperature: 10e-10  # lower limit of temp change. default: 10e-10
+    init_temperature: 10e-6  # initial temperature. default: 10e-6
+    frountier_threshold: 0.0  # dist new state to nearest neighbor to disqualify as frontier. default: 0.0 set in setup() 
+    frountierNodeRatio: 0.1  # 1/10, or 1 nonfrontier for every 10 frontier. default: 0.1
+    k_constant: 0.0  # value used to normalize expresssion. default: 0.0 set in setup()
   PRMkConfigDefault:
     type: geometric::PRM
+    max_nearest_neighbors: 10  # use k nearest neighbors. default: 10
   PRMstarkConfigDefault:
     type: geometric::PRMstar
 manipulator:

--- a/fanuc_m10ia_moveit_config/launch/default_warehouse_db.launch
+++ b/fanuc_m10ia_moveit_config/launch/default_warehouse_db.launch
@@ -1,11 +1,10 @@
 <launch>
 
   <arg name="reset" default="false"/>
-
   <!-- If not specified, we'll use a default database location -->
   <arg name="moveit_warehouse_database_path" default="$(find fanuc_m10ia_moveit_config)/default_warehouse_mongo_db" />
 
-  <!-- Launch the warehouse with a default database location -->  
+  <!-- Launch the warehouse with the configured database location -->
   <include file="$(find fanuc_m10ia_moveit_config)/launch/warehouse.launch">
     <arg name="moveit_warehouse_database_path" value="$(arg moveit_warehouse_database_path)" />
   </include>

--- a/fanuc_m10ia_moveit_config/launch/demo.launch
+++ b/fanuc_m10ia_moveit_config/launch/demo.launch
@@ -18,16 +18,16 @@
 
   <!-- We do not have a robot connected, so publish fake joint states -->
   <node name="joint_state_publisher" pkg="joint_state_publisher" type="joint_state_publisher">
-    <param name="/use_gui" value="false"/> 
+    <param name="/use_gui" value="false"/>
     <rosparam param="/source_list">[/move_group/fake_controller_joint_states]</rosparam>
   </node>
-  
+
   <!-- Given the published joint states, publish tf for the robot links -->
   <node name="robot_state_publisher" pkg="robot_state_publisher" type="robot_state_publisher" respawn="true" output="screen" />
 
   <!-- Run the main MoveIt executable without trajectory execution (we do not have controllers configured by default) -->
   <include file="$(find fanuc_m10ia_moveit_config)/launch/move_group.launch">
-    <arg name="allow_trajectory_execution" value="true"/>  
+    <arg name="allow_trajectory_execution" value="true"/>
     <arg name="fake_execution" value="true"/>
     <arg name="info" value="true"/>
     <arg name="debug" value="$(arg debug)"/>

--- a/fanuc_m10ia_moveit_config/launch/joystick_control.launch
+++ b/fanuc_m10ia_moveit_config/launch/joystick_control.launch
@@ -1,0 +1,17 @@
+<launch>
+  <!-- See moveit_ros/visualization/doc/joystick.rst for documentation -->
+
+  <arg name="dev" default="/dev/input/js0" />
+
+  <!-- Launch joy node -->
+  <node pkg="joy" type="joy_node" name="joy">
+    <param name="dev" value="$(arg dev)" /> <!-- Customize this to match the location your joystick is plugged in on-->
+    <param name="deadzone" value="0.2" />
+    <param name="autorepeat_rate" value="40" />
+    <param name="coalesce_interval" value="0.025" />
+  </node>
+
+  <!-- Launch python interface -->
+  <node pkg="moveit_ros_visualization" type="moveit_joy.py" output="screen" name="moveit_joy"/>
+        
+</launch>

--- a/fanuc_m10ia_moveit_config/launch/move_group.launch
+++ b/fanuc_m10ia_moveit_config/launch/move_group.launch
@@ -5,15 +5,16 @@
   <!-- GDB Debug Option -->
   <arg name="debug" default="false" />
   <arg unless="$(arg debug)" name="launch_prefix" value="" />
-  <arg     if="$(arg debug)" name="launch_prefix" value="gdb --ex run --args" />
+  <arg     if="$(arg debug)" name="launch_prefix"
+	   value="gdb -x $(find fanuc_m10ia_moveit_config)/launch/gdb_settings.gdb --ex run --args" />
 
   <!-- Verbose Mode Option -->
-  <arg name="info" default="$(arg debug)" />  
+  <arg name="info" default="$(arg debug)" />
   <arg unless="$(arg info)" name="command_args" value="" />
   <arg     if="$(arg info)" name="command_args" value="--debug" />
 
   <!-- move_group settings -->
-  <arg name="allow_trajectory_execution" default="true"/> 
+  <arg name="allow_trajectory_execution" default="true"/>
   <arg name="fake_execution" default="false"/>
   <arg name="max_safe_path_cost" default="1"/>
   <arg name="jiggle_fraction" default="0.05" />
@@ -33,7 +34,7 @@
 
   <!-- Sensors Functionality -->
   <include ns="move_group" file="$(find fanuc_m10ia_moveit_config)/launch/sensor_manager.launch.xml" if="$(arg allow_trajectory_execution)">
-    <arg name="moveit_sensor_manager" value="fanuc_m10ia" /> 
+    <arg name="moveit_sensor_manager" value="fanuc_m10ia" />
   </include>
 
   <!-- Start the actual move_group node/action server -->
@@ -55,6 +56,7 @@
 				      move_group/MoveGroupQueryPlannersService
 				      move_group/MoveGroupStateValidationService
 				      move_group/MoveGroupGetPlanningSceneService
+				      move_group/ClearOctomapService
 				      " />
 
     <!-- Publish the planning scene of the physical robot so that rviz plugin can know actual robot -->
@@ -63,5 +65,5 @@
     <param name="planning_scene_monitor/publish_state_updates" value="$(arg publish_monitored_planning_scene)" />
     <param name="planning_scene_monitor/publish_transforms_updates" value="$(arg publish_monitored_planning_scene)" />
   </node>
-  
+
 </launch>

--- a/fanuc_m16ib20_moveit_config/.setup_assistant
+++ b/fanuc_m16ib20_moveit_config/.setup_assistant
@@ -5,4 +5,4 @@ moveit_setup_assistant_config:
   SRDF:
     relative_path: config/fanuc_m16ib20.srdf
   CONFIG:
-    generated_timestamp: 1397057762
+    generated_timestamp: 1432404655

--- a/fanuc_m16ib20_moveit_config/config/fanuc_m16ib20.srdf
+++ b/fanuc_m16ib20_moveit_config/config/fanuc_m16ib20.srdf
@@ -25,6 +25,7 @@
     <virtual_joint name="FixedBase" type="fixed" parent_frame="world" child_link="base_link" />
     <!--DISABLE COLLISIONS: By default it is assumed that any link of the robot could potentially come into collision with any other link in the robot. This tag disables collision checking between a specified pair of links. -->
     <disable_collisions link1="base_link" link2="link_1" reason="Adjacent" />
+    <disable_collisions link1="base_link" link2="link_3" reason="Never" />
     <disable_collisions link1="link_1" link2="link_2" reason="Adjacent" />
     <disable_collisions link1="link_1" link2="link_3" reason="Never" />
     <disable_collisions link1="link_2" link2="link_3" reason="Adjacent" />

--- a/fanuc_m16ib20_moveit_config/config/joint_limits.yaml
+++ b/fanuc_m16ib20_moveit_config/config/joint_limits.yaml
@@ -1,14 +1,22 @@
+# joint_limits.yaml allows the dynamics properties specified in the URDF to be overwritten or augmented as needed
+# Specific joint properties can be changed with the keys [max_position, min_position, max_velocity, max_acceleration]
+# Joint limits can be turned off with [has_velocity_limits, has_acceleration_limits]
 joint_limits:
-  joint_3:
-    has_velocity_limits: true
-    max_velocity: 3.0543
-    has_acceleration_limits: true
-    max_acceleration: 0.61086
   joint_1:
     has_velocity_limits: true
     max_velocity: 2.8798
     has_acceleration_limits: true
     max_acceleration: 0.57596
+  joint_2:
+    has_velocity_limits: true
+    max_velocity: 2.8798
+    has_acceleration_limits: true
+    max_acceleration: 0.57596
+  joint_3:
+    has_velocity_limits: true
+    max_velocity: 3.0543
+    has_acceleration_limits: true
+    max_acceleration: 0.61086
   joint_4:
     has_velocity_limits: true
     max_velocity: 6.1087
@@ -19,11 +27,6 @@ joint_limits:
     max_velocity: 5.9341
     has_acceleration_limits: true
     max_acceleration: 1.18682
-  joint_2:
-    has_velocity_limits: true
-    max_velocity: 2.8798
-    has_acceleration_limits: true
-    max_acceleration: 0.57596
   joint_6:
     has_velocity_limits: true
     max_velocity: 9.0757

--- a/fanuc_m16ib20_moveit_config/config/ompl_planning.yaml
+++ b/fanuc_m16ib20_moveit_config/config/ompl_planning.yaml
@@ -1,24 +1,55 @@
 planner_configs:
   SBLkConfigDefault:
     type: geometric::SBL
+    range: 0.0  # Max motion added to tree. ==> maxDistance_ default: 0.0, if 0.0, set on setup()
   ESTkConfigDefault:
     type: geometric::EST
+    range: 0.0  # Max motion added to tree. ==> maxDistance_ default: 0.0, if 0.0 setup()
+    goal_bias: 0.05  # When close to goal select goal, with this probability. default: 0.05
   LBKPIECEkConfigDefault:
     type: geometric::LBKPIECE
+    range: 0.0  # Max motion added to tree. ==> maxDistance_ default: 0.0, if 0.0, set on setup()
+    border_fraction: 0.9  # Fraction of time focused on boarder default: 0.9
+    min_valid_path_fraction: 0.5  # Accept partially valid moves above fraction. default: 0.5
   BKPIECEkConfigDefault:
     type: geometric::BKPIECE
+    range: 0.0  # Max motion added to tree. ==> maxDistance_ default: 0.0, if 0.0, set on setup()
+    border_fraction: 0.9  # Fraction of time focused on boarder default: 0.9
+    failed_expansion_score_factor: 0.5  # When extending motion fails, scale score by factor. default: 0.5
+    min_valid_path_fraction: 0.5  # Accept partially valid moves above fraction. default: 0.5
   KPIECEkConfigDefault:
     type: geometric::KPIECE
+    range: 0.0  # Max motion added to tree. ==> maxDistance_ default: 0.0, if 0.0, set on setup()
+    goal_bias: 0.05  # When close to goal select goal, with this probability. default: 0.05 
+    border_fraction: 0.9  # Fraction of time focused on boarder default: 0.9 (0.0,1.]
+    failed_expansion_score_factor: 0.5  # When extending motion fails, scale score by factor. default: 0.5
+    min_valid_path_fraction: 0.5  # Accept partially valid moves above fraction. default: 0.5
   RRTkConfigDefault:
     type: geometric::RRT
+    range: 0.0  # Max motion added to tree. ==> maxDistance_ default: 0.0, if 0.0, set on setup()
+    goal_bias: 0.05  # When close to goal select goal, with this probability? default: 0.05
   RRTConnectkConfigDefault:
     type: geometric::RRTConnect
+    range: 0.0  # Max motion added to tree. ==> maxDistance_ default: 0.0, if 0.0, set on setup()
   RRTstarkConfigDefault:
     type: geometric::RRTstar
+    range: 0.0  # Max motion added to tree. ==> maxDistance_ default: 0.0, if 0.0, set on setup()
+    goal_bias: 0.05  # When close to goal select goal, with this probability? default: 0.05
+    delay_collision_checking: 1  # Stop collision checking as soon as C-free parent found. default 1
   TRRTkConfigDefault:
     type: geometric::TRRT
+    range: 0.0  # Max motion added to tree. ==> maxDistance_ default: 0.0, if 0.0, set on setup()
+    goal_bias: 0.05  # When close to goal select goal, with this probability? default: 0.05
+    max_states_failed: 10  # when to start increasing temp. default: 10
+    temp_change_factor: 2.0  # how much to increase or decrease temp. default: 2.0
+    min_temperature: 10e-10  # lower limit of temp change. default: 10e-10
+    init_temperature: 10e-6  # initial temperature. default: 10e-6
+    frountier_threshold: 0.0  # dist new state to nearest neighbor to disqualify as frontier. default: 0.0 set in setup() 
+    frountierNodeRatio: 0.1  # 1/10, or 1 nonfrontier for every 10 frontier. default: 0.1
+    k_constant: 0.0  # value used to normalize expresssion. default: 0.0 set in setup()
   PRMkConfigDefault:
     type: geometric::PRM
+    max_nearest_neighbors: 10  # use k nearest neighbors. default: 10
   PRMstarkConfigDefault:
     type: geometric::PRMstar
 manipulator:

--- a/fanuc_m16ib20_moveit_config/launch/default_warehouse_db.launch
+++ b/fanuc_m16ib20_moveit_config/launch/default_warehouse_db.launch
@@ -1,11 +1,10 @@
 <launch>
 
   <arg name="reset" default="false"/>
-
   <!-- If not specified, we'll use a default database location -->
   <arg name="moveit_warehouse_database_path" default="$(find fanuc_m16ib20_moveit_config)/default_warehouse_mongo_db" />
 
-  <!-- Launch the warehouse with a default database location -->  
+  <!-- Launch the warehouse with the configured database location -->
   <include file="$(find fanuc_m16ib20_moveit_config)/launch/warehouse.launch">
     <arg name="moveit_warehouse_database_path" value="$(arg moveit_warehouse_database_path)" />
   </include>

--- a/fanuc_m16ib20_moveit_config/launch/demo.launch
+++ b/fanuc_m16ib20_moveit_config/launch/demo.launch
@@ -18,16 +18,16 @@
 
   <!-- We do not have a robot connected, so publish fake joint states -->
   <node name="joint_state_publisher" pkg="joint_state_publisher" type="joint_state_publisher">
-    <param name="/use_gui" value="false"/> 
+    <param name="/use_gui" value="false"/>
     <rosparam param="/source_list">[/move_group/fake_controller_joint_states]</rosparam>
   </node>
-  
+
   <!-- Given the published joint states, publish tf for the robot links -->
   <node name="robot_state_publisher" pkg="robot_state_publisher" type="robot_state_publisher" respawn="true" output="screen" />
 
   <!-- Run the main MoveIt executable without trajectory execution (we do not have controllers configured by default) -->
   <include file="$(find fanuc_m16ib20_moveit_config)/launch/move_group.launch">
-    <arg name="allow_trajectory_execution" value="true"/>  
+    <arg name="allow_trajectory_execution" value="true"/>
     <arg name="fake_execution" value="true"/>
     <arg name="info" value="true"/>
     <arg name="debug" value="$(arg debug)"/>

--- a/fanuc_m16ib20_moveit_config/launch/joystick_control.launch
+++ b/fanuc_m16ib20_moveit_config/launch/joystick_control.launch
@@ -1,0 +1,17 @@
+<launch>
+  <!-- See moveit_ros/visualization/doc/joystick.rst for documentation -->
+
+  <arg name="dev" default="/dev/input/js0" />
+
+  <!-- Launch joy node -->
+  <node pkg="joy" type="joy_node" name="joy">
+    <param name="dev" value="$(arg dev)" /> <!-- Customize this to match the location your joystick is plugged in on-->
+    <param name="deadzone" value="0.2" />
+    <param name="autorepeat_rate" value="40" />
+    <param name="coalesce_interval" value="0.025" />
+  </node>
+
+  <!-- Launch python interface -->
+  <node pkg="moveit_ros_visualization" type="moveit_joy.py" output="screen" name="moveit_joy"/>
+        
+</launch>

--- a/fanuc_m16ib20_moveit_config/launch/move_group.launch
+++ b/fanuc_m16ib20_moveit_config/launch/move_group.launch
@@ -5,15 +5,16 @@
   <!-- GDB Debug Option -->
   <arg name="debug" default="false" />
   <arg unless="$(arg debug)" name="launch_prefix" value="" />
-  <arg     if="$(arg debug)" name="launch_prefix" value="gdb --ex run --args" />
+  <arg     if="$(arg debug)" name="launch_prefix"
+	   value="gdb -x $(find fanuc_m16ib20_moveit_config)/launch/gdb_settings.gdb --ex run --args" />
 
   <!-- Verbose Mode Option -->
-  <arg name="info" default="$(arg debug)" />  
+  <arg name="info" default="$(arg debug)" />
   <arg unless="$(arg info)" name="command_args" value="" />
   <arg     if="$(arg info)" name="command_args" value="--debug" />
 
   <!-- move_group settings -->
-  <arg name="allow_trajectory_execution" default="true"/> 
+  <arg name="allow_trajectory_execution" default="true"/>
   <arg name="fake_execution" default="false"/>
   <arg name="max_safe_path_cost" default="1"/>
   <arg name="jiggle_fraction" default="0.05" />
@@ -33,7 +34,7 @@
 
   <!-- Sensors Functionality -->
   <include ns="move_group" file="$(find fanuc_m16ib20_moveit_config)/launch/sensor_manager.launch.xml" if="$(arg allow_trajectory_execution)">
-    <arg name="moveit_sensor_manager" value="fanuc_m16ib20" /> 
+    <arg name="moveit_sensor_manager" value="fanuc_m16ib20" />
   </include>
 
   <!-- Start the actual move_group node/action server -->
@@ -55,6 +56,7 @@
 				      move_group/MoveGroupQueryPlannersService
 				      move_group/MoveGroupStateValidationService
 				      move_group/MoveGroupGetPlanningSceneService
+				      move_group/ClearOctomapService
 				      " />
 
     <!-- Publish the planning scene of the physical robot so that rviz plugin can know actual robot -->
@@ -63,5 +65,5 @@
     <param name="planning_scene_monitor/publish_state_updates" value="$(arg publish_monitored_planning_scene)" />
     <param name="planning_scene_monitor/publish_transforms_updates" value="$(arg publish_monitored_planning_scene)" />
   </node>
-  
+
 </launch>

--- a/fanuc_m20ia10l_moveit_config/.setup_assistant
+++ b/fanuc_m20ia10l_moveit_config/.setup_assistant
@@ -5,4 +5,4 @@ moveit_setup_assistant_config:
   SRDF:
     relative_path: config/fanuc_m20ia10l.srdf
   CONFIG:
-    generated_timestamp: 1398165472
+    generated_timestamp: 1432417026

--- a/fanuc_m20ia10l_moveit_config/config/joint_limits.yaml
+++ b/fanuc_m20ia10l_moveit_config/config/joint_limits.yaml
@@ -1,31 +1,34 @@
+# joint_limits.yaml allows the dynamics properties specified in the URDF to be overwritten or augmented as needed
+# Specific joint properties can be changed with the keys [max_position, min_position, max_velocity, max_acceleration]
+# Joint limits can be turned off with [has_velocity_limits, has_acceleration_limits]
 joint_limits:
-  joint_5:
-    has_velocity_limits: true
-    max_velocity: 6.981317
-    has_acceleration_limits: true
-    max_acceleration: 1.3962634
-  joint_2:
-    has_velocity_limits: true
-    max_velocity: 3.054326
-    has_acceleration_limits: true
-    max_acceleration: 0.6108652
-  joint_6:
-    has_velocity_limits: true
-    max_velocity: 10.47198
-    has_acceleration_limits: true
-    max_acceleration: 2.094396
-  joint_4:
-    has_velocity_limits: true
-    max_velocity: 6.981317
-    has_acceleration_limits: true
-    max_acceleration: 1.3962634
-  joint_3:
-    has_velocity_limits: true
-    max_velocity: 3.141593
-    has_acceleration_limits: true
-    max_acceleration: 0.6283186
   joint_1:
     has_velocity_limits: true
     max_velocity: 3.403392
     has_acceleration_limits: true
     max_acceleration: 0.6806784
+  joint_2:
+    has_velocity_limits: true
+    max_velocity: 3.054326
+    has_acceleration_limits: true
+    max_acceleration: 0.6108652
+  joint_3:
+    has_velocity_limits: true
+    max_velocity: 3.141593
+    has_acceleration_limits: true
+    max_acceleration: 0.6283186
+  joint_4:
+    has_velocity_limits: true
+    max_velocity: 6.981317
+    has_acceleration_limits: true
+    max_acceleration: 1.3962634
+  joint_5:
+    has_velocity_limits: true
+    max_velocity: 6.981317
+    has_acceleration_limits: true
+    max_acceleration: 1.3962634
+  joint_6:
+    has_velocity_limits: true
+    max_velocity: 10.47198
+    has_acceleration_limits: true
+    max_acceleration: 2.094396

--- a/fanuc_m20ia10l_moveit_config/config/ompl_planning.yaml
+++ b/fanuc_m20ia10l_moveit_config/config/ompl_planning.yaml
@@ -1,24 +1,55 @@
 planner_configs:
   SBLkConfigDefault:
     type: geometric::SBL
+    range: 0.0  # Max motion added to tree. ==> maxDistance_ default: 0.0, if 0.0, set on setup()
   ESTkConfigDefault:
     type: geometric::EST
+    range: 0.0  # Max motion added to tree. ==> maxDistance_ default: 0.0, if 0.0 setup()
+    goal_bias: 0.05  # When close to goal select goal, with this probability. default: 0.05
   LBKPIECEkConfigDefault:
     type: geometric::LBKPIECE
+    range: 0.0  # Max motion added to tree. ==> maxDistance_ default: 0.0, if 0.0, set on setup()
+    border_fraction: 0.9  # Fraction of time focused on boarder default: 0.9
+    min_valid_path_fraction: 0.5  # Accept partially valid moves above fraction. default: 0.5
   BKPIECEkConfigDefault:
     type: geometric::BKPIECE
+    range: 0.0  # Max motion added to tree. ==> maxDistance_ default: 0.0, if 0.0, set on setup()
+    border_fraction: 0.9  # Fraction of time focused on boarder default: 0.9
+    failed_expansion_score_factor: 0.5  # When extending motion fails, scale score by factor. default: 0.5
+    min_valid_path_fraction: 0.5  # Accept partially valid moves above fraction. default: 0.5
   KPIECEkConfigDefault:
     type: geometric::KPIECE
+    range: 0.0  # Max motion added to tree. ==> maxDistance_ default: 0.0, if 0.0, set on setup()
+    goal_bias: 0.05  # When close to goal select goal, with this probability. default: 0.05 
+    border_fraction: 0.9  # Fraction of time focused on boarder default: 0.9 (0.0,1.]
+    failed_expansion_score_factor: 0.5  # When extending motion fails, scale score by factor. default: 0.5
+    min_valid_path_fraction: 0.5  # Accept partially valid moves above fraction. default: 0.5
   RRTkConfigDefault:
     type: geometric::RRT
+    range: 0.0  # Max motion added to tree. ==> maxDistance_ default: 0.0, if 0.0, set on setup()
+    goal_bias: 0.05  # When close to goal select goal, with this probability? default: 0.05
   RRTConnectkConfigDefault:
     type: geometric::RRTConnect
+    range: 0.0  # Max motion added to tree. ==> maxDistance_ default: 0.0, if 0.0, set on setup()
   RRTstarkConfigDefault:
     type: geometric::RRTstar
+    range: 0.0  # Max motion added to tree. ==> maxDistance_ default: 0.0, if 0.0, set on setup()
+    goal_bias: 0.05  # When close to goal select goal, with this probability? default: 0.05
+    delay_collision_checking: 1  # Stop collision checking as soon as C-free parent found. default 1
   TRRTkConfigDefault:
     type: geometric::TRRT
+    range: 0.0  # Max motion added to tree. ==> maxDistance_ default: 0.0, if 0.0, set on setup()
+    goal_bias: 0.05  # When close to goal select goal, with this probability? default: 0.05
+    max_states_failed: 10  # when to start increasing temp. default: 10
+    temp_change_factor: 2.0  # how much to increase or decrease temp. default: 2.0
+    min_temperature: 10e-10  # lower limit of temp change. default: 10e-10
+    init_temperature: 10e-6  # initial temperature. default: 10e-6
+    frountier_threshold: 0.0  # dist new state to nearest neighbor to disqualify as frontier. default: 0.0 set in setup() 
+    frountierNodeRatio: 0.1  # 1/10, or 1 nonfrontier for every 10 frontier. default: 0.1
+    k_constant: 0.0  # value used to normalize expresssion. default: 0.0 set in setup()
   PRMkConfigDefault:
     type: geometric::PRM
+    max_nearest_neighbors: 10  # use k nearest neighbors. default: 10
   PRMstarkConfigDefault:
     type: geometric::PRMstar
 manipulator:

--- a/fanuc_m20ia10l_moveit_config/launch/default_warehouse_db.launch
+++ b/fanuc_m20ia10l_moveit_config/launch/default_warehouse_db.launch
@@ -1,11 +1,10 @@
 <launch>
 
   <arg name="reset" default="false"/>
-
   <!-- If not specified, we'll use a default database location -->
   <arg name="moveit_warehouse_database_path" default="$(find fanuc_m20ia10l_moveit_config)/default_warehouse_mongo_db" />
 
-  <!-- Launch the warehouse with a default database location -->  
+  <!-- Launch the warehouse with the configured database location -->
   <include file="$(find fanuc_m20ia10l_moveit_config)/launch/warehouse.launch">
     <arg name="moveit_warehouse_database_path" value="$(arg moveit_warehouse_database_path)" />
   </include>

--- a/fanuc_m20ia10l_moveit_config/launch/demo.launch
+++ b/fanuc_m20ia10l_moveit_config/launch/demo.launch
@@ -18,16 +18,16 @@
 
   <!-- We do not have a robot connected, so publish fake joint states -->
   <node name="joint_state_publisher" pkg="joint_state_publisher" type="joint_state_publisher">
-    <param name="/use_gui" value="false"/> 
+    <param name="/use_gui" value="false"/>
     <rosparam param="/source_list">[/move_group/fake_controller_joint_states]</rosparam>
   </node>
-  
+
   <!-- Given the published joint states, publish tf for the robot links -->
   <node name="robot_state_publisher" pkg="robot_state_publisher" type="robot_state_publisher" respawn="true" output="screen" />
 
   <!-- Run the main MoveIt executable without trajectory execution (we do not have controllers configured by default) -->
   <include file="$(find fanuc_m20ia10l_moveit_config)/launch/move_group.launch">
-    <arg name="allow_trajectory_execution" value="true"/>  
+    <arg name="allow_trajectory_execution" value="true"/>
     <arg name="fake_execution" value="true"/>
     <arg name="info" value="true"/>
     <arg name="debug" value="$(arg debug)"/>

--- a/fanuc_m20ia10l_moveit_config/launch/joystick_control.launch
+++ b/fanuc_m20ia10l_moveit_config/launch/joystick_control.launch
@@ -1,0 +1,17 @@
+<launch>
+  <!-- See moveit_ros/visualization/doc/joystick.rst for documentation -->
+
+  <arg name="dev" default="/dev/input/js0" />
+
+  <!-- Launch joy node -->
+  <node pkg="joy" type="joy_node" name="joy">
+    <param name="dev" value="$(arg dev)" /> <!-- Customize this to match the location your joystick is plugged in on-->
+    <param name="deadzone" value="0.2" />
+    <param name="autorepeat_rate" value="40" />
+    <param name="coalesce_interval" value="0.025" />
+  </node>
+
+  <!-- Launch python interface -->
+  <node pkg="moveit_ros_visualization" type="moveit_joy.py" output="screen" name="moveit_joy"/>
+        
+</launch>

--- a/fanuc_m20ia10l_moveit_config/launch/move_group.launch
+++ b/fanuc_m20ia10l_moveit_config/launch/move_group.launch
@@ -5,15 +5,16 @@
   <!-- GDB Debug Option -->
   <arg name="debug" default="false" />
   <arg unless="$(arg debug)" name="launch_prefix" value="" />
-  <arg     if="$(arg debug)" name="launch_prefix" value="gdb --ex run --args" />
+  <arg     if="$(arg debug)" name="launch_prefix"
+	   value="gdb -x $(find fanuc_m20ia10l_moveit_config)/launch/gdb_settings.gdb --ex run --args" />
 
   <!-- Verbose Mode Option -->
-  <arg name="info" default="$(arg debug)" />  
+  <arg name="info" default="$(arg debug)" />
   <arg unless="$(arg info)" name="command_args" value="" />
   <arg     if="$(arg info)" name="command_args" value="--debug" />
 
   <!-- move_group settings -->
-  <arg name="allow_trajectory_execution" default="true"/> 
+  <arg name="allow_trajectory_execution" default="true"/>
   <arg name="fake_execution" default="false"/>
   <arg name="max_safe_path_cost" default="1"/>
   <arg name="jiggle_fraction" default="0.05" />
@@ -33,7 +34,7 @@
 
   <!-- Sensors Functionality -->
   <include ns="move_group" file="$(find fanuc_m20ia10l_moveit_config)/launch/sensor_manager.launch.xml" if="$(arg allow_trajectory_execution)">
-    <arg name="moveit_sensor_manager" value="fanuc_m20ia10l" /> 
+    <arg name="moveit_sensor_manager" value="fanuc_m20ia10l" />
   </include>
 
   <!-- Start the actual move_group node/action server -->
@@ -55,6 +56,7 @@
 				      move_group/MoveGroupQueryPlannersService
 				      move_group/MoveGroupStateValidationService
 				      move_group/MoveGroupGetPlanningSceneService
+				      move_group/ClearOctomapService
 				      " />
 
     <!-- Publish the planning scene of the physical robot so that rviz plugin can know actual robot -->
@@ -63,5 +65,5 @@
     <param name="planning_scene_monitor/publish_state_updates" value="$(arg publish_monitored_planning_scene)" />
     <param name="planning_scene_monitor/publish_transforms_updates" value="$(arg publish_monitored_planning_scene)" />
   </node>
-  
+
 </launch>

--- a/fanuc_m20ia_moveit_config/.setup_assistant
+++ b/fanuc_m20ia_moveit_config/.setup_assistant
@@ -5,4 +5,4 @@ moveit_setup_assistant_config:
   SRDF:
     relative_path: config/fanuc_m20ia.srdf
   CONFIG:
-    generated_timestamp: 1398164855
+    generated_timestamp: 1432415611

--- a/fanuc_m20ia_moveit_config/config/joint_limits.yaml
+++ b/fanuc_m20ia_moveit_config/config/joint_limits.yaml
@@ -1,31 +1,34 @@
+# joint_limits.yaml allows the dynamics properties specified in the URDF to be overwritten or augmented as needed
+# Specific joint properties can be changed with the keys [max_position, min_position, max_velocity, max_acceleration]
+# Joint limits can be turned off with [has_velocity_limits, has_acceleration_limits]
 joint_limits:
-  joint_5:
-    has_velocity_limits: true
-    max_velocity: 6.283185
-    has_acceleration_limits: true
-    max_acceleration: 1.256637
-  joint_3:
-    has_velocity_limits: true
-    max_velocity: 3.141593
-    has_acceleration_limits: true
-    max_acceleration: 0.6283186
-  joint_2:
-    has_velocity_limits: true
-    max_velocity: 3.054326
-    has_acceleration_limits: true
-    max_acceleration: 0.6108652
   joint_1:
     has_velocity_limits: true
     max_velocity: 3.403392
     has_acceleration_limits: true
     max_acceleration: 0.6806784
-  joint_6:
+  joint_2:
     has_velocity_limits: true
-    max_velocity: 9.599311
+    max_velocity: 3.054326
     has_acceleration_limits: true
-    max_acceleration: 1.9198622
+    max_acceleration: 0.6108652
+  joint_3:
+    has_velocity_limits: true
+    max_velocity: 3.141593
+    has_acceleration_limits: true
+    max_acceleration: 0.6283186
   joint_4:
     has_velocity_limits: true
     max_velocity: 6.283185
     has_acceleration_limits: true
     max_acceleration: 1.256637
+  joint_5:
+    has_velocity_limits: true
+    max_velocity: 6.283185
+    has_acceleration_limits: true
+    max_acceleration: 1.256637
+  joint_6:
+    has_velocity_limits: true
+    max_velocity: 9.599311
+    has_acceleration_limits: true
+    max_acceleration: 1.9198622

--- a/fanuc_m20ia_moveit_config/config/ompl_planning.yaml
+++ b/fanuc_m20ia_moveit_config/config/ompl_planning.yaml
@@ -1,24 +1,55 @@
 planner_configs:
   SBLkConfigDefault:
     type: geometric::SBL
+    range: 0.0  # Max motion added to tree. ==> maxDistance_ default: 0.0, if 0.0, set on setup()
   ESTkConfigDefault:
     type: geometric::EST
+    range: 0.0  # Max motion added to tree. ==> maxDistance_ default: 0.0, if 0.0 setup()
+    goal_bias: 0.05  # When close to goal select goal, with this probability. default: 0.05
   LBKPIECEkConfigDefault:
     type: geometric::LBKPIECE
+    range: 0.0  # Max motion added to tree. ==> maxDistance_ default: 0.0, if 0.0, set on setup()
+    border_fraction: 0.9  # Fraction of time focused on boarder default: 0.9
+    min_valid_path_fraction: 0.5  # Accept partially valid moves above fraction. default: 0.5
   BKPIECEkConfigDefault:
     type: geometric::BKPIECE
+    range: 0.0  # Max motion added to tree. ==> maxDistance_ default: 0.0, if 0.0, set on setup()
+    border_fraction: 0.9  # Fraction of time focused on boarder default: 0.9
+    failed_expansion_score_factor: 0.5  # When extending motion fails, scale score by factor. default: 0.5
+    min_valid_path_fraction: 0.5  # Accept partially valid moves above fraction. default: 0.5
   KPIECEkConfigDefault:
     type: geometric::KPIECE
+    range: 0.0  # Max motion added to tree. ==> maxDistance_ default: 0.0, if 0.0, set on setup()
+    goal_bias: 0.05  # When close to goal select goal, with this probability. default: 0.05 
+    border_fraction: 0.9  # Fraction of time focused on boarder default: 0.9 (0.0,1.]
+    failed_expansion_score_factor: 0.5  # When extending motion fails, scale score by factor. default: 0.5
+    min_valid_path_fraction: 0.5  # Accept partially valid moves above fraction. default: 0.5
   RRTkConfigDefault:
     type: geometric::RRT
+    range: 0.0  # Max motion added to tree. ==> maxDistance_ default: 0.0, if 0.0, set on setup()
+    goal_bias: 0.05  # When close to goal select goal, with this probability? default: 0.05
   RRTConnectkConfigDefault:
     type: geometric::RRTConnect
+    range: 0.0  # Max motion added to tree. ==> maxDistance_ default: 0.0, if 0.0, set on setup()
   RRTstarkConfigDefault:
     type: geometric::RRTstar
+    range: 0.0  # Max motion added to tree. ==> maxDistance_ default: 0.0, if 0.0, set on setup()
+    goal_bias: 0.05  # When close to goal select goal, with this probability? default: 0.05
+    delay_collision_checking: 1  # Stop collision checking as soon as C-free parent found. default 1
   TRRTkConfigDefault:
     type: geometric::TRRT
+    range: 0.0  # Max motion added to tree. ==> maxDistance_ default: 0.0, if 0.0, set on setup()
+    goal_bias: 0.05  # When close to goal select goal, with this probability? default: 0.05
+    max_states_failed: 10  # when to start increasing temp. default: 10
+    temp_change_factor: 2.0  # how much to increase or decrease temp. default: 2.0
+    min_temperature: 10e-10  # lower limit of temp change. default: 10e-10
+    init_temperature: 10e-6  # initial temperature. default: 10e-6
+    frountier_threshold: 0.0  # dist new state to nearest neighbor to disqualify as frontier. default: 0.0 set in setup() 
+    frountierNodeRatio: 0.1  # 1/10, or 1 nonfrontier for every 10 frontier. default: 0.1
+    k_constant: 0.0  # value used to normalize expresssion. default: 0.0 set in setup()
   PRMkConfigDefault:
     type: geometric::PRM
+    max_nearest_neighbors: 10  # use k nearest neighbors. default: 10
   PRMstarkConfigDefault:
     type: geometric::PRMstar
 manipulator:

--- a/fanuc_m20ia_moveit_config/launch/default_warehouse_db.launch
+++ b/fanuc_m20ia_moveit_config/launch/default_warehouse_db.launch
@@ -1,11 +1,10 @@
 <launch>
 
   <arg name="reset" default="false"/>
-
   <!-- If not specified, we'll use a default database location -->
   <arg name="moveit_warehouse_database_path" default="$(find fanuc_m20ia_moveit_config)/default_warehouse_mongo_db" />
 
-  <!-- Launch the warehouse with a default database location -->  
+  <!-- Launch the warehouse with the configured database location -->
   <include file="$(find fanuc_m20ia_moveit_config)/launch/warehouse.launch">
     <arg name="moveit_warehouse_database_path" value="$(arg moveit_warehouse_database_path)" />
   </include>

--- a/fanuc_m20ia_moveit_config/launch/demo.launch
+++ b/fanuc_m20ia_moveit_config/launch/demo.launch
@@ -18,16 +18,16 @@
 
   <!-- We do not have a robot connected, so publish fake joint states -->
   <node name="joint_state_publisher" pkg="joint_state_publisher" type="joint_state_publisher">
-    <param name="/use_gui" value="false"/> 
+    <param name="/use_gui" value="false"/>
     <rosparam param="/source_list">[/move_group/fake_controller_joint_states]</rosparam>
   </node>
-  
+
   <!-- Given the published joint states, publish tf for the robot links -->
   <node name="robot_state_publisher" pkg="robot_state_publisher" type="robot_state_publisher" respawn="true" output="screen" />
 
   <!-- Run the main MoveIt executable without trajectory execution (we do not have controllers configured by default) -->
   <include file="$(find fanuc_m20ia_moveit_config)/launch/move_group.launch">
-    <arg name="allow_trajectory_execution" value="true"/>  
+    <arg name="allow_trajectory_execution" value="true"/>
     <arg name="fake_execution" value="true"/>
     <arg name="info" value="true"/>
     <arg name="debug" value="$(arg debug)"/>

--- a/fanuc_m20ia_moveit_config/launch/joystick_control.launch
+++ b/fanuc_m20ia_moveit_config/launch/joystick_control.launch
@@ -1,0 +1,17 @@
+<launch>
+  <!-- See moveit_ros/visualization/doc/joystick.rst for documentation -->
+
+  <arg name="dev" default="/dev/input/js0" />
+
+  <!-- Launch joy node -->
+  <node pkg="joy" type="joy_node" name="joy">
+    <param name="dev" value="$(arg dev)" /> <!-- Customize this to match the location your joystick is plugged in on-->
+    <param name="deadzone" value="0.2" />
+    <param name="autorepeat_rate" value="40" />
+    <param name="coalesce_interval" value="0.025" />
+  </node>
+
+  <!-- Launch python interface -->
+  <node pkg="moveit_ros_visualization" type="moveit_joy.py" output="screen" name="moveit_joy"/>
+        
+</launch>

--- a/fanuc_m20ia_moveit_config/launch/move_group.launch
+++ b/fanuc_m20ia_moveit_config/launch/move_group.launch
@@ -5,15 +5,16 @@
   <!-- GDB Debug Option -->
   <arg name="debug" default="false" />
   <arg unless="$(arg debug)" name="launch_prefix" value="" />
-  <arg     if="$(arg debug)" name="launch_prefix" value="gdb --ex run --args" />
+  <arg     if="$(arg debug)" name="launch_prefix"
+	   value="gdb -x $(find fanuc_m20ia_moveit_config)/launch/gdb_settings.gdb --ex run --args" />
 
   <!-- Verbose Mode Option -->
-  <arg name="info" default="$(arg debug)" />  
+  <arg name="info" default="$(arg debug)" />
   <arg unless="$(arg info)" name="command_args" value="" />
   <arg     if="$(arg info)" name="command_args" value="--debug" />
 
   <!-- move_group settings -->
-  <arg name="allow_trajectory_execution" default="true"/> 
+  <arg name="allow_trajectory_execution" default="true"/>
   <arg name="fake_execution" default="false"/>
   <arg name="max_safe_path_cost" default="1"/>
   <arg name="jiggle_fraction" default="0.05" />
@@ -33,7 +34,7 @@
 
   <!-- Sensors Functionality -->
   <include ns="move_group" file="$(find fanuc_m20ia_moveit_config)/launch/sensor_manager.launch.xml" if="$(arg allow_trajectory_execution)">
-    <arg name="moveit_sensor_manager" value="fanuc_m20ia" /> 
+    <arg name="moveit_sensor_manager" value="fanuc_m20ia" />
   </include>
 
   <!-- Start the actual move_group node/action server -->
@@ -55,6 +56,7 @@
 				      move_group/MoveGroupQueryPlannersService
 				      move_group/MoveGroupStateValidationService
 				      move_group/MoveGroupGetPlanningSceneService
+				      move_group/ClearOctomapService
 				      " />
 
     <!-- Publish the planning scene of the physical robot so that rviz plugin can know actual robot -->
@@ -63,5 +65,5 @@
     <param name="planning_scene_monitor/publish_state_updates" value="$(arg publish_monitored_planning_scene)" />
     <param name="planning_scene_monitor/publish_transforms_updates" value="$(arg publish_monitored_planning_scene)" />
   </node>
-  
+
 </launch>

--- a/fanuc_m430ia2f_moveit_config/.setup_assistant
+++ b/fanuc_m430ia2f_moveit_config/.setup_assistant
@@ -5,4 +5,4 @@ moveit_setup_assistant_config:
   SRDF:
     relative_path: config/fanuc_m430ia2f.srdf
   CONFIG:
-    generated_timestamp: 1397209284
+    generated_timestamp: 1432417246

--- a/fanuc_m430ia2f_moveit_config/config/joint_limits.yaml
+++ b/fanuc_m430ia2f_moveit_config/config/joint_limits.yaml
@@ -1,14 +1,12 @@
+# joint_limits.yaml allows the dynamics properties specified in the URDF to be overwritten or augmented as needed
+# Specific joint properties can be changed with the keys [max_position, min_position, max_velocity, max_acceleration]
+# Joint limits can be turned off with [has_velocity_limits, has_acceleration_limits]
 joint_limits:
   joint_1:
     has_velocity_limits: true
     max_velocity: 5.24
     has_acceleration_limits: true
     max_acceleration: 1.048
-  joint_4:
-    has_velocity_limits: true
-    max_velocity: 6.28
-    has_acceleration_limits: true
-    max_acceleration: 1.256
   joint_2:
     has_velocity_limits: true
     max_velocity: 5.59
@@ -19,6 +17,11 @@ joint_limits:
     max_velocity: 5.59
     has_acceleration_limits: true
     max_acceleration: 1.118
+  joint_4:
+    has_velocity_limits: true
+    max_velocity: 6.28
+    has_acceleration_limits: true
+    max_acceleration: 1.256
   joint_5:
     has_velocity_limits: true
     max_velocity: 20.94

--- a/fanuc_m430ia2f_moveit_config/config/ompl_planning.yaml
+++ b/fanuc_m430ia2f_moveit_config/config/ompl_planning.yaml
@@ -1,24 +1,55 @@
 planner_configs:
   SBLkConfigDefault:
     type: geometric::SBL
+    range: 0.0  # Max motion added to tree. ==> maxDistance_ default: 0.0, if 0.0, set on setup()
   ESTkConfigDefault:
     type: geometric::EST
+    range: 0.0  # Max motion added to tree. ==> maxDistance_ default: 0.0, if 0.0 setup()
+    goal_bias: 0.05  # When close to goal select goal, with this probability. default: 0.05
   LBKPIECEkConfigDefault:
     type: geometric::LBKPIECE
+    range: 0.0  # Max motion added to tree. ==> maxDistance_ default: 0.0, if 0.0, set on setup()
+    border_fraction: 0.9  # Fraction of time focused on boarder default: 0.9
+    min_valid_path_fraction: 0.5  # Accept partially valid moves above fraction. default: 0.5
   BKPIECEkConfigDefault:
     type: geometric::BKPIECE
+    range: 0.0  # Max motion added to tree. ==> maxDistance_ default: 0.0, if 0.0, set on setup()
+    border_fraction: 0.9  # Fraction of time focused on boarder default: 0.9
+    failed_expansion_score_factor: 0.5  # When extending motion fails, scale score by factor. default: 0.5
+    min_valid_path_fraction: 0.5  # Accept partially valid moves above fraction. default: 0.5
   KPIECEkConfigDefault:
     type: geometric::KPIECE
+    range: 0.0  # Max motion added to tree. ==> maxDistance_ default: 0.0, if 0.0, set on setup()
+    goal_bias: 0.05  # When close to goal select goal, with this probability. default: 0.05 
+    border_fraction: 0.9  # Fraction of time focused on boarder default: 0.9 (0.0,1.]
+    failed_expansion_score_factor: 0.5  # When extending motion fails, scale score by factor. default: 0.5
+    min_valid_path_fraction: 0.5  # Accept partially valid moves above fraction. default: 0.5
   RRTkConfigDefault:
     type: geometric::RRT
+    range: 0.0  # Max motion added to tree. ==> maxDistance_ default: 0.0, if 0.0, set on setup()
+    goal_bias: 0.05  # When close to goal select goal, with this probability? default: 0.05
   RRTConnectkConfigDefault:
     type: geometric::RRTConnect
+    range: 0.0  # Max motion added to tree. ==> maxDistance_ default: 0.0, if 0.0, set on setup()
   RRTstarkConfigDefault:
     type: geometric::RRTstar
+    range: 0.0  # Max motion added to tree. ==> maxDistance_ default: 0.0, if 0.0, set on setup()
+    goal_bias: 0.05  # When close to goal select goal, with this probability? default: 0.05
+    delay_collision_checking: 1  # Stop collision checking as soon as C-free parent found. default 1
   TRRTkConfigDefault:
     type: geometric::TRRT
+    range: 0.0  # Max motion added to tree. ==> maxDistance_ default: 0.0, if 0.0, set on setup()
+    goal_bias: 0.05  # When close to goal select goal, with this probability? default: 0.05
+    max_states_failed: 10  # when to start increasing temp. default: 10
+    temp_change_factor: 2.0  # how much to increase or decrease temp. default: 2.0
+    min_temperature: 10e-10  # lower limit of temp change. default: 10e-10
+    init_temperature: 10e-6  # initial temperature. default: 10e-6
+    frountier_threshold: 0.0  # dist new state to nearest neighbor to disqualify as frontier. default: 0.0 set in setup() 
+    frountierNodeRatio: 0.1  # 1/10, or 1 nonfrontier for every 10 frontier. default: 0.1
+    k_constant: 0.0  # value used to normalize expresssion. default: 0.0 set in setup()
   PRMkConfigDefault:
     type: geometric::PRM
+    max_nearest_neighbors: 10  # use k nearest neighbors. default: 10
   PRMstarkConfigDefault:
     type: geometric::PRMstar
 manipulator:

--- a/fanuc_m430ia2f_moveit_config/launch/default_warehouse_db.launch
+++ b/fanuc_m430ia2f_moveit_config/launch/default_warehouse_db.launch
@@ -1,11 +1,10 @@
 <launch>
 
   <arg name="reset" default="false"/>
-
   <!-- If not specified, we'll use a default database location -->
   <arg name="moveit_warehouse_database_path" default="$(find fanuc_m430ia2f_moveit_config)/default_warehouse_mongo_db" />
 
-  <!-- Launch the warehouse with a default database location -->  
+  <!-- Launch the warehouse with the configured database location -->
   <include file="$(find fanuc_m430ia2f_moveit_config)/launch/warehouse.launch">
     <arg name="moveit_warehouse_database_path" value="$(arg moveit_warehouse_database_path)" />
   </include>

--- a/fanuc_m430ia2f_moveit_config/launch/demo.launch
+++ b/fanuc_m430ia2f_moveit_config/launch/demo.launch
@@ -18,16 +18,16 @@
 
   <!-- We do not have a robot connected, so publish fake joint states -->
   <node name="joint_state_publisher" pkg="joint_state_publisher" type="joint_state_publisher">
-    <param name="/use_gui" value="false"/> 
+    <param name="/use_gui" value="false"/>
     <rosparam param="/source_list">[/move_group/fake_controller_joint_states]</rosparam>
   </node>
-  
+
   <!-- Given the published joint states, publish tf for the robot links -->
   <node name="robot_state_publisher" pkg="robot_state_publisher" type="robot_state_publisher" respawn="true" output="screen" />
 
   <!-- Run the main MoveIt executable without trajectory execution (we do not have controllers configured by default) -->
   <include file="$(find fanuc_m430ia2f_moveit_config)/launch/move_group.launch">
-    <arg name="allow_trajectory_execution" value="true"/>  
+    <arg name="allow_trajectory_execution" value="true"/>
     <arg name="fake_execution" value="true"/>
     <arg name="info" value="true"/>
     <arg name="debug" value="$(arg debug)"/>

--- a/fanuc_m430ia2f_moveit_config/launch/joystick_control.launch
+++ b/fanuc_m430ia2f_moveit_config/launch/joystick_control.launch
@@ -1,0 +1,17 @@
+<launch>
+  <!-- See moveit_ros/visualization/doc/joystick.rst for documentation -->
+
+  <arg name="dev" default="/dev/input/js0" />
+
+  <!-- Launch joy node -->
+  <node pkg="joy" type="joy_node" name="joy">
+    <param name="dev" value="$(arg dev)" /> <!-- Customize this to match the location your joystick is plugged in on-->
+    <param name="deadzone" value="0.2" />
+    <param name="autorepeat_rate" value="40" />
+    <param name="coalesce_interval" value="0.025" />
+  </node>
+
+  <!-- Launch python interface -->
+  <node pkg="moveit_ros_visualization" type="moveit_joy.py" output="screen" name="moveit_joy"/>
+        
+</launch>

--- a/fanuc_m430ia2f_moveit_config/launch/move_group.launch
+++ b/fanuc_m430ia2f_moveit_config/launch/move_group.launch
@@ -5,15 +5,16 @@
   <!-- GDB Debug Option -->
   <arg name="debug" default="false" />
   <arg unless="$(arg debug)" name="launch_prefix" value="" />
-  <arg     if="$(arg debug)" name="launch_prefix" value="gdb --ex run --args" />
+  <arg     if="$(arg debug)" name="launch_prefix"
+	   value="gdb -x $(find fanuc_m430ia2f_moveit_config)/launch/gdb_settings.gdb --ex run --args" />
 
   <!-- Verbose Mode Option -->
-  <arg name="info" default="$(arg debug)" />  
+  <arg name="info" default="$(arg debug)" />
   <arg unless="$(arg info)" name="command_args" value="" />
   <arg     if="$(arg info)" name="command_args" value="--debug" />
 
   <!-- move_group settings -->
-  <arg name="allow_trajectory_execution" default="true"/> 
+  <arg name="allow_trajectory_execution" default="true"/>
   <arg name="fake_execution" default="false"/>
   <arg name="max_safe_path_cost" default="1"/>
   <arg name="jiggle_fraction" default="0.05" />
@@ -33,7 +34,7 @@
 
   <!-- Sensors Functionality -->
   <include ns="move_group" file="$(find fanuc_m430ia2f_moveit_config)/launch/sensor_manager.launch.xml" if="$(arg allow_trajectory_execution)">
-    <arg name="moveit_sensor_manager" value="fanuc_m430ia2f" /> 
+    <arg name="moveit_sensor_manager" value="fanuc_m430ia2f" />
   </include>
 
   <!-- Start the actual move_group node/action server -->
@@ -55,6 +56,7 @@
 				      move_group/MoveGroupQueryPlannersService
 				      move_group/MoveGroupStateValidationService
 				      move_group/MoveGroupGetPlanningSceneService
+				      move_group/ClearOctomapService
 				      " />
 
     <!-- Publish the planning scene of the physical robot so that rviz plugin can know actual robot -->
@@ -63,5 +65,5 @@
     <param name="planning_scene_monitor/publish_state_updates" value="$(arg publish_monitored_planning_scene)" />
     <param name="planning_scene_monitor/publish_transforms_updates" value="$(arg publish_monitored_planning_scene)" />
   </node>
-  
+
 </launch>

--- a/fanuc_m430ia2p_moveit_config/.setup_assistant
+++ b/fanuc_m430ia2p_moveit_config/.setup_assistant
@@ -5,4 +5,4 @@ moveit_setup_assistant_config:
   SRDF:
     relative_path: config/fanuc_m430ia2p.srdf
   CONFIG:
-    generated_timestamp: 1399474201
+    generated_timestamp: 1432417424

--- a/fanuc_m430ia2p_moveit_config/config/joint_limits.yaml
+++ b/fanuc_m430ia2p_moveit_config/config/joint_limits.yaml
@@ -1,31 +1,34 @@
+# joint_limits.yaml allows the dynamics properties specified in the URDF to be overwritten or augmented as needed
+# Specific joint properties can be changed with the keys [max_position, min_position, max_velocity, max_acceleration]
+# Joint limits can be turned off with [has_velocity_limits, has_acceleration_limits]
 joint_limits:
-  joint_4:
-    has_velocity_limits: true
-    max_velocity: 5.24
-    has_acceleration_limits: true
-    max_acceleration: 1.048
   joint_1:
     has_velocity_limits: true
     max_velocity: 5.24
     has_acceleration_limits: true
     max_acceleration: 1.048
-  joint_3:
-    has_velocity_limits: true
-    max_velocity: 5.93
-    has_acceleration_limits: true
-    max_acceleration: 1.186
   joint_2:
     has_velocity_limits: true
     max_velocity: 5.59
     has_acceleration_limits: true
     max_acceleration: 1.118
-  joint_6:
+  joint_3:
     has_velocity_limits: true
-    max_velocity: 12.57
+    max_velocity: 5.93
     has_acceleration_limits: true
-    max_acceleration: 2.514
+    max_acceleration: 1.186
+  joint_4:
+    has_velocity_limits: true
+    max_velocity: 5.24
+    has_acceleration_limits: true
+    max_acceleration: 1.048
   joint_5:
     has_velocity_limits: true
     max_velocity: 5.24
     has_acceleration_limits: true
     max_acceleration: 1.048
+  joint_6:
+    has_velocity_limits: true
+    max_velocity: 12.57
+    has_acceleration_limits: true
+    max_acceleration: 2.514

--- a/fanuc_m430ia2p_moveit_config/config/ompl_planning.yaml
+++ b/fanuc_m430ia2p_moveit_config/config/ompl_planning.yaml
@@ -1,24 +1,55 @@
 planner_configs:
   SBLkConfigDefault:
     type: geometric::SBL
+    range: 0.0  # Max motion added to tree. ==> maxDistance_ default: 0.0, if 0.0, set on setup()
   ESTkConfigDefault:
     type: geometric::EST
+    range: 0.0  # Max motion added to tree. ==> maxDistance_ default: 0.0, if 0.0 setup()
+    goal_bias: 0.05  # When close to goal select goal, with this probability. default: 0.05
   LBKPIECEkConfigDefault:
     type: geometric::LBKPIECE
+    range: 0.0  # Max motion added to tree. ==> maxDistance_ default: 0.0, if 0.0, set on setup()
+    border_fraction: 0.9  # Fraction of time focused on boarder default: 0.9
+    min_valid_path_fraction: 0.5  # Accept partially valid moves above fraction. default: 0.5
   BKPIECEkConfigDefault:
     type: geometric::BKPIECE
+    range: 0.0  # Max motion added to tree. ==> maxDistance_ default: 0.0, if 0.0, set on setup()
+    border_fraction: 0.9  # Fraction of time focused on boarder default: 0.9
+    failed_expansion_score_factor: 0.5  # When extending motion fails, scale score by factor. default: 0.5
+    min_valid_path_fraction: 0.5  # Accept partially valid moves above fraction. default: 0.5
   KPIECEkConfigDefault:
     type: geometric::KPIECE
+    range: 0.0  # Max motion added to tree. ==> maxDistance_ default: 0.0, if 0.0, set on setup()
+    goal_bias: 0.05  # When close to goal select goal, with this probability. default: 0.05 
+    border_fraction: 0.9  # Fraction of time focused on boarder default: 0.9 (0.0,1.]
+    failed_expansion_score_factor: 0.5  # When extending motion fails, scale score by factor. default: 0.5
+    min_valid_path_fraction: 0.5  # Accept partially valid moves above fraction. default: 0.5
   RRTkConfigDefault:
     type: geometric::RRT
+    range: 0.0  # Max motion added to tree. ==> maxDistance_ default: 0.0, if 0.0, set on setup()
+    goal_bias: 0.05  # When close to goal select goal, with this probability? default: 0.05
   RRTConnectkConfigDefault:
     type: geometric::RRTConnect
+    range: 0.0  # Max motion added to tree. ==> maxDistance_ default: 0.0, if 0.0, set on setup()
   RRTstarkConfigDefault:
     type: geometric::RRTstar
+    range: 0.0  # Max motion added to tree. ==> maxDistance_ default: 0.0, if 0.0, set on setup()
+    goal_bias: 0.05  # When close to goal select goal, with this probability? default: 0.05
+    delay_collision_checking: 1  # Stop collision checking as soon as C-free parent found. default 1
   TRRTkConfigDefault:
     type: geometric::TRRT
+    range: 0.0  # Max motion added to tree. ==> maxDistance_ default: 0.0, if 0.0, set on setup()
+    goal_bias: 0.05  # When close to goal select goal, with this probability? default: 0.05
+    max_states_failed: 10  # when to start increasing temp. default: 10
+    temp_change_factor: 2.0  # how much to increase or decrease temp. default: 2.0
+    min_temperature: 10e-10  # lower limit of temp change. default: 10e-10
+    init_temperature: 10e-6  # initial temperature. default: 10e-6
+    frountier_threshold: 0.0  # dist new state to nearest neighbor to disqualify as frontier. default: 0.0 set in setup() 
+    frountierNodeRatio: 0.1  # 1/10, or 1 nonfrontier for every 10 frontier. default: 0.1
+    k_constant: 0.0  # value used to normalize expresssion. default: 0.0 set in setup()
   PRMkConfigDefault:
     type: geometric::PRM
+    max_nearest_neighbors: 10  # use k nearest neighbors. default: 10
   PRMstarkConfigDefault:
     type: geometric::PRMstar
 manipulator:

--- a/fanuc_m430ia2p_moveit_config/launch/default_warehouse_db.launch
+++ b/fanuc_m430ia2p_moveit_config/launch/default_warehouse_db.launch
@@ -1,11 +1,10 @@
 <launch>
 
   <arg name="reset" default="false"/>
-
   <!-- If not specified, we'll use a default database location -->
   <arg name="moveit_warehouse_database_path" default="$(find fanuc_m430ia2p_moveit_config)/default_warehouse_mongo_db" />
 
-  <!-- Launch the warehouse with a default database location -->  
+  <!-- Launch the warehouse with the configured database location -->
   <include file="$(find fanuc_m430ia2p_moveit_config)/launch/warehouse.launch">
     <arg name="moveit_warehouse_database_path" value="$(arg moveit_warehouse_database_path)" />
   </include>

--- a/fanuc_m430ia2p_moveit_config/launch/demo.launch
+++ b/fanuc_m430ia2p_moveit_config/launch/demo.launch
@@ -18,16 +18,16 @@
 
   <!-- We do not have a robot connected, so publish fake joint states -->
   <node name="joint_state_publisher" pkg="joint_state_publisher" type="joint_state_publisher">
-    <param name="/use_gui" value="false"/> 
+    <param name="/use_gui" value="false"/>
     <rosparam param="/source_list">[/move_group/fake_controller_joint_states]</rosparam>
   </node>
-  
+
   <!-- Given the published joint states, publish tf for the robot links -->
   <node name="robot_state_publisher" pkg="robot_state_publisher" type="robot_state_publisher" respawn="true" output="screen" />
 
   <!-- Run the main MoveIt executable without trajectory execution (we do not have controllers configured by default) -->
   <include file="$(find fanuc_m430ia2p_moveit_config)/launch/move_group.launch">
-    <arg name="allow_trajectory_execution" value="true"/>  
+    <arg name="allow_trajectory_execution" value="true"/>
     <arg name="fake_execution" value="true"/>
     <arg name="info" value="true"/>
     <arg name="debug" value="$(arg debug)"/>

--- a/fanuc_m430ia2p_moveit_config/launch/joystick_control.launch
+++ b/fanuc_m430ia2p_moveit_config/launch/joystick_control.launch
@@ -1,0 +1,17 @@
+<launch>
+  <!-- See moveit_ros/visualization/doc/joystick.rst for documentation -->
+
+  <arg name="dev" default="/dev/input/js0" />
+
+  <!-- Launch joy node -->
+  <node pkg="joy" type="joy_node" name="joy">
+    <param name="dev" value="$(arg dev)" /> <!-- Customize this to match the location your joystick is plugged in on-->
+    <param name="deadzone" value="0.2" />
+    <param name="autorepeat_rate" value="40" />
+    <param name="coalesce_interval" value="0.025" />
+  </node>
+
+  <!-- Launch python interface -->
+  <node pkg="moveit_ros_visualization" type="moveit_joy.py" output="screen" name="moveit_joy"/>
+        
+</launch>

--- a/fanuc_m430ia2p_moveit_config/launch/move_group.launch
+++ b/fanuc_m430ia2p_moveit_config/launch/move_group.launch
@@ -5,15 +5,16 @@
   <!-- GDB Debug Option -->
   <arg name="debug" default="false" />
   <arg unless="$(arg debug)" name="launch_prefix" value="" />
-  <arg     if="$(arg debug)" name="launch_prefix" value="gdb --ex run --args" />
+  <arg     if="$(arg debug)" name="launch_prefix"
+	   value="gdb -x $(find fanuc_m430ia2p_moveit_config)/launch/gdb_settings.gdb --ex run --args" />
 
   <!-- Verbose Mode Option -->
-  <arg name="info" default="$(arg debug)" />  
+  <arg name="info" default="$(arg debug)" />
   <arg unless="$(arg info)" name="command_args" value="" />
   <arg     if="$(arg info)" name="command_args" value="--debug" />
 
   <!-- move_group settings -->
-  <arg name="allow_trajectory_execution" default="true"/> 
+  <arg name="allow_trajectory_execution" default="true"/>
   <arg name="fake_execution" default="false"/>
   <arg name="max_safe_path_cost" default="1"/>
   <arg name="jiggle_fraction" default="0.05" />
@@ -33,7 +34,7 @@
 
   <!-- Sensors Functionality -->
   <include ns="move_group" file="$(find fanuc_m430ia2p_moveit_config)/launch/sensor_manager.launch.xml" if="$(arg allow_trajectory_execution)">
-    <arg name="moveit_sensor_manager" value="fanuc_m430ia2p" /> 
+    <arg name="moveit_sensor_manager" value="fanuc_m430ia2p" />
   </include>
 
   <!-- Start the actual move_group node/action server -->
@@ -55,6 +56,7 @@
 				      move_group/MoveGroupQueryPlannersService
 				      move_group/MoveGroupStateValidationService
 				      move_group/MoveGroupGetPlanningSceneService
+				      move_group/ClearOctomapService
 				      " />
 
     <!-- Publish the planning scene of the physical robot so that rviz plugin can know actual robot -->
@@ -63,5 +65,5 @@
     <param name="planning_scene_monitor/publish_state_updates" value="$(arg publish_monitored_planning_scene)" />
     <param name="planning_scene_monitor/publish_transforms_updates" value="$(arg publish_monitored_planning_scene)" />
   </node>
-  
+
 </launch>


### PR DESCRIPTION
As per title.

This includes adding the 'joystick control' launch files, 'clear octomap' capability, comments in all config files and some comments in launch files.

Apart from M-16iB/20 (`link_3` added to `disabled` column in collision db), no changes to planning infrastructure or configuration data, so I don't expect any effect on the correct functioning of these pkgs.
