### PR TITLE
readme: update link to devel job (new buildfarm).

### DIFF
--- a/readme.md
+++ b/readme.md
@@ -1,6 +1,6 @@
 # Fanuc
 
-[![Build Status](http://jenkins.ros.org/job/devel-indigo-fanuc/badge/icon)](http://jenkins.ros.org/job/devel-indigo-fanuc/)
+[![Build Status](http://build.ros.org/job/Idev__fanuc__ubuntu_trusty_amd64/badge/icon)](http://build.ros.org/job/Idev__fanuc__ubuntu_trusty_amd64)
 
 [ROS-Industrial][] Fanuc meta-package. See the [ROS wiki][] page for more
 information.


### PR DESCRIPTION
As per subject.

With the move to the new buildfarm, the old links have gone stale. This PR fixes that.
