### PR TITLE
Alternative 'fix' for issue #156: document potential poor performance with LBKPIECE1

### DIFF
--- a/fanuc_lrmate200ic5h_moveit_config/readme.md
+++ b/fanuc_lrmate200ic5h_moveit_config/readme.md
@@ -5,6 +5,12 @@
 This package is part of the [ROS-Industrial][] program. See the main [fanuc][]
 page on the ROS wiki for more information on usage.
 
+## Known issues - poor planning performance
+
+Please see the [known issues][] page on the ROS wiki.
+
+
 
 [ROS-Industrial]: http://wiki.ros.org/Industrial
 [fanuc]: http://wiki.ros.org/fanuc
+[known issues]: http://wiki.ros.org/fanuc/indigo/known_issues

--- a/fanuc_lrmate200ic5l_moveit_config/readme.md
+++ b/fanuc_lrmate200ic5l_moveit_config/readme.md
@@ -5,6 +5,12 @@
 This package is part of the [ROS-Industrial][] program. See the main [fanuc][]
 page on the ROS wiki for more information on usage.
 
+## Known issues - poor planning performance
+
+Please see the [known issues][] page on the ROS wiki.
+
+
 
 [ROS-Industrial]: http://wiki.ros.org/Industrial
 [fanuc]: http://wiki.ros.org/fanuc
+[known issues]: http://wiki.ros.org/fanuc/indigo/known_issues

--- a/fanuc_lrmate200ic_moveit_config/readme.md
+++ b/fanuc_lrmate200ic_moveit_config/readme.md
@@ -5,6 +5,12 @@
 This package is part of the [ROS-Industrial][] program. See the main [fanuc][]
 page on the ROS wiki for more information on usage.
 
+## Known issues - poor planning performance
+
+Please see the [known issues][] page on the ROS wiki.
+
+
 
 [ROS-Industrial]: http://wiki.ros.org/Industrial
 [fanuc]: http://wiki.ros.org/fanuc
+[known issues]: http://wiki.ros.org/fanuc/indigo/known_issues

--- a/fanuc_m10ia_moveit_config/readme.md
+++ b/fanuc_m10ia_moveit_config/readme.md
@@ -5,6 +5,12 @@
 This package is part of the [ROS-Industrial][] program. See the main [fanuc][]
 page on the ROS wiki for more information on usage.
 
+## Known issues - poor planning performance
+
+Please see the [known issues][] page on the ROS wiki.
+
+
 
 [ROS-Industrial]: http://wiki.ros.org/Industrial
 [fanuc]: http://wiki.ros.org/fanuc
+[known issues]: http://wiki.ros.org/fanuc/indigo/known_issues

--- a/fanuc_m16ib20_moveit_config/readme.md
+++ b/fanuc_m16ib20_moveit_config/readme.md
@@ -5,6 +5,12 @@
 This package is part of the [ROS-Industrial][] program. See the main [fanuc][]
 page on the ROS wiki for more information on usage.
 
+## Known issues - poor planning performance
+
+Please see the [known issues][] page on the ROS wiki.
+
+
 
 [ROS-Industrial]: http://wiki.ros.org/Industrial
 [fanuc]: http://wiki.ros.org/fanuc
+[known issues]: http://wiki.ros.org/fanuc/indigo/known_issues

--- a/fanuc_m20ia10l_moveit_config/readme.md
+++ b/fanuc_m20ia10l_moveit_config/readme.md
@@ -5,6 +5,12 @@
 This package is part of the [ROS-Industrial][] program. See the main [fanuc][]
 page on the ROS wiki for more information on usage.
 
+## Known issues - poor planning performance
+
+Please see the [known issues][] page on the ROS wiki.
+
+
 
 [ROS-Industrial]: http://wiki.ros.org/Industrial
 [fanuc]: http://wiki.ros.org/fanuc
+[known issues]: http://wiki.ros.org/fanuc/indigo/known_issues

--- a/fanuc_m20ia_moveit_config/readme.md
+++ b/fanuc_m20ia_moveit_config/readme.md
@@ -5,6 +5,12 @@
 This package is part of the [ROS-Industrial][] program. See the main [fanuc][]
 page on the ROS wiki for more information on usage.
 
+## Known issues - poor planning performance
+
+Please see the [known issues][] page on the ROS wiki.
+
+
 
 [ROS-Industrial]: http://wiki.ros.org/Industrial
 [fanuc]: http://wiki.ros.org/fanuc
+[known issues]: http://wiki.ros.org/fanuc/indigo/known_issues

--- a/fanuc_m430ia2f_moveit_config/readme.md
+++ b/fanuc_m430ia2f_moveit_config/readme.md
@@ -5,6 +5,12 @@
 This package is part of the [ROS-Industrial][] program. See the main [fanuc][]
 page on the ROS wiki for more information on usage.
 
+## Known issues - poor planning performance
+
+Please see the [known issues][] page on the ROS wiki.
+
+
 
 [ROS-Industrial]: http://wiki.ros.org/Industrial
 [fanuc]: http://wiki.ros.org/fanuc
+[known issues]: http://wiki.ros.org/fanuc/indigo/known_issues

--- a/fanuc_m430ia2p_moveit_config/readme.md
+++ b/fanuc_m430ia2p_moveit_config/readme.md
@@ -5,6 +5,12 @@
 This package is part of the [ROS-Industrial][] program. See the main [fanuc][]
 page on the ROS wiki for more information on usage.
 
+## Known issues - poor planning performance
+
+Please see the [known issues][] page on the ROS wiki.
+
+
 
 [ROS-Industrial]: http://wiki.ros.org/Industrial
 [fanuc]: http://wiki.ros.org/fanuc
+[known issues]: http://wiki.ros.org/fanuc/indigo/known_issues


### PR DESCRIPTION
As I've not received any reports of poor planning performance with the MoveIt configurations in either the `fanuc` or the `fanuc_experimental` repository, I've opted to document the issue in the per-pkg `readme.md`, instead of removing the `projection_evaluator` entry from `ompl_planning.yaml`.

I've referred users to the relevant issue (ros-industrial/universal_robot#193) as well as provided two possible solutions / work-arounds (`planning attempts = 1` and using `RRTConnect`).
