### PR TITLE
Xacro indent

### DIFF
--- a/fanuc_lrmate200ic_support/urdf/lrmate200ic.xacro
+++ b/fanuc_lrmate200ic_support/urdf/lrmate200ic.xacro
@@ -1,5 +1,5 @@
 <?xml version="1.0" ?>
 <robot name="fanuc_lrmate200ic" xmlns:xacro="http://ros.org/wiki/xacro">
-  <xacro:include filename="$(find fanuc_lrmate200ic_support)/urdf/lrmate200ic_macro.xacro"/>
-  <xacro:fanuc_lrmate200ic prefix=""/>
+    <xacro:include filename="$(find fanuc_lrmate200ic_support)/urdf/lrmate200ic_macro.xacro"/>
+    <xacro:fanuc_lrmate200ic prefix=""/>
 </robot>

--- a/fanuc_lrmate200ic_support/urdf/lrmate200ic5f.xacro
+++ b/fanuc_lrmate200ic_support/urdf/lrmate200ic5f.xacro
@@ -1,5 +1,5 @@
 <?xml version="1.0" ?>
 <robot name="fanuc_lrmate200ic5f" xmlns:xacro="http://ros.org/wiki/xacro">
-  <xacro:include filename="$(find fanuc_lrmate200ic_support)/urdf/lrmate200ic5f_macro.xacro"/>
-  <xacro:fanuc_lrmate200ic5f prefix=""/>
+    <xacro:include filename="$(find fanuc_lrmate200ic_support)/urdf/lrmate200ic5f_macro.xacro"/>
+    <xacro:fanuc_lrmate200ic5f prefix=""/>
 </robot>

--- a/fanuc_lrmate200ic_support/urdf/lrmate200ic5f_macro.xacro
+++ b/fanuc_lrmate200ic_support/urdf/lrmate200ic5f_macro.xacro
@@ -1,148 +1,148 @@
 <?xml version="1.0" ?>
 <robot xmlns:xacro="http://ros.org/wiki/xacro">
-  <xacro:include filename="$(find fanuc_resources)/urdf/common_materials.xacro"/>
-  <xacro:include filename="$(find fanuc_resources)/urdf/common_constants.xacro"/>
+    <xacro:include filename="$(find fanuc_resources)/urdf/common_materials.xacro"/>
+    <xacro:include filename="$(find fanuc_resources)/urdf/common_constants.xacro"/>
 
-  <xacro:macro name="fanuc_lrmate200ic5f" params="prefix">
-    <link name="${prefix}base_link">
-      <visual>
-        <origin xyz="0 0 0" rpy="0 0 0" />
-        <geometry>
-          <mesh filename="package://fanuc_lrmate200ic_support/meshes/lrmate200ic/visual/base_link.stl" />
-        </geometry>
-        <xacro:material_fanuc_gray24 />
-      </visual>
-      <collision>
-        <origin xyz="0 0 0" rpy="0 0 0" />
-        <geometry>
-          <mesh filename="package://fanuc_lrmate200ic_support/meshes/lrmate200ic/collision/base_link.stl" />
-        </geometry>
-      </collision>
-    </link>
-    <link name="${prefix}link_1">
-      <visual>
-        <origin xyz="0 0 0" rpy="0 0 0" />
-        <geometry>
-          <mesh filename="package://fanuc_lrmate200ic_support/meshes/lrmate200ic/visual/link_1.stl" />
-        </geometry>
-        <xacro:material_fanuc_yellow />
-      </visual>
-      <collision>
-        <origin xyz="0 0 0" rpy="0 0 0" />
-        <geometry>
-          <mesh filename="package://fanuc_lrmate200ic_support/meshes/lrmate200ic/collision/link_1.stl" />
-        </geometry>
-      </collision>
-    </link>
-    <link name="${prefix}link_2">
-      <visual>
-        <origin xyz="0 0 0" rpy="0 0 0" />
-        <geometry>
-          <mesh filename="package://fanuc_lrmate200ic_support/meshes/lrmate200ic/visual/link_2.stl" />
-        </geometry>
-        <xacro:material_fanuc_yellow />
-      </visual>
-      <collision>
-        <origin xyz="0 0 0" rpy="0 0 0" />
-        <geometry>
-          <mesh filename="package://fanuc_lrmate200ic_support/meshes/lrmate200ic/collision/link_2.stl" />
-        </geometry>
-      </collision>
-    </link>
-    <link name="${prefix}link_3">
-      <visual>
-        <origin xyz="0 0 0" rpy="0 0 0" />
-        <geometry>
-          <mesh filename="package://fanuc_lrmate200ic_support/meshes/lrmate200ic5h/visual/link_3.stl" />
-        </geometry>
-        <xacro:material_fanuc_yellow />
-      </visual>
-      <collision>
-        <origin xyz="0 0 0" rpy="0 0 0" />
-        <geometry>
-          <mesh filename="package://fanuc_lrmate200ic_support/meshes/lrmate200ic5h/collision/link_3.stl" />
-        </geometry>
-      </collision>
-    </link>
-    <link name="${prefix}link_4">
-      <visual>
-        <origin xyz="0 0 0" rpy="0 0 0" />
-        <geometry>
-          <mesh filename="package://fanuc_lrmate200ic_support/meshes/lrmate200ic/visual/link_5.stl" />
-        </geometry>
-        <xacro:material_fanuc_yellow />
-      </visual>
-      <collision>
-        <origin xyz="0 0 0" rpy="0 0 0" />
-        <geometry>
-          <mesh filename="package://fanuc_lrmate200ic_support/meshes/lrmate200ic/collision/link_5.stl" />
-        </geometry>
-      </collision>
-    </link>
-    <link name="${prefix}link_5">
-      <visual>
-        <origin xyz="0 0 0" rpy="0 0 0"/>
-        <geometry>
-          <mesh filename="package://fanuc_lrmate200ic_support/meshes/lrmate200ic/visual/link_6.stl" />
-        </geometry>
-        <xacro:material_fanuc_black />
-      </visual>
-      <collision>
-        <origin xyz="0 0 0" rpy="0 0 0"/>
-        <geometry>
-          <mesh filename="package://fanuc_lrmate200ic_support/meshes/lrmate200ic/collision/link_6.stl" />
-        </geometry>
-      </collision>
-    </link>
-    <link name="${prefix}tool0" />
+    <xacro:macro name="fanuc_lrmate200ic5f" params="prefix">
+        <link name="${prefix}base_link">
+            <visual>
+                <origin xyz="0 0 0" rpy="0 0 0" />
+                <geometry>
+                    <mesh filename="package://fanuc_lrmate200ic_support/meshes/lrmate200ic/visual/base_link.stl" />
+                </geometry>
+                <xacro:material_fanuc_gray24 />
+            </visual>
+            <collision>
+                <origin xyz="0 0 0" rpy="0 0 0" />
+                <geometry>
+                    <mesh filename="package://fanuc_lrmate200ic_support/meshes/lrmate200ic/collision/base_link.stl" />
+                </geometry>
+            </collision>
+        </link>
+        <link name="${prefix}link_1">
+            <visual>
+                <origin xyz="0 0 0" rpy="0 0 0" />
+                <geometry>
+                    <mesh filename="package://fanuc_lrmate200ic_support/meshes/lrmate200ic/visual/link_1.stl" />
+                </geometry>
+                <xacro:material_fanuc_yellow />
+            </visual>
+            <collision>
+                <origin xyz="0 0 0" rpy="0 0 0" />
+                <geometry>
+                    <mesh filename="package://fanuc_lrmate200ic_support/meshes/lrmate200ic/collision/link_1.stl" />
+                </geometry>
+            </collision>
+        </link>
+        <link name="${prefix}link_2">
+            <visual>
+                <origin xyz="0 0 0" rpy="0 0 0" />
+                <geometry>
+                    <mesh filename="package://fanuc_lrmate200ic_support/meshes/lrmate200ic/visual/link_2.stl" />
+                </geometry>
+                <xacro:material_fanuc_yellow />
+            </visual>
+            <collision>
+                <origin xyz="0 0 0" rpy="0 0 0" />
+                <geometry>
+                    <mesh filename="package://fanuc_lrmate200ic_support/meshes/lrmate200ic/collision/link_2.stl" />
+                </geometry>
+            </collision>
+        </link>
+        <link name="${prefix}link_3">
+            <visual>
+                <origin xyz="0 0 0" rpy="0 0 0" />
+                <geometry>
+                    <mesh filename="package://fanuc_lrmate200ic_support/meshes/lrmate200ic5h/visual/link_3.stl" />
+                </geometry>
+                <xacro:material_fanuc_yellow />
+            </visual>
+            <collision>
+                <origin xyz="0 0 0" rpy="0 0 0" />
+                <geometry>
+                    <mesh filename="package://fanuc_lrmate200ic_support/meshes/lrmate200ic5h/collision/link_3.stl" />
+                </geometry>
+            </collision>
+        </link>
+        <link name="${prefix}link_4">
+            <visual>
+                <origin xyz="0 0 0" rpy="0 0 0" />
+                <geometry>
+                    <mesh filename="package://fanuc_lrmate200ic_support/meshes/lrmate200ic/visual/link_5.stl" />
+                </geometry>
+                <xacro:material_fanuc_yellow />
+            </visual>
+            <collision>
+                <origin xyz="0 0 0" rpy="0 0 0" />
+                <geometry>
+                    <mesh filename="package://fanuc_lrmate200ic_support/meshes/lrmate200ic/collision/link_5.stl" />
+                </geometry>
+            </collision>
+        </link>
+        <link name="${prefix}link_5">
+            <visual>
+                <origin xyz="0 0 0" rpy="0 0 0"/>
+                <geometry>
+                    <mesh filename="package://fanuc_lrmate200ic_support/meshes/lrmate200ic/visual/link_6.stl" />
+                </geometry>
+                <xacro:material_fanuc_black />
+            </visual>
+            <collision>
+                <origin xyz="0 0 0" rpy="0 0 0"/>
+                <geometry>
+                    <mesh filename="package://fanuc_lrmate200ic_support/meshes/lrmate200ic/collision/link_6.stl" />
+                </geometry>
+            </collision>
+        </link>
+        <link name="${prefix}tool0" />
 
-    <joint name="${prefix}joint_1" type="revolute">
-      <origin xyz="0 0 0.330" rpy="0 0 0" />
-      <parent link="${prefix}base_link" />
-      <child link="${prefix}link_1" />
-      <axis xyz="0 0 1" />
-      <limit effort="0" lower="-2.9671" upper="2.9671" velocity="6.1087" />
-    </joint>
-    <joint name="${prefix}joint_2" type="revolute">
-      <origin xyz="0.075 0 0" rpy="0 0 0" />
-      <parent link="${prefix}link_1" />
-      <child link="${prefix}link_2" />
-      <axis xyz="0 1 0" />
-      <limit effort="0" lower="-1.0472" upper="2.4435" velocity="6.1087" />
-    </joint>
-    <joint name="${prefix}joint_3" type="revolute">
-      <origin xyz="0 0 0.300" rpy="0 0 0" />
-      <parent link="${prefix}link_2" />
-      <child link="${prefix}link_3" />
-      <axis xyz="0 -1 0" />
-      <limit effort="0" lower="-2.4784" upper="4.0143" velocity="6.9813" />
-    </joint>
-    <joint name="${prefix}joint_4" type="revolute">
-      <origin xyz="0.3275 0 0.075" rpy="0 0 0" />
-      <parent link="${prefix}link_3" />
-      <child link="${prefix}link_4" />
-      <axis xyz="0 -1 0" />
-      <limit effort="0" lower="-2.0944" upper="2.0944" velocity="7.8540" />
-    </joint>
-    <joint name="${prefix}joint_5" type="revolute">
-      <origin xyz="0.080 0 0" rpy="0 0 0" />
-      <parent link="${prefix}link_4" />
-      <child link="${prefix}link_5" />
-      <axis xyz="-1 0 0" />
-      <limit effort="0" lower="-6.285" upper="6.285" velocity="20.94395" />
-    </joint>
-    <joint name="${prefix}joint_5-tool0" type="fixed">
-      <origin xyz="0 0 0" rpy="${m_pi} ${-m_pi_2} 0" />
-      <parent link="${prefix}link_5" />
-      <child link="${prefix}tool0" />
-    </joint>
+        <joint name="${prefix}joint_1" type="revolute">
+            <origin xyz="0 0 0.330" rpy="0 0 0" />
+            <parent link="${prefix}base_link" />
+            <child link="${prefix}link_1" />
+            <axis xyz="0 0 1" />
+            <limit effort="0" lower="-2.9671" upper="2.9671" velocity="6.1087" />
+        </joint>
+        <joint name="${prefix}joint_2" type="revolute">
+            <origin xyz="0.075 0 0" rpy="0 0 0" />
+            <parent link="${prefix}link_1" />
+            <child link="${prefix}link_2" />
+            <axis xyz="0 1 0" />
+            <limit effort="0" lower="-1.0472" upper="2.4435" velocity="6.1087" />
+        </joint>
+        <joint name="${prefix}joint_3" type="revolute">
+            <origin xyz="0 0 0.300" rpy="0 0 0" />
+            <parent link="${prefix}link_2" />
+            <child link="${prefix}link_3" />
+            <axis xyz="0 -1 0" />
+            <limit effort="0" lower="-2.4784" upper="4.0143" velocity="6.9813" />
+        </joint>
+        <joint name="${prefix}joint_4" type="revolute">
+            <origin xyz="0.3275 0 0.075" rpy="0 0 0" />
+            <parent link="${prefix}link_3" />
+            <child link="${prefix}link_4" />
+            <axis xyz="0 -1 0" />
+            <limit effort="0" lower="-2.0944" upper="2.0944" velocity="7.8540" />
+        </joint>
+        <joint name="${prefix}joint_5" type="revolute">
+            <origin xyz="0.080 0 0" rpy="0 0 0" />
+            <parent link="${prefix}link_4" />
+            <child link="${prefix}link_5" />
+            <axis xyz="-1 0 0" />
+            <limit effort="0" lower="-6.285" upper="6.285" velocity="20.94395" />
+        </joint>
+        <joint name="${prefix}joint_5-tool0" type="fixed">
+            <origin xyz="0 0 0" rpy="${m_pi} ${-m_pi_2} 0" />
+            <parent link="${prefix}link_5" />
+            <child link="${prefix}tool0" />
+        </joint>
 
-    <!-- ROS base_link to Fanuc World Coordinates transform -->
-    <link name="${prefix}base" />
-    <joint name="${prefix}base_link-base" type="fixed">
-      <origin xyz="0 0 0.330" rpy="0 0 0"/>
-      <parent link="${prefix}base_link"/>
-      <child link="${prefix}base"/>
-    </joint>
-  </xacro:macro>
+        <!-- ROS base_link to Fanuc World Coordinates transform -->
+        <link name="${prefix}base" />
+        <joint name="${prefix}base_link-base" type="fixed">
+            <origin xyz="0 0 0.330" rpy="0 0 0"/>
+            <parent link="${prefix}base_link"/>
+            <child link="${prefix}base"/>
+        </joint>
+    </xacro:macro>
 </robot>

--- a/fanuc_lrmate200ic_support/urdf/lrmate200ic5h.xacro
+++ b/fanuc_lrmate200ic_support/urdf/lrmate200ic5h.xacro
@@ -1,5 +1,5 @@
 <?xml version="1.0" ?>
 <robot name="fanuc_lrmate200ic5h" xmlns:xacro="http://ros.org/wiki/xacro">
-  <xacro:include filename="$(find fanuc_lrmate200ic_support)/urdf/lrmate200ic5h_macro.xacro"/>
-  <xacro:fanuc_lrmate200ic5h prefix=""/>
+    <xacro:include filename="$(find fanuc_lrmate200ic_support)/urdf/lrmate200ic5h_macro.xacro"/>
+    <xacro:fanuc_lrmate200ic5h prefix=""/>
 </robot>

--- a/fanuc_lrmate200ic_support/urdf/lrmate200ic5h_macro.xacro
+++ b/fanuc_lrmate200ic_support/urdf/lrmate200ic5h_macro.xacro
@@ -1,148 +1,148 @@
 <?xml version="1.0" ?>
 <robot xmlns:xacro="http://ros.org/wiki/xacro">
-  <xacro:include filename="$(find fanuc_resources)/urdf/common_materials.xacro"/>
-  <xacro:include filename="$(find fanuc_resources)/urdf/common_constants.xacro"/>
+    <xacro:include filename="$(find fanuc_resources)/urdf/common_materials.xacro"/>
+    <xacro:include filename="$(find fanuc_resources)/urdf/common_constants.xacro"/>
 
-  <xacro:macro name="fanuc_lrmate200ic5h" params="prefix">
-    <link name="${prefix}base_link">
-      <visual>
-        <origin xyz="0 0 0" rpy="0 0 0" />
-        <geometry>
-          <mesh filename="package://fanuc_lrmate200ic_support/meshes/lrmate200ic/visual/base_link.stl" />
-        </geometry>
-        <xacro:material_fanuc_gray24 />
-      </visual>
-      <collision>
-        <origin xyz="0 0 0" rpy="0 0 0" />
-        <geometry>
-          <mesh filename="package://fanuc_lrmate200ic_support/meshes/lrmate200ic/collision/base_link.stl" />
-        </geometry>
-      </collision>
-    </link>
-    <link name="${prefix}link_1">
-      <visual>
-        <origin xyz="0 0 0" rpy="0 0 0" />
-        <geometry>
-          <mesh filename="package://fanuc_lrmate200ic_support/meshes/lrmate200ic/visual/link_1.stl" />
-        </geometry>
-        <xacro:material_fanuc_yellow />
-      </visual>
-      <collision>
-        <origin xyz="0 0 0" rpy="0 0 0" />
-        <geometry>
-          <mesh filename="package://fanuc_lrmate200ic_support/meshes/lrmate200ic/collision/link_1.stl" />
-        </geometry>
-      </collision>
-    </link>
-    <link name="${prefix}link_2">
-      <visual>
-        <origin xyz="0 0 0" rpy="0 0 0" />
-        <geometry>
-          <mesh filename="package://fanuc_lrmate200ic_support/meshes/lrmate200ic/visual/link_2.stl" />
-        </geometry>
-        <xacro:material_fanuc_yellow />
-      </visual>
-      <collision>
-        <origin xyz="0 0 0" rpy="0 0 0" />
-        <geometry>
-          <mesh filename="package://fanuc_lrmate200ic_support/meshes/lrmate200ic/collision/link_2.stl" />
-        </geometry>
-      </collision>
-    </link>
-    <link name="${prefix}link_3">
-      <visual>
-        <origin xyz="0 0 0" rpy="0 0 0" />
-        <geometry>
-          <mesh filename="package://fanuc_lrmate200ic_support/meshes/lrmate200ic5h/visual/link_3.stl" />
-        </geometry>
-        <xacro:material_fanuc_yellow />
-      </visual>
-      <collision>
-        <origin xyz="0 0 0" rpy="0 0 0" />
-        <geometry>
-          <mesh filename="package://fanuc_lrmate200ic_support/meshes/lrmate200ic5h/collision/link_3.stl" />
-        </geometry>
-      </collision>
-    </link>
-    <link name="${prefix}link_4">
-      <visual>
-        <origin xyz="0 0 0" rpy="0 0 0" />
-        <geometry>
-          <mesh filename="package://fanuc_lrmate200ic_support/meshes/lrmate200ic/visual/link_5.stl" />
-        </geometry>
-        <xacro:material_fanuc_yellow />
-      </visual>
-      <collision>
-        <origin xyz="0 0 0" rpy="0 0 0" />
-        <geometry>
-          <mesh filename="package://fanuc_lrmate200ic_support/meshes/lrmate200ic/collision/link_5.stl" />
-        </geometry>
-      </collision>
-    </link>
-    <link name="${prefix}link_5">
-      <visual>
-        <origin xyz="0 0 0" rpy="0 0 0"/>
-        <geometry>
-          <mesh filename="package://fanuc_lrmate200ic_support/meshes/lrmate200ic/visual/link_6.stl" />
-        </geometry>
-        <xacro:material_fanuc_black />
-      </visual>
-      <collision>
-        <origin xyz="0 0 0" rpy="0 0 0"/>
-        <geometry>
-          <mesh filename="package://fanuc_lrmate200ic_support/meshes/lrmate200ic/collision/link_6.stl" />
-        </geometry>
-      </collision>
-    </link>
-    <link name="${prefix}tool0" />
+    <xacro:macro name="fanuc_lrmate200ic5h" params="prefix">
+        <link name="${prefix}base_link">
+            <visual>
+                <origin xyz="0 0 0" rpy="0 0 0" />
+                <geometry>
+                    <mesh filename="package://fanuc_lrmate200ic_support/meshes/lrmate200ic/visual/base_link.stl" />
+                </geometry>
+                <xacro:material_fanuc_gray24 />
+            </visual>
+            <collision>
+                <origin xyz="0 0 0" rpy="0 0 0" />
+                <geometry>
+                    <mesh filename="package://fanuc_lrmate200ic_support/meshes/lrmate200ic/collision/base_link.stl" />
+                </geometry>
+            </collision>
+        </link>
+        <link name="${prefix}link_1">
+            <visual>
+                <origin xyz="0 0 0" rpy="0 0 0" />
+                <geometry>
+                    <mesh filename="package://fanuc_lrmate200ic_support/meshes/lrmate200ic/visual/link_1.stl" />
+                </geometry>
+                <xacro:material_fanuc_yellow />
+            </visual>
+            <collision>
+                <origin xyz="0 0 0" rpy="0 0 0" />
+                <geometry>
+                    <mesh filename="package://fanuc_lrmate200ic_support/meshes/lrmate200ic/collision/link_1.stl" />
+                </geometry>
+            </collision>
+        </link>
+        <link name="${prefix}link_2">
+            <visual>
+                <origin xyz="0 0 0" rpy="0 0 0" />
+                <geometry>
+                    <mesh filename="package://fanuc_lrmate200ic_support/meshes/lrmate200ic/visual/link_2.stl" />
+                </geometry>
+                <xacro:material_fanuc_yellow />
+            </visual>
+            <collision>
+                <origin xyz="0 0 0" rpy="0 0 0" />
+                <geometry>
+                    <mesh filename="package://fanuc_lrmate200ic_support/meshes/lrmate200ic/collision/link_2.stl" />
+                </geometry>
+            </collision>
+        </link>
+        <link name="${prefix}link_3">
+            <visual>
+                <origin xyz="0 0 0" rpy="0 0 0" />
+                <geometry>
+                    <mesh filename="package://fanuc_lrmate200ic_support/meshes/lrmate200ic5h/visual/link_3.stl" />
+                </geometry>
+                <xacro:material_fanuc_yellow />
+            </visual>
+            <collision>
+                <origin xyz="0 0 0" rpy="0 0 0" />
+                <geometry>
+                    <mesh filename="package://fanuc_lrmate200ic_support/meshes/lrmate200ic5h/collision/link_3.stl" />
+                </geometry>
+            </collision>
+        </link>
+        <link name="${prefix}link_4">
+            <visual>
+                <origin xyz="0 0 0" rpy="0 0 0" />
+                <geometry>
+                    <mesh filename="package://fanuc_lrmate200ic_support/meshes/lrmate200ic/visual/link_5.stl" />
+                </geometry>
+                <xacro:material_fanuc_yellow />
+            </visual>
+            <collision>
+                <origin xyz="0 0 0" rpy="0 0 0" />
+                <geometry>
+                    <mesh filename="package://fanuc_lrmate200ic_support/meshes/lrmate200ic/collision/link_5.stl" />
+                </geometry>
+            </collision>
+        </link>
+        <link name="${prefix}link_5">
+            <visual>
+                <origin xyz="0 0 0" rpy="0 0 0"/>
+                <geometry>
+                    <mesh filename="package://fanuc_lrmate200ic_support/meshes/lrmate200ic/visual/link_6.stl" />
+                </geometry>
+                <xacro:material_fanuc_black />
+            </visual>
+            <collision>
+                <origin xyz="0 0 0" rpy="0 0 0"/>
+                <geometry>
+                    <mesh filename="package://fanuc_lrmate200ic_support/meshes/lrmate200ic/collision/link_6.stl" />
+                </geometry>
+            </collision>
+        </link>
+        <link name="${prefix}tool0" />
 
-    <joint name="${prefix}joint_1" type="revolute">
-      <origin xyz="0 0 0.330" rpy="0 0 0" />
-      <parent link="${prefix}base_link" />
-      <child link="${prefix}link_1" />
-      <axis xyz="0 0 1" />
-      <limit effort="0" lower="-2.9671" upper="2.9671" velocity="6.1087" />
-    </joint>
-    <joint name="${prefix}joint_2" type="revolute">
-      <origin xyz="0.075 0 0" rpy="0 0 0" />
-      <parent link="${prefix}link_1" />
-      <child link="${prefix}link_2" />
-      <axis xyz="0 1 0" />
-      <limit effort="0" lower="-1.0472" upper="2.4435" velocity="6.1087" />
-    </joint>
-    <joint name="${prefix}joint_3" type="revolute">
-      <origin xyz="0 0 0.300" rpy="0 0 0" />
-      <parent link="${prefix}link_2" />
-      <child link="${prefix}link_3" />
-      <axis xyz="0 -1 0" />
-      <limit effort="0" lower="-2.4784" upper="4.0143" velocity="6.9813" />
-    </joint>
-    <joint name="${prefix}joint_4" type="revolute">
-      <origin xyz="0.320 0 0.075" rpy="0 0 0" />
-      <parent link="${prefix}link_3" />
-      <child link="${prefix}link_4" />
-      <axis xyz="0 -1 0" />
-      <limit effort="0" lower="-2.0944" upper="2.0944" velocity="7.8540" />
-    </joint>
-    <joint name="${prefix}joint_5" type="revolute">
-      <origin xyz="0.080 0 0" rpy="0 0 0" />
-      <parent link="${prefix}link_4" />
-      <child link="${prefix}link_5" />
-      <axis xyz="-1 0 0" />
-      <limit effort="0" lower="-6.285" upper="6.285" velocity="12.5664" />
-    </joint>
-    <joint name="${prefix}joint_5-tool0" type="fixed">
-      <origin xyz="0 0 0" rpy="${m_pi} ${-m_pi_2} 0" />
-      <parent link="${prefix}link_5" />
-      <child link="${prefix}tool0" />
-    </joint>
+        <joint name="${prefix}joint_1" type="revolute">
+            <origin xyz="0 0 0.330" rpy="0 0 0" />
+            <parent link="${prefix}base_link" />
+            <child link="${prefix}link_1" />
+            <axis xyz="0 0 1" />
+            <limit effort="0" lower="-2.9671" upper="2.9671" velocity="6.1087" />
+        </joint>
+        <joint name="${prefix}joint_2" type="revolute">
+            <origin xyz="0.075 0 0" rpy="0 0 0" />
+            <parent link="${prefix}link_1" />
+            <child link="${prefix}link_2" />
+            <axis xyz="0 1 0" />
+            <limit effort="0" lower="-1.0472" upper="2.4435" velocity="6.1087" />
+        </joint>
+        <joint name="${prefix}joint_3" type="revolute">
+            <origin xyz="0 0 0.300" rpy="0 0 0" />
+            <parent link="${prefix}link_2" />
+            <child link="${prefix}link_3" />
+            <axis xyz="0 -1 0" />
+            <limit effort="0" lower="-2.4784" upper="4.0143" velocity="6.9813" />
+        </joint>
+        <joint name="${prefix}joint_4" type="revolute">
+            <origin xyz="0.320 0 0.075" rpy="0 0 0" />
+            <parent link="${prefix}link_3" />
+            <child link="${prefix}link_4" />
+            <axis xyz="0 -1 0" />
+            <limit effort="0" lower="-2.0944" upper="2.0944" velocity="7.8540" />
+        </joint>
+        <joint name="${prefix}joint_5" type="revolute">
+            <origin xyz="0.080 0 0" rpy="0 0 0" />
+            <parent link="${prefix}link_4" />
+            <child link="${prefix}link_5" />
+            <axis xyz="-1 0 0" />
+            <limit effort="0" lower="-6.285" upper="6.285" velocity="12.5664" />
+        </joint>
+        <joint name="${prefix}joint_5-tool0" type="fixed">
+            <origin xyz="0 0 0" rpy="${m_pi} ${-m_pi_2} 0" />
+            <parent link="${prefix}link_5" />
+            <child link="${prefix}tool0" />
+        </joint>
 
-    <!-- ROS base_link to Fanuc World Coordinates transform -->
-    <link name="${prefix}base" />
-    <joint name="${prefix}base_link-base" type="fixed">
-      <origin xyz="0 0 0.330" rpy="0 0 0"/>
-      <parent link="${prefix}base_link"/>
-      <child link="${prefix}base"/>
-    </joint>
-  </xacro:macro>
+        <!-- ROS base_link to Fanuc World Coordinates transform -->
+        <link name="${prefix}base" />
+        <joint name="${prefix}base_link-base" type="fixed">
+            <origin xyz="0 0 0.330" rpy="0 0 0"/>
+            <parent link="${prefix}base_link"/>
+            <child link="${prefix}base"/>
+        </joint>
+    </xacro:macro>
 </robot>

--- a/fanuc_lrmate200ic_support/urdf/lrmate200ic5hs.xacro
+++ b/fanuc_lrmate200ic_support/urdf/lrmate200ic5hs.xacro
@@ -1,5 +1,5 @@
 <?xml version="1.0" ?>
 <robot name="fanuc_lrmate200ic5hs" xmlns:xacro="http://ros.org/wiki/xacro">
-  <xacro:include filename="$(find fanuc_lrmate200ic_support)/urdf/lrmate200ic5hs_macro.xacro"/>
-  <xacro:fanuc_lrmate200ic5hs prefix=""/>
+    <xacro:include filename="$(find fanuc_lrmate200ic_support)/urdf/lrmate200ic5hs_macro.xacro"/>
+    <xacro:fanuc_lrmate200ic5hs prefix=""/>
 </robot>

--- a/fanuc_lrmate200ic_support/urdf/lrmate200ic5hs_macro.xacro
+++ b/fanuc_lrmate200ic_support/urdf/lrmate200ic5hs_macro.xacro
@@ -1,148 +1,148 @@
 <?xml version="1.0" ?>
 <robot xmlns:xacro="http://ros.org/wiki/xacro">
-  <xacro:include filename="$(find fanuc_resources)/urdf/common_materials.xacro"/>
-  <xacro:include filename="$(find fanuc_resources)/urdf/common_constants.xacro"/>
+    <xacro:include filename="$(find fanuc_resources)/urdf/common_materials.xacro"/>
+    <xacro:include filename="$(find fanuc_resources)/urdf/common_constants.xacro"/>
 
-  <xacro:macro name="fanuc_lrmate200ic5hs" params="prefix">
-    <link name="${prefix}base_link">
-      <visual>
-        <origin xyz="0 0 0" rpy="0 0 0" />
-        <geometry>
-          <mesh filename="package://fanuc_lrmate200ic_support/meshes/lrmate200ic/visual/base_link.stl" />
-        </geometry>
-        <xacro:material_fanuc_gray24 />
-      </visual>
-      <collision>
-        <origin xyz="0 0 0" rpy="0 0 0" />
-        <geometry>
-          <mesh filename="package://fanuc_lrmate200ic_support/meshes/lrmate200ic/collision/base_link.stl" />
-        </geometry>
-      </collision>
-    </link>
-    <link name="${prefix}link_1">
-      <visual>
-        <origin xyz="0 0 0" rpy="0 0 0" />
-        <geometry>
-          <mesh filename="package://fanuc_lrmate200ic_support/meshes/lrmate200ic/visual/link_1.stl" />
-        </geometry>
-        <xacro:material_fanuc_yellow />
-      </visual>
-      <collision>
-        <origin xyz="0 0 0" rpy="0 0 0" />
-        <geometry>
-          <mesh filename="package://fanuc_lrmate200ic_support/meshes/lrmate200ic/collision/link_1.stl" />
-        </geometry>
-      </collision>
-    </link>
-    <link name="${prefix}link_2">
-      <visual>
-        <origin xyz="0 0 0" rpy="0 0 0" />
-        <geometry>
-          <mesh filename="package://fanuc_lrmate200ic_support/meshes/lrmate200ic/visual/link_2.stl" />
-        </geometry>
-        <xacro:material_fanuc_yellow />
-      </visual>
-      <collision>
-        <origin xyz="0 0 0" rpy="0 0 0" />
-        <geometry>
-          <mesh filename="package://fanuc_lrmate200ic_support/meshes/lrmate200ic/collision/link_2.stl" />
-        </geometry>
-      </collision>
-    </link>
-    <link name="${prefix}link_3">
-      <visual>
-        <origin xyz="0 0 0" rpy="0 0 0" />
-        <geometry>
-          <mesh filename="package://fanuc_lrmate200ic_support/meshes/lrmate200ic5h/visual/link_3.stl" />
-        </geometry>
-        <xacro:material_fanuc_yellow />
-      </visual>
-      <collision>
-        <origin xyz="0 0 0" rpy="0 0 0" />
-        <geometry>
-          <mesh filename="package://fanuc_lrmate200ic_support/meshes/lrmate200ic5h/collision/link_3.stl" />
-        </geometry>
-      </collision>
-    </link>
-    <link name="${prefix}link_4">
-      <visual>
-        <origin xyz="0 0 0" rpy="0 0 0" />
-        <geometry>
-          <mesh filename="package://fanuc_lrmate200ic_support/meshes/lrmate200ic/visual/link_5.stl" />
-        </geometry>
-        <xacro:material_fanuc_yellow />
-      </visual>
-      <collision>
-        <origin xyz="0 0 0" rpy="0 0 0" />
-        <geometry>
-          <mesh filename="package://fanuc_lrmate200ic_support/meshes/lrmate200ic/collision/link_5.stl" />
-        </geometry>
-      </collision>
-    </link>
-    <link name="${prefix}link_5">
-      <visual>
-        <origin xyz="0 0 0" rpy="0 0 0"/>
-        <geometry>
-          <mesh filename="package://fanuc_lrmate200ic_support/meshes/lrmate200ic/visual/link_6.stl" />
-        </geometry>
-        <xacro:material_fanuc_black />
-      </visual>
-      <collision>
-        <origin xyz="0 0 0" rpy="0 0 0"/>
-        <geometry>
-          <mesh filename="package://fanuc_lrmate200ic_support/meshes/lrmate200ic/collision/link_6.stl" />
-        </geometry>
-      </collision>
-    </link>
-    <link name="${prefix}tool0" />
+    <xacro:macro name="fanuc_lrmate200ic5hs" params="prefix">
+        <link name="${prefix}base_link">
+            <visual>
+                <origin xyz="0 0 0" rpy="0 0 0" />
+                <geometry>
+                    <mesh filename="package://fanuc_lrmate200ic_support/meshes/lrmate200ic/visual/base_link.stl" />
+                </geometry>
+                <xacro:material_fanuc_gray24 />
+            </visual>
+            <collision>
+                <origin xyz="0 0 0" rpy="0 0 0" />
+                <geometry>
+                    <mesh filename="package://fanuc_lrmate200ic_support/meshes/lrmate200ic/collision/base_link.stl" />
+                </geometry>
+            </collision>
+        </link>
+        <link name="${prefix}link_1">
+            <visual>
+                <origin xyz="0 0 0" rpy="0 0 0" />
+                <geometry>
+                    <mesh filename="package://fanuc_lrmate200ic_support/meshes/lrmate200ic/visual/link_1.stl" />
+                </geometry>
+                <xacro:material_fanuc_yellow />
+            </visual>
+            <collision>
+                <origin xyz="0 0 0" rpy="0 0 0" />
+                <geometry>
+                    <mesh filename="package://fanuc_lrmate200ic_support/meshes/lrmate200ic/collision/link_1.stl" />
+                </geometry>
+            </collision>
+        </link>
+        <link name="${prefix}link_2">
+            <visual>
+                <origin xyz="0 0 0" rpy="0 0 0" />
+                <geometry>
+                    <mesh filename="package://fanuc_lrmate200ic_support/meshes/lrmate200ic/visual/link_2.stl" />
+                </geometry>
+                <xacro:material_fanuc_yellow />
+            </visual>
+            <collision>
+                <origin xyz="0 0 0" rpy="0 0 0" />
+                <geometry>
+                    <mesh filename="package://fanuc_lrmate200ic_support/meshes/lrmate200ic/collision/link_2.stl" />
+                </geometry>
+            </collision>
+        </link>
+        <link name="${prefix}link_3">
+            <visual>
+                <origin xyz="0 0 0" rpy="0 0 0" />
+                <geometry>
+                    <mesh filename="package://fanuc_lrmate200ic_support/meshes/lrmate200ic5h/visual/link_3.stl" />
+                </geometry>
+                <xacro:material_fanuc_yellow />
+            </visual>
+            <collision>
+                <origin xyz="0 0 0" rpy="0 0 0" />
+                <geometry>
+                    <mesh filename="package://fanuc_lrmate200ic_support/meshes/lrmate200ic5h/collision/link_3.stl" />
+                </geometry>
+            </collision>
+        </link>
+        <link name="${prefix}link_4">
+            <visual>
+                <origin xyz="0 0 0" rpy="0 0 0" />
+                <geometry>
+                    <mesh filename="package://fanuc_lrmate200ic_support/meshes/lrmate200ic/visual/link_5.stl" />
+                </geometry>
+                <xacro:material_fanuc_yellow />
+            </visual>
+            <collision>
+                <origin xyz="0 0 0" rpy="0 0 0" />
+                <geometry>
+                    <mesh filename="package://fanuc_lrmate200ic_support/meshes/lrmate200ic/collision/link_5.stl" />
+                </geometry>
+            </collision>
+        </link>
+        <link name="${prefix}link_5">
+            <visual>
+                <origin xyz="0 0 0" rpy="0 0 0"/>
+                <geometry>
+                    <mesh filename="package://fanuc_lrmate200ic_support/meshes/lrmate200ic/visual/link_6.stl" />
+                </geometry>
+                <xacro:material_fanuc_black />
+            </visual>
+            <collision>
+                <origin xyz="0 0 0" rpy="0 0 0"/>
+                <geometry>
+                    <mesh filename="package://fanuc_lrmate200ic_support/meshes/lrmate200ic/collision/link_6.stl" />
+                </geometry>
+            </collision>
+        </link>
+        <link name="${prefix}tool0" />
 
-    <joint name="${prefix}joint_1" type="revolute">
-      <origin xyz="0 0 0.330" rpy="0 0 0" />
-      <parent link="${prefix}base_link" />
-      <child link="${prefix}link_1" />
-      <axis xyz="0 0 1" />
-      <limit effort="0" lower="-2.9671" upper="2.9671" velocity="6.1087" />
-    </joint>
-    <joint name="${prefix}joint_2" type="revolute">
-      <origin xyz="0.075 0 0" rpy="0 0 0" />
-      <parent link="${prefix}link_1" />
-      <child link="${prefix}link_2" />
-      <axis xyz="0 1 0" />
-      <limit effort="0" lower="-1.0472" upper="2.4435" velocity="6.1087" />
-    </joint>
-    <joint name="${prefix}joint_3" type="revolute">
-      <origin xyz="0 0 0.300" rpy="0 0 0" />
-      <parent link="${prefix}link_2" />
-      <child link="${prefix}link_3" />
-      <axis xyz="0 -1 0" />
-      <limit effort="0" lower="-2.4784" upper="4.0143" velocity="6.9813" />
-    </joint>
-    <joint name="${prefix}joint_4" type="revolute">
-      <origin xyz="0.320 0 0.075" rpy="0 0 0" />
-      <parent link="${prefix}link_3" />
-      <child link="${prefix}link_4" />
-      <axis xyz="0 -1 0" />
-      <limit effort="0" lower="-2.0944" upper="2.0944" velocity="7.8540" />
-    </joint>
-    <joint name="${prefix}joint_5" type="revolute">
-      <origin xyz="0.080 0 0" rpy="0 0 0" />
-      <parent link="${prefix}link_4" />
-      <child link="${prefix}link_5" />
-      <axis xyz="-1 0 0" />
-      <limit effort="0" lower="-6.285" upper="6.285" velocity="20.94395" />
-    </joint>
-    <joint name="${prefix}joint_5-tool0" type="fixed">
-      <origin xyz="0 0 0" rpy="${m_pi} ${-m_pi_2} 0" />
-      <parent link="${prefix}link_5" />
-      <child link="${prefix}tool0" />
-    </joint>
+        <joint name="${prefix}joint_1" type="revolute">
+            <origin xyz="0 0 0.330" rpy="0 0 0" />
+            <parent link="${prefix}base_link" />
+            <child link="${prefix}link_1" />
+            <axis xyz="0 0 1" />
+            <limit effort="0" lower="-2.9671" upper="2.9671" velocity="6.1087" />
+        </joint>
+        <joint name="${prefix}joint_2" type="revolute">
+            <origin xyz="0.075 0 0" rpy="0 0 0" />
+            <parent link="${prefix}link_1" />
+            <child link="${prefix}link_2" />
+            <axis xyz="0 1 0" />
+            <limit effort="0" lower="-1.0472" upper="2.4435" velocity="6.1087" />
+        </joint>
+        <joint name="${prefix}joint_3" type="revolute">
+            <origin xyz="0 0 0.300" rpy="0 0 0" />
+            <parent link="${prefix}link_2" />
+            <child link="${prefix}link_3" />
+            <axis xyz="0 -1 0" />
+            <limit effort="0" lower="-2.4784" upper="4.0143" velocity="6.9813" />
+        </joint>
+        <joint name="${prefix}joint_4" type="revolute">
+            <origin xyz="0.320 0 0.075" rpy="0 0 0" />
+            <parent link="${prefix}link_3" />
+            <child link="${prefix}link_4" />
+            <axis xyz="0 -1 0" />
+            <limit effort="0" lower="-2.0944" upper="2.0944" velocity="7.8540" />
+        </joint>
+        <joint name="${prefix}joint_5" type="revolute">
+            <origin xyz="0.080 0 0" rpy="0 0 0" />
+            <parent link="${prefix}link_4" />
+            <child link="${prefix}link_5" />
+            <axis xyz="-1 0 0" />
+            <limit effort="0" lower="-6.285" upper="6.285" velocity="20.94395" />
+        </joint>
+        <joint name="${prefix}joint_5-tool0" type="fixed">
+            <origin xyz="0 0 0" rpy="${m_pi} ${-m_pi_2} 0" />
+            <parent link="${prefix}link_5" />
+            <child link="${prefix}tool0" />
+        </joint>
 
-    <!-- ROS base_link to Fanuc World Coordinates transform -->
-    <link name="${prefix}base" />
-    <joint name="${prefix}base_link-base" type="fixed">
-      <origin xyz="0 0 0.330" rpy="0 0 0"/>
-      <parent link="${prefix}base_link"/>
-      <child link="${prefix}base"/>
-    </joint>
-  </xacro:macro>
+        <!-- ROS base_link to Fanuc World Coordinates transform -->
+        <link name="${prefix}base" />
+        <joint name="${prefix}base_link-base" type="fixed">
+            <origin xyz="0 0 0.330" rpy="0 0 0"/>
+            <parent link="${prefix}base_link"/>
+            <child link="${prefix}base"/>
+        </joint>
+    </xacro:macro>
 </robot>

--- a/fanuc_lrmate200ic_support/urdf/lrmate200ic5l.xacro
+++ b/fanuc_lrmate200ic_support/urdf/lrmate200ic5l.xacro
@@ -1,5 +1,5 @@
 <?xml version="1.0" ?>
 <robot name="fanuc_lrmate200ic5l" xmlns:xacro="http://ros.org/wiki/xacro">
-  <xacro:include filename="$(find fanuc_lrmate200ic_support)/urdf/lrmate200ic5l_macro.xacro"/>
-  <xacro:fanuc_lrmate200ic5l prefix=""/>
+    <xacro:include filename="$(find fanuc_lrmate200ic_support)/urdf/lrmate200ic5l_macro.xacro"/>
+    <xacro:fanuc_lrmate200ic5l prefix=""/>
 </robot>

--- a/fanuc_lrmate200ic_support/urdf/lrmate200ic5l_macro.xacro
+++ b/fanuc_lrmate200ic_support/urdf/lrmate200ic5l_macro.xacro
@@ -1,170 +1,170 @@
 <?xml version="1.0" ?>
 <robot xmlns:xacro="http://ros.org/wiki/xacro">
-  <xacro:include filename="$(find fanuc_resources)/urdf/common_materials.xacro"/>
-  <xacro:include filename="$(find fanuc_resources)/urdf/common_constants.xacro"/>
+    <xacro:include filename="$(find fanuc_resources)/urdf/common_materials.xacro"/>
+    <xacro:include filename="$(find fanuc_resources)/urdf/common_constants.xacro"/>
 
-  <xacro:macro name="fanuc_lrmate200ic5l" params="prefix">
-    <link name="${prefix}base_link">
-      <visual>
-        <origin xyz="0 0 0" rpy="0 0 0"/>
-        <geometry>
-          <mesh filename="package://fanuc_lrmate200ic_support/meshes/lrmate200ic/visual/base_link.stl"/>
-        </geometry>
-        <xacro:material_fanuc_gray24 />
-      </visual>
-      <collision>
-        <origin xyz="0 0 0" rpy="0 0 0"/>
-        <geometry>
-          <mesh filename="package://fanuc_lrmate200ic_support/meshes/lrmate200ic/collision/base_link.stl"/>
-        </geometry>
-      </collision>
-    </link>
-    <link name="${prefix}link_1">
-      <visual>
-        <origin xyz="0 0 0" rpy="0 0 0"/>
-        <geometry>
-          <mesh filename="package://fanuc_lrmate200ic_support/meshes/lrmate200ic/visual/link_1.stl"/>
-        </geometry>
-        <xacro:material_fanuc_yellow />
-      </visual>
-      <collision>
-        <origin xyz="0 0 0" rpy="0 0 0"/>
-        <geometry>
-          <mesh filename="package://fanuc_lrmate200ic_support/meshes/lrmate200ic/collision/link_1.stl"/>
-        </geometry>
-      </collision>
-    </link>
-    <link name="${prefix}link_2">
-      <visual>
-        <origin xyz="0 0 0" rpy="0 0 0"/>
-        <geometry>
-          <mesh filename="package://fanuc_lrmate200ic_support/meshes/lrmate200ic5l/visual/link_2.stl"/>
-        </geometry>
-        <xacro:material_fanuc_yellow />
-      </visual>
-      <collision>
-        <origin xyz="0 0 0" rpy="0 0 0"/>
-        <geometry>
-          <mesh filename="package://fanuc_lrmate200ic_support/meshes/lrmate200ic5l/collision/link_2.stl"/>
-        </geometry>
-      </collision>
-    </link>
-    <link name="${prefix}link_3">
-      <visual>
-        <origin xyz="0 0 0" rpy="0 0 0"/>
-        <geometry>
-          <mesh filename="package://fanuc_lrmate200ic_support/meshes/lrmate200ic/visual/link_3.stl"/>
-        </geometry>
-        <xacro:material_fanuc_yellow />
-      </visual>
-      <collision>
-        <origin xyz="0 0 0" rpy="0 0 0"/>
-        <geometry>
-          <mesh filename="package://fanuc_lrmate200ic_support/meshes/lrmate200ic/collision/link_3.stl"/>
-        </geometry>
-      </collision>
-    </link>
-    <link name="${prefix}link_4">
-      <visual>
-        <origin xyz="0 0 0" rpy="0 0 0"/>
-        <geometry>
-          <mesh filename="package://fanuc_lrmate200ic_support/meshes/lrmate200ic5l/visual/link_4.stl"/>
-        </geometry>
-        <xacro:material_fanuc_yellow />
-      </visual>
-      <collision>
-        <origin xyz="0 0 0" rpy="0 0 0"/>
-        <geometry>
-          <mesh filename="package://fanuc_lrmate200ic_support/meshes/lrmate200ic5l/collision/link_4.stl"/>
-        </geometry>
-      </collision>
-    </link>
-    <link name="${prefix}link_5">
-      <visual>
-        <origin xyz="0 0 0" rpy="0 0 0"/>
-        <geometry>
-          <mesh filename="package://fanuc_lrmate200ic_support/meshes/lrmate200ic/visual/link_5.stl"/>
-        </geometry>
-        <xacro:material_fanuc_yellow />
-      </visual>
-      <collision>
-        <origin xyz="0 0 0" rpy="0 0 0"/>
-        <geometry>
-          <mesh filename="package://fanuc_lrmate200ic_support/meshes/lrmate200ic/collision/link_5.stl"/>
-        </geometry>
-      </collision>
-    </link>
-    <link name="${prefix}link_6">
-      <visual>
-        <origin xyz="0 0 0" rpy="0 0 0"/>
-        <geometry>
-          <mesh filename="package://fanuc_lrmate200ic_support/meshes/lrmate200ic/visual/link_6.stl"/>
-        </geometry>
-        <xacro:material_fanuc_black />
-      </visual>
-      <collision>
-        <origin xyz="0 0 0" rpy="0 0 0"/>
-        <geometry>
-          <mesh filename="package://fanuc_lrmate200ic_support/meshes/lrmate200ic/collision/link_6.stl"/>
-        </geometry>
-      </collision>
-    </link>
-    <link name="${prefix}tool0" />
+    <xacro:macro name="fanuc_lrmate200ic5l" params="prefix">
+        <link name="${prefix}base_link">
+            <visual>
+                <origin xyz="0 0 0" rpy="0 0 0"/>
+                <geometry>
+                    <mesh filename="package://fanuc_lrmate200ic_support/meshes/lrmate200ic/visual/base_link.stl"/>
+                </geometry>
+                <xacro:material_fanuc_gray24 />
+            </visual>
+            <collision>
+                <origin xyz="0 0 0" rpy="0 0 0"/>
+                <geometry>
+                    <mesh filename="package://fanuc_lrmate200ic_support/meshes/lrmate200ic/collision/base_link.stl"/>
+                </geometry>
+            </collision>
+        </link>
+        <link name="${prefix}link_1">
+            <visual>
+                <origin xyz="0 0 0" rpy="0 0 0"/>
+                <geometry>
+                    <mesh filename="package://fanuc_lrmate200ic_support/meshes/lrmate200ic/visual/link_1.stl"/>
+                </geometry>
+                <xacro:material_fanuc_yellow />
+            </visual>
+            <collision>
+                <origin xyz="0 0 0" rpy="0 0 0"/>
+                <geometry>
+                    <mesh filename="package://fanuc_lrmate200ic_support/meshes/lrmate200ic/collision/link_1.stl"/>
+                </geometry>
+            </collision>
+        </link>
+        <link name="${prefix}link_2">
+            <visual>
+                <origin xyz="0 0 0" rpy="0 0 0"/>
+                <geometry>
+                    <mesh filename="package://fanuc_lrmate200ic_support/meshes/lrmate200ic5l/visual/link_2.stl"/>
+                </geometry>
+                <xacro:material_fanuc_yellow />
+            </visual>
+            <collision>
+                <origin xyz="0 0 0" rpy="0 0 0"/>
+                <geometry>
+                    <mesh filename="package://fanuc_lrmate200ic_support/meshes/lrmate200ic5l/collision/link_2.stl"/>
+                </geometry>
+            </collision>
+        </link>
+        <link name="${prefix}link_3">
+            <visual>
+                <origin xyz="0 0 0" rpy="0 0 0"/>
+                <geometry>
+                    <mesh filename="package://fanuc_lrmate200ic_support/meshes/lrmate200ic/visual/link_3.stl"/>
+                </geometry>
+                <xacro:material_fanuc_yellow />
+            </visual>
+            <collision>
+                <origin xyz="0 0 0" rpy="0 0 0"/>
+                <geometry>
+                    <mesh filename="package://fanuc_lrmate200ic_support/meshes/lrmate200ic/collision/link_3.stl"/>
+                </geometry>
+            </collision>
+        </link>
+        <link name="${prefix}link_4">
+            <visual>
+                <origin xyz="0 0 0" rpy="0 0 0"/>
+                <geometry>
+                    <mesh filename="package://fanuc_lrmate200ic_support/meshes/lrmate200ic5l/visual/link_4.stl"/>
+                </geometry>
+                <xacro:material_fanuc_yellow />
+            </visual>
+            <collision>
+                <origin xyz="0 0 0" rpy="0 0 0"/>
+                <geometry>
+                    <mesh filename="package://fanuc_lrmate200ic_support/meshes/lrmate200ic5l/collision/link_4.stl"/>
+                </geometry>
+            </collision>
+        </link>
+        <link name="${prefix}link_5">
+            <visual>
+                <origin xyz="0 0 0" rpy="0 0 0"/>
+                <geometry>
+                    <mesh filename="package://fanuc_lrmate200ic_support/meshes/lrmate200ic/visual/link_5.stl"/>
+                </geometry>
+                <xacro:material_fanuc_yellow />
+            </visual>
+            <collision>
+                <origin xyz="0 0 0" rpy="0 0 0"/>
+                <geometry>
+                    <mesh filename="package://fanuc_lrmate200ic_support/meshes/lrmate200ic/collision/link_5.stl"/>
+                </geometry>
+            </collision>
+        </link>
+        <link name="${prefix}link_6">
+            <visual>
+                <origin xyz="0 0 0" rpy="0 0 0"/>
+                <geometry>
+                    <mesh filename="package://fanuc_lrmate200ic_support/meshes/lrmate200ic/visual/link_6.stl"/>
+                </geometry>
+                <xacro:material_fanuc_black />
+            </visual>
+            <collision>
+                <origin xyz="0 0 0" rpy="0 0 0"/>
+                <geometry>
+                    <mesh filename="package://fanuc_lrmate200ic_support/meshes/lrmate200ic/collision/link_6.stl"/>
+                </geometry>
+            </collision>
+        </link>
+        <link name="${prefix}tool0" />
 
-    <joint name="${prefix}joint_1" type="revolute">
-      <origin xyz="0 0 0.330" rpy="0 0 0" />
-      <parent link="${prefix}base_link" />
-      <child link="${prefix}link_1" />
-      <axis xyz="0 0 1" />
-      <limit effort="0" lower="-2.9671" upper="2.9671" velocity="4.7124" />
-    </joint>
-    <joint name="${prefix}joint_2" type="revolute">
-      <origin xyz="0.075 0 0" rpy="0 0 0" />
-      <parent link="${prefix}link_1" />
-      <child link="${prefix}link_2" />
-      <axis xyz="0 1 0" />
-      <limit effort="0" lower="-1.5708" upper="2.4435" velocity="4.7124" />
-    </joint>
-    <joint name="${prefix}joint_3" type="revolute">
-      <origin xyz="0 0 0.400" rpy="0 0 0" />
-      <parent link="${prefix}link_2" />
-      <child link="${prefix}link_3" />
-      <axis xyz="0 -1 0" />
-      <limit effort="0" lower="-2.5831" upper="4.0143" velocity="4.7124" />
-    </joint>
-    <joint name="${prefix}joint_4" type="revolute">
-      <origin xyz="0 0 0.075" rpy="0 0 0"/>
-      <parent link="${prefix}link_3"/>
-      <child link="${prefix}link_4"/>
-      <axis xyz="-1 0 0"/>
-      <limit effort="0" lower="-3.3161" upper="3.3161" velocity="7.8540" />
-    </joint>
-    <joint name="${prefix}joint_5" type="revolute">
-      <origin xyz="0.410 0 0" rpy="0 0 0"/>
-      <parent link="${prefix}link_4"/>
-      <child link="${prefix}link_5"/>
-      <axis xyz="0 -1 0"/>
-      <limit effort="0" lower="-2.0944" upper="2.0944" velocity="7.8540" />
-    </joint>
-    <joint name="${prefix}joint_6" type="revolute">
-      <origin xyz="0.080 0 0" rpy="0 0 0"/>
-      <parent link="${prefix}link_5"/>
-      <child link="${prefix}link_6"/>
-      <axis xyz="-1 0 0"/>
-      <limit effort="0" lower="-6.2832" upper="6.2832" velocity="12.5664" />
-    </joint>
-    <joint name="${prefix}joint_6-tool0" type="fixed">
-      <origin xyz="0 0 0" rpy="${m_pi} ${-m_pi_2} 0" />
-      <parent link="${prefix}link_6" />
-      <child link="${prefix}tool0" />
-    </joint>
+        <joint name="${prefix}joint_1" type="revolute">
+            <origin xyz="0 0 0.330" rpy="0 0 0" />
+            <parent link="${prefix}base_link" />
+            <child link="${prefix}link_1" />
+            <axis xyz="0 0 1" />
+            <limit effort="0" lower="-2.9671" upper="2.9671" velocity="4.7124" />
+        </joint>
+        <joint name="${prefix}joint_2" type="revolute">
+            <origin xyz="0.075 0 0" rpy="0 0 0" />
+            <parent link="${prefix}link_1" />
+            <child link="${prefix}link_2" />
+            <axis xyz="0 1 0" />
+            <limit effort="0" lower="-1.5708" upper="2.4435" velocity="4.7124" />
+        </joint>
+        <joint name="${prefix}joint_3" type="revolute">
+            <origin xyz="0 0 0.400" rpy="0 0 0" />
+            <parent link="${prefix}link_2" />
+            <child link="${prefix}link_3" />
+            <axis xyz="0 -1 0" />
+            <limit effort="0" lower="-2.5831" upper="4.0143" velocity="4.7124" />
+        </joint>
+        <joint name="${prefix}joint_4" type="revolute">
+            <origin xyz="0 0 0.075" rpy="0 0 0"/>
+            <parent link="${prefix}link_3"/>
+            <child link="${prefix}link_4"/>
+            <axis xyz="-1 0 0"/>
+            <limit effort="0" lower="-3.3161" upper="3.3161" velocity="7.8540" />
+        </joint>
+        <joint name="${prefix}joint_5" type="revolute">
+            <origin xyz="0.410 0 0" rpy="0 0 0"/>
+            <parent link="${prefix}link_4"/>
+            <child link="${prefix}link_5"/>
+            <axis xyz="0 -1 0"/>
+            <limit effort="0" lower="-2.0944" upper="2.0944" velocity="7.8540" />
+        </joint>
+        <joint name="${prefix}joint_6" type="revolute">
+            <origin xyz="0.080 0 0" rpy="0 0 0"/>
+            <parent link="${prefix}link_5"/>
+            <child link="${prefix}link_6"/>
+            <axis xyz="-1 0 0"/>
+            <limit effort="0" lower="-6.2832" upper="6.2832" velocity="12.5664" />
+        </joint>
+        <joint name="${prefix}joint_6-tool0" type="fixed">
+            <origin xyz="0 0 0" rpy="${m_pi} ${-m_pi_2} 0" />
+            <parent link="${prefix}link_6" />
+            <child link="${prefix}tool0" />
+        </joint>
 
-    <!-- ROS base_link to Fanuc World Coordinates transform -->
-    <link name="${prefix}base" />
-    <joint name="${prefix}base_link-base" type="fixed">
-      <origin xyz="0 0 0.330" rpy="0 0 0"/>
-      <parent link="${prefix}base_link"/>
-      <child link="${prefix}base"/>
-    </joint>
-  </xacro:macro>
+        <!-- ROS base_link to Fanuc World Coordinates transform -->
+        <link name="${prefix}base" />
+        <joint name="${prefix}base_link-base" type="fixed">
+            <origin xyz="0 0 0.330" rpy="0 0 0"/>
+            <parent link="${prefix}base_link"/>
+            <child link="${prefix}base"/>
+        </joint>
+    </xacro:macro>
 </robot>

--- a/fanuc_lrmate200ic_support/urdf/lrmate200ic_macro.xacro
+++ b/fanuc_lrmate200ic_support/urdf/lrmate200ic_macro.xacro
@@ -1,170 +1,170 @@
 <?xml version="1.0" ?>
 <robot xmlns:xacro="http://ros.org/wiki/xacro">
-  <xacro:include filename="$(find fanuc_resources)/urdf/common_materials.xacro"/>
-  <xacro:include filename="$(find fanuc_resources)/urdf/common_constants.xacro"/>
+    <xacro:include filename="$(find fanuc_resources)/urdf/common_materials.xacro"/>
+    <xacro:include filename="$(find fanuc_resources)/urdf/common_constants.xacro"/>
 
-  <xacro:macro name="fanuc_lrmate200ic" params="prefix">
-    <link name="${prefix}base_link">
-      <visual>
-        <origin xyz="0 0 0" rpy="0 0 0"/>
-        <geometry>
-          <mesh filename="package://fanuc_lrmate200ic_support/meshes/lrmate200ic/visual/base_link.stl"/>
-        </geometry>
-        <xacro:material_fanuc_gray24 />
-      </visual>
-      <collision>
-        <origin xyz="0 0 0" rpy="0 0 0"/>
-        <geometry>
-          <mesh filename="package://fanuc_lrmate200ic_support/meshes/lrmate200ic/collision/base_link.stl"/>
-        </geometry>
-      </collision>
-    </link>
-    <link name="${prefix}link_1">
-      <visual>
-        <origin xyz="0 0 0" rpy="0 0 0"/>
-        <geometry>
-          <mesh filename="package://fanuc_lrmate200ic_support/meshes/lrmate200ic/visual/link_1.stl"/>
-        </geometry>
-        <xacro:material_fanuc_yellow />
-      </visual>
-      <collision>
-        <origin xyz="0 0 0" rpy="0 0 0"/>
-        <geometry>
-          <mesh filename="package://fanuc_lrmate200ic_support/meshes/lrmate200ic/collision/link_1.stl"/>
-        </geometry>
-      </collision>
-    </link>
-    <link name="${prefix}link_2">
-      <visual>
-        <origin xyz="0 0 0" rpy="0 0 0"/>
-        <geometry>
-          <mesh filename="package://fanuc_lrmate200ic_support/meshes/lrmate200ic/visual/link_2.stl"/>
-        </geometry>
-        <xacro:material_fanuc_yellow />
-      </visual>
-      <collision>
-        <origin xyz="0 0 0" rpy="0 0 0"/>
-        <geometry>
-          <mesh filename="package://fanuc_lrmate200ic_support/meshes/lrmate200ic/collision/link_2.stl"/>
-        </geometry>
-      </collision>
-    </link>
-    <link name="${prefix}link_3">
-      <visual>
-        <origin xyz="0 0 0" rpy="0 0 0"/>
-        <geometry>
-          <mesh filename="package://fanuc_lrmate200ic_support/meshes/lrmate200ic/visual/link_3.stl"/>
-        </geometry>
-        <xacro:material_fanuc_yellow />
-      </visual>
-      <collision>
-        <origin xyz="0 0 0" rpy="0 0 0"/>
-        <geometry>
-          <mesh filename="package://fanuc_lrmate200ic_support/meshes/lrmate200ic/collision/link_3.stl"/>
-        </geometry>
-      </collision>
-    </link>
-    <link name="${prefix}link_4">
-      <visual>
-        <origin xyz="0 0 0" rpy="0 0 0"/>
-        <geometry>
-          <mesh filename="package://fanuc_lrmate200ic_support/meshes/lrmate200ic/visual/link_4.stl"/>
-        </geometry>
-        <xacro:material_fanuc_yellow />
-      </visual>
-      <collision>
-        <origin xyz="0 0 0" rpy="0 0 0"/>
-        <geometry>
-          <mesh filename="package://fanuc_lrmate200ic_support/meshes/lrmate200ic/collision/link_4.stl"/>
-        </geometry>
-      </collision>
-    </link>
-    <link name="${prefix}link_5">
-      <visual>
-        <origin xyz="0 0 0" rpy="0 0 0"/>
-        <geometry>
-          <mesh filename="package://fanuc_lrmate200ic_support/meshes/lrmate200ic/visual/link_5.stl"/>
-        </geometry>
-        <xacro:material_fanuc_yellow />
-      </visual>
-      <collision>
-        <origin xyz="0 0 0" rpy="0 0 0"/>
-        <geometry>
-          <mesh filename="package://fanuc_lrmate200ic_support/meshes/lrmate200ic/collision/link_5.stl"/>
-        </geometry>
-      </collision>
-    </link>
-    <link name="${prefix}link_6">
-      <visual>
-        <origin xyz="0 0 0" rpy="0 0 0"/>
-        <geometry>
-          <mesh filename="package://fanuc_lrmate200ic_support/meshes/lrmate200ic/visual/link_6.stl"/>
-        </geometry>
-        <xacro:material_fanuc_black />
-      </visual>
-      <collision>
-        <origin xyz="0 0 0" rpy="0 0 0"/>
-        <geometry>
-          <mesh filename="package://fanuc_lrmate200ic_support/meshes/lrmate200ic/collision/link_6.stl"/>
-        </geometry>
-      </collision>
-    </link>
-    <link name="${prefix}tool0" />
+    <xacro:macro name="fanuc_lrmate200ic" params="prefix">
+        <link name="${prefix}base_link">
+            <visual>
+                <origin xyz="0 0 0" rpy="0 0 0"/>
+                <geometry>
+                    <mesh filename="package://fanuc_lrmate200ic_support/meshes/lrmate200ic/visual/base_link.stl"/>
+                </geometry>
+                <xacro:material_fanuc_gray24 />
+            </visual>
+            <collision>
+                <origin xyz="0 0 0" rpy="0 0 0"/>
+                <geometry>
+                    <mesh filename="package://fanuc_lrmate200ic_support/meshes/lrmate200ic/collision/base_link.stl"/>
+                </geometry>
+            </collision>
+        </link>
+        <link name="${prefix}link_1">
+            <visual>
+                <origin xyz="0 0 0" rpy="0 0 0"/>
+                <geometry>
+                    <mesh filename="package://fanuc_lrmate200ic_support/meshes/lrmate200ic/visual/link_1.stl"/>
+                </geometry>
+                <xacro:material_fanuc_yellow />
+            </visual>
+            <collision>
+                <origin xyz="0 0 0" rpy="0 0 0"/>
+                <geometry>
+                    <mesh filename="package://fanuc_lrmate200ic_support/meshes/lrmate200ic/collision/link_1.stl"/>
+                </geometry>
+            </collision>
+        </link>
+        <link name="${prefix}link_2">
+            <visual>
+                <origin xyz="0 0 0" rpy="0 0 0"/>
+                <geometry>
+                    <mesh filename="package://fanuc_lrmate200ic_support/meshes/lrmate200ic/visual/link_2.stl"/>
+                </geometry>
+                <xacro:material_fanuc_yellow />
+            </visual>
+            <collision>
+                <origin xyz="0 0 0" rpy="0 0 0"/>
+                <geometry>
+                    <mesh filename="package://fanuc_lrmate200ic_support/meshes/lrmate200ic/collision/link_2.stl"/>
+                </geometry>
+            </collision>
+        </link>
+        <link name="${prefix}link_3">
+            <visual>
+                <origin xyz="0 0 0" rpy="0 0 0"/>
+                <geometry>
+                    <mesh filename="package://fanuc_lrmate200ic_support/meshes/lrmate200ic/visual/link_3.stl"/>
+                </geometry>
+                <xacro:material_fanuc_yellow />
+            </visual>
+            <collision>
+                <origin xyz="0 0 0" rpy="0 0 0"/>
+                <geometry>
+                    <mesh filename="package://fanuc_lrmate200ic_support/meshes/lrmate200ic/collision/link_3.stl"/>
+                </geometry>
+            </collision>
+        </link>
+        <link name="${prefix}link_4">
+            <visual>
+                <origin xyz="0 0 0" rpy="0 0 0"/>
+                <geometry>
+                    <mesh filename="package://fanuc_lrmate200ic_support/meshes/lrmate200ic/visual/link_4.stl"/>
+                </geometry>
+                <xacro:material_fanuc_yellow />
+            </visual>
+            <collision>
+                <origin xyz="0 0 0" rpy="0 0 0"/>
+                <geometry>
+                    <mesh filename="package://fanuc_lrmate200ic_support/meshes/lrmate200ic/collision/link_4.stl"/>
+                </geometry>
+            </collision>
+        </link>
+        <link name="${prefix}link_5">
+            <visual>
+                <origin xyz="0 0 0" rpy="0 0 0"/>
+                <geometry>
+                    <mesh filename="package://fanuc_lrmate200ic_support/meshes/lrmate200ic/visual/link_5.stl"/>
+                </geometry>
+                <xacro:material_fanuc_yellow />
+            </visual>
+            <collision>
+                <origin xyz="0 0 0" rpy="0 0 0"/>
+                <geometry>
+                    <mesh filename="package://fanuc_lrmate200ic_support/meshes/lrmate200ic/collision/link_5.stl"/>
+                </geometry>
+            </collision>
+        </link>
+        <link name="${prefix}link_6">
+            <visual>
+                <origin xyz="0 0 0" rpy="0 0 0"/>
+                <geometry>
+                    <mesh filename="package://fanuc_lrmate200ic_support/meshes/lrmate200ic/visual/link_6.stl"/>
+                </geometry>
+                <xacro:material_fanuc_black />
+            </visual>
+            <collision>
+                <origin xyz="0 0 0" rpy="0 0 0"/>
+                <geometry>
+                    <mesh filename="package://fanuc_lrmate200ic_support/meshes/lrmate200ic/collision/link_6.stl"/>
+                </geometry>
+            </collision>
+        </link>
+        <link name="${prefix}tool0" />
 
-    <joint name="${prefix}joint_1" type="revolute">
-      <origin xyz="0 0 0.330" rpy="0 0 0" />
-      <parent link="${prefix}base_link" />
-      <child link="${prefix}link_1" />
-      <axis xyz="0 0 1" />
-      <limit effort="0" lower="-2.9671" upper="2.9671" velocity="6.1087" />
-    </joint>
-    <joint name="${prefix}joint_2" type="revolute">
-      <origin xyz="0.075 0 0" rpy="0 0 0" />
-      <parent link="${prefix}link_1" />
-      <child link="${prefix}link_2" />
-      <axis xyz="0 1 0" />
-      <limit effort="0" lower="-1.0472" upper="2.4435" velocity="6.1087" />
-    </joint>
-    <joint name="${prefix}joint_3" type="revolute">
-      <origin xyz="0 0 0.300" rpy="0 0 0" />
-      <parent link="${prefix}link_2" />
-      <child link="${prefix}link_3" />
-      <axis xyz="0 -1 0" />
-      <limit effort="0" lower="-2.4784" upper="4.0143" velocity="6.9813" />
-    </joint>
-    <joint name="${prefix}joint_4" type="revolute">
-      <origin xyz="0 0 0.075" rpy="0 0 0"/>
-      <parent link="${prefix}link_3"/>
-      <child link="${prefix}link_4"/>
-      <axis xyz="-1 0 0"/>
-      <limit effort="0" lower="-3.3161" upper="3.3161" velocity="7.8540" />
-    </joint>
-    <joint name="${prefix}joint_5" type="revolute">
-      <origin xyz="0.320 0 0" rpy="0 0 0"/>
-      <parent link="${prefix}link_4"/>
-      <child link="${prefix}link_5"/>
-      <axis xyz="0 -1 0"/>
-      <limit effort="0" lower="-2.0944" upper="2.0944" velocity="7.8540" />
-    </joint>
-    <joint name="${prefix}joint_6" type="revolute">
-      <origin xyz="0.080 0 0" rpy="0 0 0"/>
-      <parent link="${prefix}link_5"/>
-      <child link="${prefix}link_6"/>
-      <axis xyz="-1 0 0"/>
-      <limit effort="0" lower="-6.2832" upper="6.2832" velocity="12.5664" />
-    </joint>
-    <joint name="${prefix}joint_6-tool0" type="fixed">
-      <origin xyz="0 0 0" rpy="${m_pi} ${-m_pi_2} 0" />
-      <parent link="${prefix}link_6" />
-      <child link="${prefix}tool0" />
-    </joint>
+        <joint name="${prefix}joint_1" type="revolute">
+            <origin xyz="0 0 0.330" rpy="0 0 0" />
+            <parent link="${prefix}base_link" />
+            <child link="${prefix}link_1" />
+            <axis xyz="0 0 1" />
+            <limit effort="0" lower="-2.9671" upper="2.9671" velocity="6.1087" />
+        </joint>
+        <joint name="${prefix}joint_2" type="revolute">
+            <origin xyz="0.075 0 0" rpy="0 0 0" />
+            <parent link="${prefix}link_1" />
+            <child link="${prefix}link_2" />
+            <axis xyz="0 1 0" />
+            <limit effort="0" lower="-1.0472" upper="2.4435" velocity="6.1087" />
+        </joint>
+        <joint name="${prefix}joint_3" type="revolute">
+            <origin xyz="0 0 0.300" rpy="0 0 0" />
+            <parent link="${prefix}link_2" />
+            <child link="${prefix}link_3" />
+            <axis xyz="0 -1 0" />
+            <limit effort="0" lower="-2.4784" upper="4.0143" velocity="6.9813" />
+        </joint>
+        <joint name="${prefix}joint_4" type="revolute">
+            <origin xyz="0 0 0.075" rpy="0 0 0"/>
+            <parent link="${prefix}link_3"/>
+            <child link="${prefix}link_4"/>
+            <axis xyz="-1 0 0"/>
+            <limit effort="0" lower="-3.3161" upper="3.3161" velocity="7.8540" />
+        </joint>
+        <joint name="${prefix}joint_5" type="revolute">
+            <origin xyz="0.320 0 0" rpy="0 0 0"/>
+            <parent link="${prefix}link_4"/>
+            <child link="${prefix}link_5"/>
+            <axis xyz="0 -1 0"/>
+            <limit effort="0" lower="-2.0944" upper="2.0944" velocity="7.8540" />
+        </joint>
+        <joint name="${prefix}joint_6" type="revolute">
+            <origin xyz="0.080 0 0" rpy="0 0 0"/>
+            <parent link="${prefix}link_5"/>
+            <child link="${prefix}link_6"/>
+            <axis xyz="-1 0 0"/>
+            <limit effort="0" lower="-6.2832" upper="6.2832" velocity="12.5664" />
+        </joint>
+        <joint name="${prefix}joint_6-tool0" type="fixed">
+            <origin xyz="0 0 0" rpy="${m_pi} ${-m_pi_2} 0" />
+            <parent link="${prefix}link_6" />
+            <child link="${prefix}tool0" />
+        </joint>
 
-    <!-- ROS base_link to Fanuc World Coordinates transform -->
-    <link name="${prefix}base" />
-    <joint name="${prefix}base_link-base" type="fixed">
-      <origin xyz="0 0 0.330" rpy="0 0 0"/>
-      <parent link="${prefix}base_link"/>
-      <child link="${prefix}base"/>
-    </joint>
-  </xacro:macro>
+        <!-- ROS base_link to Fanuc World Coordinates transform -->
+        <link name="${prefix}base" />
+        <joint name="${prefix}base_link-base" type="fixed">
+            <origin xyz="0 0 0.330" rpy="0 0 0"/>
+            <parent link="${prefix}base_link"/>
+            <child link="${prefix}base"/>
+        </joint>
+    </xacro:macro>
 </robot>

--- a/fanuc_m10ia_support/urdf/m10ia.xacro
+++ b/fanuc_m10ia_support/urdf/m10ia.xacro
@@ -1,5 +1,5 @@
 <?xml version="1.0" ?>
 <robot name="fanuc_m10ia" xmlns:xacro="http://ros.org/wiki/xacro">
-  <xacro:include filename="$(find fanuc_m10ia_support)/urdf/m10ia_macro.xacro"/>
-  <xacro:fanuc_m10ia prefix=""/>
+    <xacro:include filename="$(find fanuc_m10ia_support)/urdf/m10ia_macro.xacro"/>
+    <xacro:fanuc_m10ia prefix=""/>
 </robot>

--- a/fanuc_m10ia_support/urdf/m10ia_macro.xacro
+++ b/fanuc_m10ia_support/urdf/m10ia_macro.xacro
@@ -1,172 +1,172 @@
 <?xml version="1.0"?>
 <robot xmlns:xacro="http://ros.org/wiki/xacro">
-  <xacro:include filename="$(find fanuc_resources)/urdf/common_materials.xacro"/>
-  <xacro:include filename="$(find fanuc_resources)/urdf/common_constants.xacro"/>
+    <xacro:include filename="$(find fanuc_resources)/urdf/common_materials.xacro"/>
+    <xacro:include filename="$(find fanuc_resources)/urdf/common_constants.xacro"/>
 
-  <xacro:macro name="fanuc_m10ia" params="prefix">
-    <!-- links -->
-    <link name="${prefix}base_link">
-      <visual>
-        <origin xyz="0 0 0" rpy="0 0 0"/>
-        <geometry>
-          <mesh filename="package://fanuc_m10ia_support/meshes/m10ia/visual/base_link.stl"/>
-        </geometry>
-        <xacro:material_fanuc_gray40 />
-      </visual>
-      <collision>
-        <origin xyz="0 0 0" rpy="0 0 0"/>
-        <geometry>
-          <mesh filename="package://fanuc_m10ia_support/meshes/m10ia/collision/base_link.stl"/>
-        </geometry>
-      </collision>
-    </link>
-    <link name="${prefix}link_1">
-      <visual>
-        <origin xyz="0 0 0" rpy="0 0 0"/>
-        <geometry>
-          <mesh filename="package://fanuc_m10ia_support/meshes/m10ia/visual/link_1.stl"/>
-        </geometry>
-        <xacro:material_fanuc_yellow />
-      </visual>
-      <collision>
-        <origin xyz="0 0 0" rpy="0 0 0"/>
-        <geometry>
-          <mesh filename="package://fanuc_m10ia_support/meshes/m10ia/collision/link_1.stl"/>
-        </geometry>
-      </collision>
-    </link>
-    <link name="${prefix}link_2">
-      <visual>
-        <origin xyz="0 0 0" rpy="0 0 0"/>
-        <geometry>
-          <mesh filename="package://fanuc_m10ia_support/meshes/m10ia/visual/link_2.stl"/>
-        </geometry>
-        <xacro:material_fanuc_yellow />
-      </visual>
-      <collision>
-        <origin xyz="0 0 0" rpy="0 0 0"/>
-        <geometry>
-          <mesh filename="package://fanuc_m10ia_support/meshes/m10ia/collision/link_2.stl"/>
-        </geometry>
-      </collision>
-    </link>
-    <link name="${prefix}link_3">
-      <visual>
-        <origin xyz="0 0 0" rpy="0 0 0"/>
-        <geometry>
-          <mesh filename="package://fanuc_m10ia_support/meshes/m10ia/visual/link_3.stl"/>
-        </geometry>
-        <xacro:material_fanuc_yellow />
-      </visual>
-      <collision>
-        <origin xyz="0 0 0" rpy="0 0 0"/>
-        <geometry>
-          <mesh filename="package://fanuc_m10ia_support/meshes/m10ia/collision/link_3.stl"/>
-        </geometry>
-      </collision>
-    </link>
-    <link name="${prefix}link_4">
-      <visual>
-        <origin xyz="0 0 0" rpy="0 0 0"/>
-        <geometry>
-          <mesh filename="package://fanuc_m10ia_support/meshes/m10ia/visual/link_4.stl"/>
-        </geometry>
-        <xacro:material_fanuc_yellow />
-      </visual>
-      <collision>
-        <origin xyz="0 0 0" rpy="0 0 0"/>
-        <geometry>
-          <mesh filename="package://fanuc_m10ia_support/meshes/m10ia/collision/link_4.stl"/>
-        </geometry>
-      </collision>
-    </link>
-    <link name="${prefix}link_5">
-      <visual>
-        <origin xyz="0 0 0" rpy="0 0 0"/>
-        <geometry>
-          <mesh filename="package://fanuc_m10ia_support/meshes/m10ia/visual/link_5.stl"/>
-        </geometry>
-        <xacro:material_fanuc_yellow />
-      </visual>
-      <collision>
-        <origin xyz="0 0 0" rpy="0 0 0"/>
-        <geometry>
-          <mesh filename="package://fanuc_m10ia_support/meshes/m10ia/collision/link_5.stl"/>
-        </geometry>
-      </collision>
-    </link>
-    <link name="${prefix}link_6">
-      <visual>
-        <origin xyz="0 0 0" rpy="0 0 0"/>
-        <geometry>
-          <mesh filename="package://fanuc_m10ia_support/meshes/m10ia/visual/link_6.stl"/>
-        </geometry>
-        <xacro:material_fanuc_black />
-      </visual>
-      <collision>
-        <origin xyz="0 0 0" rpy="0 0 0"/>
-        <geometry>
-          <mesh filename="package://fanuc_m10ia_support/meshes/m10ia/collision/link_6.stl"/>
-        </geometry>
-      </collision>
-    </link>
-    <link name="${prefix}tool0"/>
+    <xacro:macro name="fanuc_m10ia" params="prefix">
+        <!-- links -->
+        <link name="${prefix}base_link">
+            <visual>
+                <origin xyz="0 0 0" rpy="0 0 0"/>
+                <geometry>
+                    <mesh filename="package://fanuc_m10ia_support/meshes/m10ia/visual/base_link.stl"/>
+                </geometry>
+                <xacro:material_fanuc_gray40 />
+            </visual>
+            <collision>
+                <origin xyz="0 0 0" rpy="0 0 0"/>
+                <geometry>
+                    <mesh filename="package://fanuc_m10ia_support/meshes/m10ia/collision/base_link.stl"/>
+                </geometry>
+            </collision>
+        </link>
+        <link name="${prefix}link_1">
+            <visual>
+                <origin xyz="0 0 0" rpy="0 0 0"/>
+                <geometry>
+                    <mesh filename="package://fanuc_m10ia_support/meshes/m10ia/visual/link_1.stl"/>
+                </geometry>
+                <xacro:material_fanuc_yellow />
+            </visual>
+            <collision>
+                <origin xyz="0 0 0" rpy="0 0 0"/>
+                <geometry>
+                    <mesh filename="package://fanuc_m10ia_support/meshes/m10ia/collision/link_1.stl"/>
+                </geometry>
+            </collision>
+        </link>
+        <link name="${prefix}link_2">
+            <visual>
+                <origin xyz="0 0 0" rpy="0 0 0"/>
+                <geometry>
+                    <mesh filename="package://fanuc_m10ia_support/meshes/m10ia/visual/link_2.stl"/>
+                </geometry>
+                <xacro:material_fanuc_yellow />
+            </visual>
+            <collision>
+                <origin xyz="0 0 0" rpy="0 0 0"/>
+                <geometry>
+                    <mesh filename="package://fanuc_m10ia_support/meshes/m10ia/collision/link_2.stl"/>
+                </geometry>
+            </collision>
+        </link>
+        <link name="${prefix}link_3">
+            <visual>
+                <origin xyz="0 0 0" rpy="0 0 0"/>
+                <geometry>
+                    <mesh filename="package://fanuc_m10ia_support/meshes/m10ia/visual/link_3.stl"/>
+                </geometry>
+                <xacro:material_fanuc_yellow />
+            </visual>
+            <collision>
+                <origin xyz="0 0 0" rpy="0 0 0"/>
+                <geometry>
+                    <mesh filename="package://fanuc_m10ia_support/meshes/m10ia/collision/link_3.stl"/>
+                </geometry>
+            </collision>
+        </link>
+        <link name="${prefix}link_4">
+            <visual>
+                <origin xyz="0 0 0" rpy="0 0 0"/>
+                <geometry>
+                    <mesh filename="package://fanuc_m10ia_support/meshes/m10ia/visual/link_4.stl"/>
+                </geometry>
+                <xacro:material_fanuc_yellow />
+            </visual>
+            <collision>
+                <origin xyz="0 0 0" rpy="0 0 0"/>
+                <geometry>
+                    <mesh filename="package://fanuc_m10ia_support/meshes/m10ia/collision/link_4.stl"/>
+                </geometry>
+            </collision>
+        </link>
+        <link name="${prefix}link_5">
+            <visual>
+                <origin xyz="0 0 0" rpy="0 0 0"/>
+                <geometry>
+                    <mesh filename="package://fanuc_m10ia_support/meshes/m10ia/visual/link_5.stl"/>
+                </geometry>
+                <xacro:material_fanuc_yellow />
+            </visual>
+            <collision>
+                <origin xyz="0 0 0" rpy="0 0 0"/>
+                <geometry>
+                    <mesh filename="package://fanuc_m10ia_support/meshes/m10ia/collision/link_5.stl"/>
+                </geometry>
+            </collision>
+        </link>
+        <link name="${prefix}link_6">
+            <visual>
+                <origin xyz="0 0 0" rpy="0 0 0"/>
+                <geometry>
+                    <mesh filename="package://fanuc_m10ia_support/meshes/m10ia/visual/link_6.stl"/>
+                </geometry>
+                <xacro:material_fanuc_black />
+            </visual>
+            <collision>
+                <origin xyz="0 0 0" rpy="0 0 0"/>
+                <geometry>
+                    <mesh filename="package://fanuc_m10ia_support/meshes/m10ia/collision/link_6.stl"/>
+                </geometry>
+            </collision>
+        </link>
+        <link name="${prefix}tool0"/>
 
-    <!-- joints -->
-    <joint name="${prefix}joint_1" type="revolute">
-      <origin xyz="0 0 0.450" rpy="0 0 0"/>
-      <parent link="${prefix}base_link"/>
-      <child link="${prefix}link_1"/>
-      <axis xyz="0 0 1"/>
-      <limit lower="-3.14" upper="3.14" effort="0" velocity="3.67"/>
-    </joint>
-    <joint name="${prefix}joint_2" type="revolute">
-      <origin xyz="0.150 0 0" rpy="0 0 0"/>
-      <parent link="${prefix}link_1"/>
-      <child link="${prefix}link_2"/>
-      <axis xyz="0 1 0"/>
-      <limit lower="-1.57" upper="2.79" effort="0" velocity="3.32"/>
-    </joint>
-    <joint name="${prefix}joint_3" type="revolute">
-      <origin xyz="0 0 0.600" rpy="0 0 0"/>
-      <parent link="${prefix}link_2"/>
-      <child link="${prefix}link_3"/>
-      <axis xyz="0 -1 0"/>
-      <limit lower="-3.14" upper="4.61" effort="0" velocity="3.67"/>
-    </joint>
-    <joint name="${prefix}joint_4" type="revolute">
-      <origin xyz="0 0 0.200" rpy="0 0 0"/>
-      <parent link="${prefix}link_3"/>
-      <child link="${prefix}link_4"/>
-      <axis xyz="-1 0 0"/>
-      <limit lower="-3.31" upper="3.31" effort="0" velocity="6.98"/>
-    </joint>
-    <joint name="${prefix}joint_5" type="revolute">
-      <origin xyz="0.640 0 0" rpy="0 0 0"/>
-      <parent link="${prefix}link_4"/>
-      <child link="${prefix}link_5"/>
-      <axis xyz="0 -1 0"/>
-      <limit lower="-3.31" upper="3.31" effort="0" velocity="6.98"/>
-    </joint>
-    <joint name="${prefix}joint_6" type="revolute">
-      <origin xyz="0.100 0 0" rpy="0 0 0"/>
-      <parent link="${prefix}link_5"/>
-      <child link="${prefix}link_6"/>
-      <axis xyz="-1 0 0"/>
-      <limit lower="-6.28" upper="6.28" effort="0" velocity="10.47"/>
-    </joint>
-    <joint name="${prefix}joint_6-tool0" type="fixed">
-      <origin xyz="0 0 0" rpy="${m_pi} ${-m_pi_2} 0" />
-      <parent link="${prefix}link_6"/>
-      <child link="${prefix}tool0"/>
-    </joint>
+        <!-- joints -->
+        <joint name="${prefix}joint_1" type="revolute">
+            <origin xyz="0 0 0.450" rpy="0 0 0"/>
+            <parent link="${prefix}base_link"/>
+            <child link="${prefix}link_1"/>
+            <axis xyz="0 0 1"/>
+            <limit lower="-3.14" upper="3.14" effort="0" velocity="3.67"/>
+        </joint>
+        <joint name="${prefix}joint_2" type="revolute">
+            <origin xyz="0.150 0 0" rpy="0 0 0"/>
+            <parent link="${prefix}link_1"/>
+            <child link="${prefix}link_2"/>
+            <axis xyz="0 1 0"/>
+            <limit lower="-1.57" upper="2.79" effort="0" velocity="3.32"/>
+        </joint>
+        <joint name="${prefix}joint_3" type="revolute">
+            <origin xyz="0 0 0.600" rpy="0 0 0"/>
+            <parent link="${prefix}link_2"/>
+            <child link="${prefix}link_3"/>
+            <axis xyz="0 -1 0"/>
+            <limit lower="-3.14" upper="4.61" effort="0" velocity="3.67"/>
+        </joint>
+        <joint name="${prefix}joint_4" type="revolute">
+            <origin xyz="0 0 0.200" rpy="0 0 0"/>
+            <parent link="${prefix}link_3"/>
+            <child link="${prefix}link_4"/>
+            <axis xyz="-1 0 0"/>
+            <limit lower="-3.31" upper="3.31" effort="0" velocity="6.98"/>
+        </joint>
+        <joint name="${prefix}joint_5" type="revolute">
+            <origin xyz="0.640 0 0" rpy="0 0 0"/>
+            <parent link="${prefix}link_4"/>
+            <child link="${prefix}link_5"/>
+            <axis xyz="0 -1 0"/>
+            <limit lower="-3.31" upper="3.31" effort="0" velocity="6.98"/>
+        </joint>
+        <joint name="${prefix}joint_6" type="revolute">
+            <origin xyz="0.100 0 0" rpy="0 0 0"/>
+            <parent link="${prefix}link_5"/>
+            <child link="${prefix}link_6"/>
+            <axis xyz="-1 0 0"/>
+            <limit lower="-6.28" upper="6.28" effort="0" velocity="10.47"/>
+        </joint>
+        <joint name="${prefix}joint_6-tool0" type="fixed">
+            <origin xyz="0 0 0" rpy="${m_pi} ${-m_pi_2} 0" />
+            <parent link="${prefix}link_6"/>
+            <child link="${prefix}tool0"/>
+        </joint>
 
-    <!-- ROS base_link to Fanuc World Coordinates transform -->
-    <link name="${prefix}base" />
-    <joint name="${prefix}base_link-base" type="fixed">
-      <origin xyz="0 0 0.450" rpy="0 0 0"/>
-      <parent link="${prefix}base_link"/>
-      <child link="${prefix}base"/>
-    </joint>
-  </xacro:macro>
+        <!-- ROS base_link to Fanuc World Coordinates transform -->
+        <link name="${prefix}base" />
+        <joint name="${prefix}base_link-base" type="fixed">
+            <origin xyz="0 0 0.450" rpy="0 0 0"/>
+            <parent link="${prefix}base_link"/>
+            <child link="${prefix}base"/>
+        </joint>
+    </xacro:macro>
 </robot>

--- a/fanuc_m16ib_support/urdf/m16ib20.xacro
+++ b/fanuc_m16ib_support/urdf/m16ib20.xacro
@@ -1,5 +1,5 @@
 <?xml version="1.0" ?>
 <robot name="fanuc_m16ib20" xmlns:xacro="http://ros.org/wiki/xacro">
-  <xacro:include filename="$(find fanuc_m16ib_support)/urdf/m16ib20_macro.xacro"/>
-  <xacro:fanuc_m16ib20 prefix=""/>
+    <xacro:include filename="$(find fanuc_m16ib_support)/urdf/m16ib20_macro.xacro"/>
+    <xacro:fanuc_m16ib20 prefix=""/>
 </robot>

--- a/fanuc_m16ib_support/urdf/m16ib20_macro.xacro
+++ b/fanuc_m16ib_support/urdf/m16ib20_macro.xacro
@@ -1,172 +1,172 @@
 <?xml version="1.0" ?>
 <robot xmlns:xacro="http://ros.org/wiki/xacro">
-  <xacro:include filename="$(find fanuc_resources)/urdf/common_materials.xacro"/>
-  <xacro:include filename="$(find fanuc_resources)/urdf/common_constants.xacro"/>
+    <xacro:include filename="$(find fanuc_resources)/urdf/common_materials.xacro"/>
+    <xacro:include filename="$(find fanuc_resources)/urdf/common_constants.xacro"/>
 
-  <xacro:macro name="fanuc_m16ib20" params="prefix">
-    <!-- links -->
-    <link name="${prefix}base_link">
-      <visual>
-        <origin xyz="0 0 0" rpy="0 0 0"/>
-        <geometry>
-          <mesh filename="package://fanuc_m16ib_support/meshes/m16ib20/visual/base_link.stl"/>
-        </geometry>
-        <xacro:material_fanuc_yellow />
-      </visual>
-      <collision>
-        <origin xyz="0 0 0" rpy="0 0 0"/>
-        <geometry>
-          <mesh filename="package://fanuc_m16ib_support/meshes/m16ib20/collision/base_link.stl"/>
-        </geometry>
-      </collision>
-    </link>
-    <link name="${prefix}link_1">
-      <visual>
-        <origin xyz="0 0 0" rpy="0 0 0"/>
-        <geometry>
-          <mesh filename="package://fanuc_m16ib_support/meshes/m16ib20/visual/link_1.stl"/>
-        </geometry>
-        <xacro:material_fanuc_yellow />
-      </visual>
-      <collision>
-        <origin xyz="0 0 0" rpy="0 0 0"/>
-        <geometry>
-          <mesh filename="package://fanuc_m16ib_support/meshes/m16ib20/collision/link_1.stl"/>
-        </geometry>
-      </collision>
-    </link>
-    <link name="${prefix}link_2">
-      <visual>
-        <origin xyz="0 0 0" rpy="0 0 0"/>
-        <geometry>
-          <mesh filename="package://fanuc_m16ib_support/meshes/m16ib20/visual/link_2.stl"/>
-        </geometry>
-        <xacro:material_fanuc_yellow />
-      </visual>
-      <collision>
-        <origin xyz="0 0 0" rpy="0 0 0"/>
-        <geometry>
-          <mesh filename="package://fanuc_m16ib_support/meshes/m16ib20/collision/link_2.stl"/>
-        </geometry>
-      </collision>
-    </link>
-    <link name="${prefix}link_3">
-      <visual>
-        <origin xyz="0 0 0" rpy="0 0 0"/>
-        <geometry>
-          <mesh filename="package://fanuc_m16ib_support/meshes/m16ib20/visual/link_3.stl"/>
-        </geometry>
-        <xacro:material_fanuc_yellow />
-      </visual>
-      <collision>
-        <origin xyz="0 0 0" rpy="0 0 0"/>
-        <geometry>
-          <mesh filename="package://fanuc_m16ib_support/meshes/m16ib20/collision/link_3.stl"/>
-        </geometry>
-      </collision>
-    </link>
-    <link name="${prefix}link_4">
-      <visual>
-        <origin xyz="0 0 0" rpy="0 0 0"/>
-        <geometry>
-          <mesh filename="package://fanuc_m16ib_support/meshes/m16ib20/visual/link_4.stl"/>
-        </geometry>
-        <xacro:material_fanuc_yellow />
-      </visual>
-      <collision>
-        <origin xyz="0 0 0" rpy="0 0 0"/>
-        <geometry>
-          <mesh filename="package://fanuc_m16ib_support/meshes/m16ib20/collision/link_4.stl"/>
-        </geometry>
-      </collision>
-    </link>
-    <link name="${prefix}link_5">
-      <visual>
-        <origin xyz="0 0 0" rpy="0 0 0"/>
-        <geometry>
-          <mesh filename="package://fanuc_m16ib_support/meshes/m16ib20/visual/link_5.stl"/>
-        </geometry>
-        <xacro:material_fanuc_yellow />
-      </visual>
-      <collision>
-        <origin xyz="0 0 0" rpy="0 0 0"/>
-        <geometry>
-          <mesh filename="package://fanuc_m16ib_support/meshes/m16ib20/collision/link_5.stl"/>
-        </geometry>
-      </collision>
-    </link>
-    <link name="${prefix}link_6">
-      <visual>
-        <origin xyz="0 0 0" rpy="0 0 0"/>
-        <geometry>
-          <mesh filename="package://fanuc_m16ib_support/meshes/m16ib20/visual/link_6.stl"/>
-        </geometry>
-        <xacro:material_fanuc_black />
-      </visual>
-      <collision>
-        <origin xyz="0 0 0" rpy="0 0 0"/>
-        <geometry>
-          <mesh filename="package://fanuc_m16ib_support/meshes/m16ib20/collision/link_6.stl"/>
-        </geometry>
-      </collision>
-    </link>
-    <link name="${prefix}tool0"/>
+    <xacro:macro name="fanuc_m16ib20" params="prefix">
+        <!-- links -->
+        <link name="${prefix}base_link">
+            <visual>
+                <origin xyz="0 0 0" rpy="0 0 0"/>
+                <geometry>
+                    <mesh filename="package://fanuc_m16ib_support/meshes/m16ib20/visual/base_link.stl"/>
+                </geometry>
+                <xacro:material_fanuc_yellow />
+            </visual>
+            <collision>
+                <origin xyz="0 0 0" rpy="0 0 0"/>
+                <geometry>
+                    <mesh filename="package://fanuc_m16ib_support/meshes/m16ib20/collision/base_link.stl"/>
+                </geometry>
+            </collision>
+        </link>
+        <link name="${prefix}link_1">
+            <visual>
+                <origin xyz="0 0 0" rpy="0 0 0"/>
+                <geometry>
+                    <mesh filename="package://fanuc_m16ib_support/meshes/m16ib20/visual/link_1.stl"/>
+                </geometry>
+                <xacro:material_fanuc_yellow />
+            </visual>
+            <collision>
+                <origin xyz="0 0 0" rpy="0 0 0"/>
+                <geometry>
+                    <mesh filename="package://fanuc_m16ib_support/meshes/m16ib20/collision/link_1.stl"/>
+                </geometry>
+            </collision>
+        </link>
+        <link name="${prefix}link_2">
+            <visual>
+                <origin xyz="0 0 0" rpy="0 0 0"/>
+                <geometry>
+                    <mesh filename="package://fanuc_m16ib_support/meshes/m16ib20/visual/link_2.stl"/>
+                </geometry>
+                <xacro:material_fanuc_yellow />
+            </visual>
+            <collision>
+                <origin xyz="0 0 0" rpy="0 0 0"/>
+                <geometry>
+                    <mesh filename="package://fanuc_m16ib_support/meshes/m16ib20/collision/link_2.stl"/>
+                </geometry>
+            </collision>
+        </link>
+        <link name="${prefix}link_3">
+            <visual>
+                <origin xyz="0 0 0" rpy="0 0 0"/>
+                <geometry>
+                    <mesh filename="package://fanuc_m16ib_support/meshes/m16ib20/visual/link_3.stl"/>
+                </geometry>
+                <xacro:material_fanuc_yellow />
+            </visual>
+            <collision>
+                <origin xyz="0 0 0" rpy="0 0 0"/>
+                <geometry>
+                    <mesh filename="package://fanuc_m16ib_support/meshes/m16ib20/collision/link_3.stl"/>
+                </geometry>
+            </collision>
+        </link>
+        <link name="${prefix}link_4">
+            <visual>
+                <origin xyz="0 0 0" rpy="0 0 0"/>
+                <geometry>
+                    <mesh filename="package://fanuc_m16ib_support/meshes/m16ib20/visual/link_4.stl"/>
+                </geometry>
+                <xacro:material_fanuc_yellow />
+            </visual>
+            <collision>
+                <origin xyz="0 0 0" rpy="0 0 0"/>
+                <geometry>
+                    <mesh filename="package://fanuc_m16ib_support/meshes/m16ib20/collision/link_4.stl"/>
+                </geometry>
+            </collision>
+        </link>
+        <link name="${prefix}link_5">
+            <visual>
+                <origin xyz="0 0 0" rpy="0 0 0"/>
+                <geometry>
+                    <mesh filename="package://fanuc_m16ib_support/meshes/m16ib20/visual/link_5.stl"/>
+                </geometry>
+                <xacro:material_fanuc_yellow />
+            </visual>
+            <collision>
+                <origin xyz="0 0 0" rpy="0 0 0"/>
+                <geometry>
+                    <mesh filename="package://fanuc_m16ib_support/meshes/m16ib20/collision/link_5.stl"/>
+                </geometry>
+            </collision>
+        </link>
+        <link name="${prefix}link_6">
+            <visual>
+                <origin xyz="0 0 0" rpy="0 0 0"/>
+                <geometry>
+                    <mesh filename="package://fanuc_m16ib_support/meshes/m16ib20/visual/link_6.stl"/>
+                </geometry>
+                <xacro:material_fanuc_black />
+            </visual>
+            <collision>
+                <origin xyz="0 0 0" rpy="0 0 0"/>
+                <geometry>
+                    <mesh filename="package://fanuc_m16ib_support/meshes/m16ib20/collision/link_6.stl"/>
+                </geometry>
+            </collision>
+        </link>
+        <link name="${prefix}tool0"/>
 
-    <!-- joints -->
-    <joint name="${prefix}joint_1" type="revolute">
-      <origin xyz="0 0 0.525" rpy="0 0 0"/>
-      <parent link="${prefix}base_link"/>
-      <child link="${prefix}link_1"/>
-      <axis xyz="0 0 1"/>
-      <limit effort="0" lower="-2.9671" upper="2.9671" velocity="2.8798" />
-    </joint>
-    <joint name="${prefix}joint_2" type="revolute">
-      <origin xyz="0.150 0 0" rpy="0 0 0"/>
-      <parent link="${prefix}link_1"/>
-      <child link="${prefix}link_2"/>
-      <axis xyz="0 1 0"/>
-      <limit effort="0" lower="-1.5708" upper="2.7925" velocity="2.8798" />
-    </joint>
-    <joint name="${prefix}joint_3" type="revolute">
-      <origin xyz="0 0 0.770" rpy="0 0 0"/>
-      <parent link="${prefix}link_2"/>
-      <child link="${prefix}link_3"/>
-      <axis xyz="0 -1 0"/>
-      <limit effort="0" lower="-2.9671" upper="5.0615" velocity="3.0543" />
-    </joint>
-    <joint name="${prefix}joint_4" type="revolute">
-      <origin xyz="0 0 0.100" rpy="0 0 0"/>
-      <parent link="${prefix}link_3"/>
-      <child link="${prefix}link_4"/>
-      <axis xyz="-1 0 0"/>
-      <limit effort="0" lower="-3.4907" upper="3.4907" velocity="6.1087" />
-    </joint>
-    <joint name="${prefix}joint_5" type="revolute">
-      <origin xyz="0.740 0 0" rpy="0 0 0"/>
-      <parent link="${prefix}link_4"/>
-      <child link="${prefix}link_5"/>
-      <axis xyz="0 -1 0"/>
-      <limit effort="0" lower="-2.4435" upper="2.4435" velocity="5.9341" />
-    </joint>
-    <joint name="${prefix}joint_6" type="revolute">
-      <origin xyz="0.100 0 0" rpy="0 0 0"/>
-      <parent link="${prefix}link_5"/>
-      <child link="${prefix}link_6"/>
-      <axis xyz="-1 0 0"/>
-      <limit effort="0" lower="-7.8540" upper="7.8540" velocity="9.0757" />
-    </joint>
-    <joint name="${prefix}joint_6-tool0" type="fixed">
-      <origin xyz="0 0 0" rpy="${m_pi} ${-m_pi_2} 0" />
-      <parent link="${prefix}link_6"/>
-      <child link="${prefix}tool0"/>
-    </joint>
+        <!-- joints -->
+        <joint name="${prefix}joint_1" type="revolute">
+            <origin xyz="0 0 0.525" rpy="0 0 0"/>
+            <parent link="${prefix}base_link"/>
+            <child link="${prefix}link_1"/>
+            <axis xyz="0 0 1"/>
+            <limit effort="0" lower="-2.9671" upper="2.9671" velocity="2.8798" />
+        </joint>
+        <joint name="${prefix}joint_2" type="revolute">
+            <origin xyz="0.150 0 0" rpy="0 0 0"/>
+            <parent link="${prefix}link_1"/>
+            <child link="${prefix}link_2"/>
+            <axis xyz="0 1 0"/>
+            <limit effort="0" lower="-1.5708" upper="2.7925" velocity="2.8798" />
+        </joint>
+        <joint name="${prefix}joint_3" type="revolute">
+            <origin xyz="0 0 0.770" rpy="0 0 0"/>
+            <parent link="${prefix}link_2"/>
+            <child link="${prefix}link_3"/>
+            <axis xyz="0 -1 0"/>
+            <limit effort="0" lower="-2.9671" upper="5.0615" velocity="3.0543" />
+        </joint>
+        <joint name="${prefix}joint_4" type="revolute">
+            <origin xyz="0 0 0.100" rpy="0 0 0"/>
+            <parent link="${prefix}link_3"/>
+            <child link="${prefix}link_4"/>
+            <axis xyz="-1 0 0"/>
+            <limit effort="0" lower="-3.4907" upper="3.4907" velocity="6.1087" />
+        </joint>
+        <joint name="${prefix}joint_5" type="revolute">
+            <origin xyz="0.740 0 0" rpy="0 0 0"/>
+            <parent link="${prefix}link_4"/>
+            <child link="${prefix}link_5"/>
+            <axis xyz="0 -1 0"/>
+            <limit effort="0" lower="-2.4435" upper="2.4435" velocity="5.9341" />
+        </joint>
+        <joint name="${prefix}joint_6" type="revolute">
+            <origin xyz="0.100 0 0" rpy="0 0 0"/>
+            <parent link="${prefix}link_5"/>
+            <child link="${prefix}link_6"/>
+            <axis xyz="-1 0 0"/>
+            <limit effort="0" lower="-7.8540" upper="7.8540" velocity="9.0757" />
+        </joint>
+        <joint name="${prefix}joint_6-tool0" type="fixed">
+            <origin xyz="0 0 0" rpy="${m_pi} ${-m_pi_2} 0" />
+            <parent link="${prefix}link_6"/>
+            <child link="${prefix}tool0"/>
+        </joint>
 
-    <!-- ROS base_link to Fanuc World Coordinates transform -->
-    <link name="${prefix}base" />
-    <joint name="${prefix}base_link-base" type="fixed">
-      <origin xyz="0 0 0.525" rpy="0 0 0"/>
-      <parent link="${prefix}base_link"/>
-      <child link="${prefix}base"/>
-    </joint>
-  </xacro:macro>
+        <!-- ROS base_link to Fanuc World Coordinates transform -->
+        <link name="${prefix}base" />
+        <joint name="${prefix}base_link-base" type="fixed">
+            <origin xyz="0 0 0.525" rpy="0 0 0"/>
+            <parent link="${prefix}base_link"/>
+            <child link="${prefix}base"/>
+        </joint>
+    </xacro:macro>
 </robot>

--- a/fanuc_m20ia_support/urdf/m20ia.xacro
+++ b/fanuc_m20ia_support/urdf/m20ia.xacro
@@ -1,5 +1,5 @@
 <?xml version="1.0" ?>
 <robot name="fanuc_m20ia" xmlns:xacro="http://ros.org/wiki/xacro">
-  <xacro:include filename="$(find fanuc_m20ia_support)/urdf/m20ia_macro.xacro"/>
-  <xacro:fanuc_m20ia prefix=""/>
+    <xacro:include filename="$(find fanuc_m20ia_support)/urdf/m20ia_macro.xacro"/>
+    <xacro:fanuc_m20ia prefix=""/>
 </robot>

--- a/fanuc_m20ia_support/urdf/m20ia10l.xacro
+++ b/fanuc_m20ia_support/urdf/m20ia10l.xacro
@@ -1,5 +1,5 @@
 <?xml version="1.0" ?>
 <robot name="fanuc_m20ia10l" xmlns:xacro="http://ros.org/wiki/xacro">
-  <xacro:include filename="$(find fanuc_m20ia_support)/urdf/m20ia10l_macro.xacro"/>
-  <xacro:fanuc_m20ia10l prefix=""/>
+    <xacro:include filename="$(find fanuc_m20ia_support)/urdf/m20ia10l_macro.xacro"/>
+    <xacro:fanuc_m20ia10l prefix=""/>
 </robot>

--- a/fanuc_m20ia_support/urdf/m20ia10l_macro.xacro
+++ b/fanuc_m20ia_support/urdf/m20ia10l_macro.xacro
@@ -1,172 +1,172 @@
 <?xml version="1.0"?>
 <robot xmlns:xacro="http://ros.org/wiki/xacro">
-  <xacro:include filename="$(find fanuc_resources)/urdf/common_materials.xacro"/>
-  <xacro:include filename="$(find fanuc_resources)/urdf/common_constants.xacro"/>
+    <xacro:include filename="$(find fanuc_resources)/urdf/common_materials.xacro"/>
+    <xacro:include filename="$(find fanuc_resources)/urdf/common_constants.xacro"/>
 
-  <xacro:macro name="fanuc_m20ia10l" params="prefix">
-    <!-- links -->
-    <link name="${prefix}base_link">
-      <visual>
-        <origin xyz="0 0 0" rpy="0 0 0"/>
-        <geometry>
-          <mesh filename="package://fanuc_m20ia_support/meshes/m20ia10l/visual/base_link.stl"/>
-        </geometry>
-        <xacro:material_fanuc_gray28 />
-      </visual>
-      <collision>
-        <origin xyz="0 0 0" rpy="0 0 0"/>
-        <geometry>
-          <mesh filename="package://fanuc_m20ia_support/meshes/m20ia10l/collision/base_link.stl"/>
-        </geometry>
-      </collision>
-    </link>
-    <link name="${prefix}link_1">
-      <visual>
-        <origin xyz="0 0 0" rpy="0 0 0"/>
-        <geometry>
-          <mesh filename="package://fanuc_m20ia_support/meshes/m20ia10l/visual/link_1.stl"/>
-        </geometry>
-        <xacro:material_fanuc_yellow />
-      </visual>
-      <collision>
-        <origin xyz="0 0 0" rpy="0 0 0"/>
-        <geometry>
-          <mesh filename="package://fanuc_m20ia_support/meshes/m20ia10l/collision/link_1.stl"/>
-        </geometry>
-      </collision>
-    </link>
-    <link name="${prefix}link_2">
-      <visual>
-        <origin xyz="0 0 0" rpy="0 0 0"/>
-        <geometry>
-          <mesh filename="package://fanuc_m20ia_support/meshes/m20ia10l/visual/link_2.stl"/>
-        </geometry>
-        <xacro:material_fanuc_yellow />
-      </visual>
-      <collision>
-        <origin xyz="0 0 0" rpy="0 0 0"/>
-        <geometry>
-          <mesh filename="package://fanuc_m20ia_support/meshes/m20ia10l/collision/link_2.stl"/>
-        </geometry>
-      </collision>
-    </link>
-    <link name="${prefix}link_3">
-      <visual>
-        <origin xyz="0 0 0" rpy="0 0 0"/>
-        <geometry>
-          <mesh filename="package://fanuc_m20ia_support/meshes/m20ia10l/visual/link_3.stl"/>
-        </geometry>
-        <xacro:material_fanuc_yellow />
-      </visual>
-      <collision>
-        <origin xyz="0 0 0" rpy="0 0 0"/>
-        <geometry>
-          <mesh filename="package://fanuc_m20ia_support/meshes/m20ia10l/collision/link_3.stl"/>
-        </geometry>
-      </collision>
-    </link>
-    <link name="${prefix}link_4">
-      <visual>
-        <origin xyz="0 0 0" rpy="0 0 0"/>
-        <geometry>
-          <mesh filename="package://fanuc_m20ia_support/meshes/m20ia10l/visual/link_4.stl"/>
-        </geometry>
-        <xacro:material_fanuc_yellow />
-      </visual>
-      <collision>
-        <origin xyz="0 0 0" rpy="0 0 0"/>
-        <geometry>
-          <mesh filename="package://fanuc_m20ia_support/meshes/m20ia10l/collision/link_4.stl"/>
-        </geometry>
-      </collision>
-    </link>
-    <link name="${prefix}link_5">
-      <visual>
-        <origin xyz="0 0 0" rpy="0 0 0"/>
-        <geometry>
-          <mesh filename="package://fanuc_m20ia_support/meshes/m20ia10l/visual/link_5.stl"/>
-        </geometry>
-        <xacro:material_fanuc_yellow />
-      </visual>
-      <collision>
-        <origin xyz="0 0 0" rpy="0 0 0"/>
-        <geometry>
-          <mesh filename="package://fanuc_m20ia_support/meshes/m20ia10l/collision/link_5.stl"/>
-        </geometry>
-      </collision>
-    </link>
-    <link name="${prefix}link_6">
-      <visual>
-        <origin xyz="0 0 0" rpy="0 0 0"/>
-        <geometry>
-          <mesh filename="package://fanuc_m20ia_support/meshes/m20ia10l/visual/link_6.stl"/>
-        </geometry>
-        <xacro:material_fanuc_black />
-      </visual>
-      <collision>
-        <origin xyz="0 0 0" rpy="0 0 0"/>
-        <geometry>
-          <mesh filename="package://fanuc_m20ia_support/meshes/m20ia10l/collision/link_6.stl"/>
-        </geometry>
-      </collision>
-    </link>
-    <link name="${prefix}tool0"/>
+    <xacro:macro name="fanuc_m20ia10l" params="prefix">
+        <!-- links -->
+        <link name="${prefix}base_link">
+            <visual>
+                <origin xyz="0 0 0" rpy="0 0 0"/>
+                <geometry>
+                    <mesh filename="package://fanuc_m20ia_support/meshes/m20ia10l/visual/base_link.stl"/>
+                </geometry>
+                <xacro:material_fanuc_gray28 />
+            </visual>
+            <collision>
+                <origin xyz="0 0 0" rpy="0 0 0"/>
+                <geometry>
+                    <mesh filename="package://fanuc_m20ia_support/meshes/m20ia10l/collision/base_link.stl"/>
+                </geometry>
+            </collision>
+        </link>
+        <link name="${prefix}link_1">
+            <visual>
+                <origin xyz="0 0 0" rpy="0 0 0"/>
+                <geometry>
+                    <mesh filename="package://fanuc_m20ia_support/meshes/m20ia10l/visual/link_1.stl"/>
+                </geometry>
+                <xacro:material_fanuc_yellow />
+            </visual>
+            <collision>
+                <origin xyz="0 0 0" rpy="0 0 0"/>
+                <geometry>
+                    <mesh filename="package://fanuc_m20ia_support/meshes/m20ia10l/collision/link_1.stl"/>
+                </geometry>
+            </collision>
+        </link>
+        <link name="${prefix}link_2">
+            <visual>
+                <origin xyz="0 0 0" rpy="0 0 0"/>
+                <geometry>
+                    <mesh filename="package://fanuc_m20ia_support/meshes/m20ia10l/visual/link_2.stl"/>
+                </geometry>
+                <xacro:material_fanuc_yellow />
+            </visual>
+            <collision>
+                <origin xyz="0 0 0" rpy="0 0 0"/>
+                <geometry>
+                    <mesh filename="package://fanuc_m20ia_support/meshes/m20ia10l/collision/link_2.stl"/>
+                </geometry>
+            </collision>
+        </link>
+        <link name="${prefix}link_3">
+            <visual>
+                <origin xyz="0 0 0" rpy="0 0 0"/>
+                <geometry>
+                    <mesh filename="package://fanuc_m20ia_support/meshes/m20ia10l/visual/link_3.stl"/>
+                </geometry>
+                <xacro:material_fanuc_yellow />
+            </visual>
+            <collision>
+                <origin xyz="0 0 0" rpy="0 0 0"/>
+                <geometry>
+                    <mesh filename="package://fanuc_m20ia_support/meshes/m20ia10l/collision/link_3.stl"/>
+                </geometry>
+            </collision>
+        </link>
+        <link name="${prefix}link_4">
+            <visual>
+                <origin xyz="0 0 0" rpy="0 0 0"/>
+                <geometry>
+                    <mesh filename="package://fanuc_m20ia_support/meshes/m20ia10l/visual/link_4.stl"/>
+                </geometry>
+                <xacro:material_fanuc_yellow />
+            </visual>
+            <collision>
+                <origin xyz="0 0 0" rpy="0 0 0"/>
+                <geometry>
+                    <mesh filename="package://fanuc_m20ia_support/meshes/m20ia10l/collision/link_4.stl"/>
+                </geometry>
+            </collision>
+        </link>
+        <link name="${prefix}link_5">
+            <visual>
+                <origin xyz="0 0 0" rpy="0 0 0"/>
+                <geometry>
+                    <mesh filename="package://fanuc_m20ia_support/meshes/m20ia10l/visual/link_5.stl"/>
+                </geometry>
+                <xacro:material_fanuc_yellow />
+            </visual>
+            <collision>
+                <origin xyz="0 0 0" rpy="0 0 0"/>
+                <geometry>
+                    <mesh filename="package://fanuc_m20ia_support/meshes/m20ia10l/collision/link_5.stl"/>
+                </geometry>
+            </collision>
+        </link>
+        <link name="${prefix}link_6">
+            <visual>
+                <origin xyz="0 0 0" rpy="0 0 0"/>
+                <geometry>
+                    <mesh filename="package://fanuc_m20ia_support/meshes/m20ia10l/visual/link_6.stl"/>
+                </geometry>
+                <xacro:material_fanuc_black />
+            </visual>
+            <collision>
+                <origin xyz="0 0 0" rpy="0 0 0"/>
+                <geometry>
+                    <mesh filename="package://fanuc_m20ia_support/meshes/m20ia10l/collision/link_6.stl"/>
+                </geometry>
+            </collision>
+        </link>
+        <link name="${prefix}tool0"/>
 
-    <!-- joints -->
-    <joint name="${prefix}joint_1" type="revolute">
-      <origin xyz="0 0 0.525" rpy="0 0 0"/>
-      <parent link="${prefix}base_link"/>
-      <child link="${prefix}link_1"/>
-      <axis xyz="0 0 1"/>
-      <limit lower="-3.228859" upper="3.228859" effort="0" velocity="3.403392" />
-    </joint>
-    <joint name="${prefix}joint_2" type="revolute">
-      <origin xyz="0.150 0 0" rpy="0 0 0"/>
-      <parent link="${prefix}link_1"/>
-      <child link="${prefix}link_2"/>
-      <axis xyz="0 1 0"/>
-      <limit lower="-1.745329" upper="2.792527" effort="0" velocity="3.054326" />
-    </joint>
-    <joint name="${prefix}joint_3" type="revolute">
-      <origin xyz="0 0 0.790" rpy="0 0 0"/>
-      <parent link="${prefix}link_2"/>
-      <child link="${prefix}link_3"/>
-      <axis xyz="0 -1 0"/>
-      <limit lower="-3.228859" upper="4.810826" effort="0" velocity="3.141593" />
-    </joint>
-    <joint name="${prefix}joint_4" type="revolute">
-      <origin xyz="0 0 0.250" rpy="0 0 0"/>
-      <parent link="${prefix}link_3"/>
-      <child link="${prefix}link_4"/>
-      <axis xyz="-1 0 0"/>
-      <limit lower="-3.490658" upper="3.490658" effort="0" velocity="6.981317" />
-    </joint>
-    <joint name="${prefix}joint_5" type="revolute">
-      <origin xyz="1.040 0 0" rpy="0 0 0"/>
-      <parent link="${prefix}link_4"/>
-      <child link="${prefix}link_5"/>
-      <axis xyz="0 -1 0"/>
-      <limit lower="-2.443461" upper="2.443461" effort="0" velocity="6.981317" />
-    </joint>
-    <joint name="${prefix}joint_6" type="revolute">
-      <origin xyz="0.100 0 0" rpy="0 0 0"/>
-      <parent link="${prefix}link_5"/>
-      <child link="${prefix}link_6"/>
-      <axis xyz="-1 0 0"/>
-      <limit lower="-4.712389" upper="4.712389" effort="0" velocity="10.471980" />
-    </joint>
-    <joint name="${prefix}joint_6-tool0" type="fixed">
-      <origin xyz="0 0 0" rpy="${m_pi} ${-m_pi_2} 0" />
-      <parent link="${prefix}link_6"/>
-      <child link="${prefix}tool0"/>
-    </joint>
+        <!-- joints -->
+        <joint name="${prefix}joint_1" type="revolute">
+            <origin xyz="0 0 0.525" rpy="0 0 0"/>
+            <parent link="${prefix}base_link"/>
+            <child link="${prefix}link_1"/>
+            <axis xyz="0 0 1"/>
+            <limit lower="-3.228859" upper="3.228859" effort="0" velocity="3.403392" />
+        </joint>
+        <joint name="${prefix}joint_2" type="revolute">
+            <origin xyz="0.150 0 0" rpy="0 0 0"/>
+            <parent link="${prefix}link_1"/>
+            <child link="${prefix}link_2"/>
+            <axis xyz="0 1 0"/>
+            <limit lower="-1.745329" upper="2.792527" effort="0" velocity="3.054326" />
+        </joint>
+        <joint name="${prefix}joint_3" type="revolute">
+            <origin xyz="0 0 0.790" rpy="0 0 0"/>
+            <parent link="${prefix}link_2"/>
+            <child link="${prefix}link_3"/>
+            <axis xyz="0 -1 0"/>
+            <limit lower="-3.228859" upper="4.810826" effort="0" velocity="3.141593" />
+        </joint>
+        <joint name="${prefix}joint_4" type="revolute">
+            <origin xyz="0 0 0.250" rpy="0 0 0"/>
+            <parent link="${prefix}link_3"/>
+            <child link="${prefix}link_4"/>
+            <axis xyz="-1 0 0"/>
+            <limit lower="-3.490658" upper="3.490658" effort="0" velocity="6.981317" />
+        </joint>
+        <joint name="${prefix}joint_5" type="revolute">
+            <origin xyz="1.040 0 0" rpy="0 0 0"/>
+            <parent link="${prefix}link_4"/>
+            <child link="${prefix}link_5"/>
+            <axis xyz="0 -1 0"/>
+            <limit lower="-2.443461" upper="2.443461" effort="0" velocity="6.981317" />
+        </joint>
+        <joint name="${prefix}joint_6" type="revolute">
+            <origin xyz="0.100 0 0" rpy="0 0 0"/>
+            <parent link="${prefix}link_5"/>
+            <child link="${prefix}link_6"/>
+            <axis xyz="-1 0 0"/>
+            <limit lower="-4.712389" upper="4.712389" effort="0" velocity="10.471980" />
+        </joint>
+        <joint name="${prefix}joint_6-tool0" type="fixed">
+            <origin xyz="0 0 0" rpy="${m_pi} ${-m_pi_2} 0" />
+            <parent link="${prefix}link_6"/>
+            <child link="${prefix}tool0"/>
+        </joint>
 
-    <!-- ROS base_link to Fanuc World Coordinates transform -->
-    <link name="${prefix}base" />
-    <joint name="${prefix}base_link-base" type="fixed">
-      <origin xyz="0 0 0.525" rpy="0 0 0"/>
-      <parent link="${prefix}base_link"/>
-      <child link="${prefix}base"/>
-    </joint>
-  </xacro:macro>
+        <!-- ROS base_link to Fanuc World Coordinates transform -->
+        <link name="${prefix}base" />
+        <joint name="${prefix}base_link-base" type="fixed">
+            <origin xyz="0 0 0.525" rpy="0 0 0"/>
+            <parent link="${prefix}base_link"/>
+            <child link="${prefix}base"/>
+        </joint>
+    </xacro:macro>
 </robot>

--- a/fanuc_m20ia_support/urdf/m20ia_macro.xacro
+++ b/fanuc_m20ia_support/urdf/m20ia_macro.xacro
@@ -1,172 +1,172 @@
 <?xml version="1.0"?>
 <robot xmlns:xacro="http://ros.org/wiki/xacro">
-  <xacro:include filename="$(find fanuc_resources)/urdf/common_materials.xacro"/>
-  <xacro:include filename="$(find fanuc_resources)/urdf/common_constants.xacro"/>
+    <xacro:include filename="$(find fanuc_resources)/urdf/common_materials.xacro"/>
+    <xacro:include filename="$(find fanuc_resources)/urdf/common_constants.xacro"/>
 
-  <xacro:macro name="fanuc_m20ia" params="prefix">
-    <!-- links -->
-    <link name="${prefix}base_link">
-      <visual>
-        <origin xyz="0 0 0" rpy="0 0 0"/>
-        <geometry>
-          <mesh filename="package://fanuc_m20ia_support/meshes/m20ia/visual/base_link.stl"/>
-        </geometry>
-        <xacro:material_fanuc_gray28 />
-      </visual>
-      <collision>
-        <origin xyz="0 0 0" rpy="0 0 0"/>
-        <geometry>
-          <mesh filename="package://fanuc_m20ia_support/meshes/m20ia/collision/base_link.stl"/>
-        </geometry>
-      </collision>
-    </link>
-    <link name="${prefix}link_1">
-      <visual>
-        <origin xyz="0 0 0" rpy="0 0 0"/>
-        <geometry>
-          <mesh filename="package://fanuc_m20ia_support/meshes/m20ia/visual/link_1.stl"/>
-        </geometry>
-        <xacro:material_fanuc_yellow />
-      </visual>
-      <collision>
-        <origin xyz="0 0 0" rpy="0 0 0"/>
-        <geometry>
-          <mesh filename="package://fanuc_m20ia_support/meshes/m20ia/collision/link_1.stl"/>
-        </geometry>
-      </collision>
-    </link>
-    <link name="${prefix}link_2">
-      <visual>
-        <origin xyz="0 0 0" rpy="0 0 0"/>
-        <geometry>
-          <mesh filename="package://fanuc_m20ia_support/meshes/m20ia/visual/link_2.stl"/>
-        </geometry>
-        <xacro:material_fanuc_yellow />
-      </visual>
-      <collision>
-        <origin xyz="0 0 0" rpy="0 0 0"/>
-        <geometry>
-          <mesh filename="package://fanuc_m20ia_support/meshes/m20ia/collision/link_2.stl"/>
-        </geometry>
-      </collision>
-    </link>
-    <link name="${prefix}link_3">
-      <visual>
-        <origin xyz="0 0 0" rpy="0 0 0"/>
-        <geometry>
-          <mesh filename="package://fanuc_m20ia_support/meshes/m20ia/visual/link_3.stl"/>
-        </geometry>
-        <xacro:material_fanuc_yellow />
-      </visual>
-      <collision>
-        <origin xyz="0 0 0" rpy="0 0 0"/>
-        <geometry>
-          <mesh filename="package://fanuc_m20ia_support/meshes/m20ia/collision/link_3.stl"/>
-        </geometry>
-      </collision>
-    </link>
-    <link name="${prefix}link_4">
-      <visual>
-        <origin xyz="0 0 0" rpy="0 0 0"/>
-        <geometry>
-          <mesh filename="package://fanuc_m20ia_support/meshes/m20ia/visual/link_4.stl"/>
-        </geometry>
-        <xacro:material_fanuc_yellow />
-      </visual>
-      <collision>
-        <origin xyz="0 0 0" rpy="0 0 0"/>
-        <geometry>
-          <mesh filename="package://fanuc_m20ia_support/meshes/m20ia/collision/link_4.stl"/>
-        </geometry>
-      </collision>
-    </link>
-    <link name="${prefix}link_5">
-      <visual>
-        <origin xyz="0 0 0" rpy="0 0 0"/>
-        <geometry>
-          <mesh filename="package://fanuc_m20ia_support/meshes/m20ia/visual/link_5.stl"/>
-        </geometry>
-        <xacro:material_fanuc_yellow />
-      </visual>
-      <collision>
-        <origin xyz="0 0 0" rpy="0 0 0"/>
-        <geometry>
-          <mesh filename="package://fanuc_m20ia_support/meshes/m20ia/collision/link_5.stl"/>
-        </geometry>
-      </collision>
-    </link>
-    <link name="${prefix}link_6">
-      <visual>
-        <origin xyz="0 0 0" rpy="0 0 0"/>
-        <geometry>
-          <mesh filename="package://fanuc_m20ia_support/meshes/m20ia/visual/link_6.stl"/>
-        </geometry>
-        <xacro:material_fanuc_black />
-      </visual>
-      <collision>
-        <origin xyz="0 0 0" rpy="0 0 0"/>
-        <geometry>
-          <mesh filename="package://fanuc_m20ia_support/meshes/m20ia/collision/link_6.stl"/>
-        </geometry>
-      </collision>
-    </link>
-    <link name="${prefix}tool0"/>
+    <xacro:macro name="fanuc_m20ia" params="prefix">
+        <!-- links -->
+        <link name="${prefix}base_link">
+            <visual>
+                <origin xyz="0 0 0" rpy="0 0 0"/>
+                <geometry>
+                    <mesh filename="package://fanuc_m20ia_support/meshes/m20ia/visual/base_link.stl"/>
+                </geometry>
+                <xacro:material_fanuc_gray28 />
+            </visual>
+            <collision>
+                <origin xyz="0 0 0" rpy="0 0 0"/>
+                <geometry>
+                    <mesh filename="package://fanuc_m20ia_support/meshes/m20ia/collision/base_link.stl"/>
+                </geometry>
+            </collision>
+        </link>
+        <link name="${prefix}link_1">
+            <visual>
+                <origin xyz="0 0 0" rpy="0 0 0"/>
+                <geometry>
+                    <mesh filename="package://fanuc_m20ia_support/meshes/m20ia/visual/link_1.stl"/>
+                </geometry>
+                <xacro:material_fanuc_yellow />
+            </visual>
+            <collision>
+                <origin xyz="0 0 0" rpy="0 0 0"/>
+                <geometry>
+                    <mesh filename="package://fanuc_m20ia_support/meshes/m20ia/collision/link_1.stl"/>
+                </geometry>
+            </collision>
+        </link>
+        <link name="${prefix}link_2">
+            <visual>
+                <origin xyz="0 0 0" rpy="0 0 0"/>
+                <geometry>
+                    <mesh filename="package://fanuc_m20ia_support/meshes/m20ia/visual/link_2.stl"/>
+                </geometry>
+                <xacro:material_fanuc_yellow />
+            </visual>
+            <collision>
+                <origin xyz="0 0 0" rpy="0 0 0"/>
+                <geometry>
+                    <mesh filename="package://fanuc_m20ia_support/meshes/m20ia/collision/link_2.stl"/>
+                </geometry>
+            </collision>
+        </link>
+        <link name="${prefix}link_3">
+            <visual>
+                <origin xyz="0 0 0" rpy="0 0 0"/>
+                <geometry>
+                    <mesh filename="package://fanuc_m20ia_support/meshes/m20ia/visual/link_3.stl"/>
+                </geometry>
+                <xacro:material_fanuc_yellow />
+            </visual>
+            <collision>
+                <origin xyz="0 0 0" rpy="0 0 0"/>
+                <geometry>
+                    <mesh filename="package://fanuc_m20ia_support/meshes/m20ia/collision/link_3.stl"/>
+                </geometry>
+            </collision>
+        </link>
+        <link name="${prefix}link_4">
+            <visual>
+                <origin xyz="0 0 0" rpy="0 0 0"/>
+                <geometry>
+                    <mesh filename="package://fanuc_m20ia_support/meshes/m20ia/visual/link_4.stl"/>
+                </geometry>
+                <xacro:material_fanuc_yellow />
+            </visual>
+            <collision>
+                <origin xyz="0 0 0" rpy="0 0 0"/>
+                <geometry>
+                    <mesh filename="package://fanuc_m20ia_support/meshes/m20ia/collision/link_4.stl"/>
+                </geometry>
+            </collision>
+        </link>
+        <link name="${prefix}link_5">
+            <visual>
+                <origin xyz="0 0 0" rpy="0 0 0"/>
+                <geometry>
+                    <mesh filename="package://fanuc_m20ia_support/meshes/m20ia/visual/link_5.stl"/>
+                </geometry>
+                <xacro:material_fanuc_yellow />
+            </visual>
+            <collision>
+                <origin xyz="0 0 0" rpy="0 0 0"/>
+                <geometry>
+                    <mesh filename="package://fanuc_m20ia_support/meshes/m20ia/collision/link_5.stl"/>
+                </geometry>
+            </collision>
+        </link>
+        <link name="${prefix}link_6">
+            <visual>
+                <origin xyz="0 0 0" rpy="0 0 0"/>
+                <geometry>
+                    <mesh filename="package://fanuc_m20ia_support/meshes/m20ia/visual/link_6.stl"/>
+                </geometry>
+                <xacro:material_fanuc_black />
+            </visual>
+            <collision>
+                <origin xyz="0 0 0" rpy="0 0 0"/>
+                <geometry>
+                    <mesh filename="package://fanuc_m20ia_support/meshes/m20ia/collision/link_6.stl"/>
+                </geometry>
+            </collision>
+        </link>
+        <link name="${prefix}tool0"/>
 
-    <!-- joints -->
-    <joint name="${prefix}joint_1" type="revolute">
-      <origin xyz="0 0 0.525" rpy="0 0 0"/>
-      <parent link="${prefix}base_link"/>
-      <child link="${prefix}link_1"/>
-      <axis xyz="0 0 1"/>
-      <limit lower="-2.967060" upper="2.967060" effort="0" velocity="3.403392" />
-    </joint>
-    <joint name="${prefix}joint_2" type="revolute">
-      <origin xyz="0.150 0 0" rpy="0 0 0"/>
-      <parent link="${prefix}link_1"/>
-      <child link="${prefix}link_2"/>
-      <axis xyz="0 1 0"/>
-      <limit lower="-1.745329" upper="2.792527" effort="0" velocity="3.054326" />
-    </joint>
-    <joint name="${prefix}joint_3" type="revolute">
-      <origin xyz="0 0 0.790" rpy="0 0 0"/>
-      <parent link="${prefix}link_2"/>
-      <child link="${prefix}link_3"/>
-      <axis xyz="0 -1 0"/>
-      <limit lower="-3.228859" upper="4.766843" effort="0" velocity="3.141593" />
-    </joint>
-    <joint name="${prefix}joint_4" type="revolute">
-      <origin xyz="0 0 0.250" rpy="0 0 0"/>
-      <parent link="${prefix}link_3"/>
-      <child link="${prefix}link_4"/>
-      <axis xyz="-1 0 0"/>
-      <limit lower="-3.490658" upper="3.490658" effort="0" velocity="6.283185" />
-    </joint>
-    <joint name="${prefix}joint_5" type="revolute">
-      <origin xyz="0.835 0 0" rpy="0 0 0"/>
-      <parent link="${prefix}link_4"/>
-      <child link="${prefix}link_5"/>
-      <axis xyz="0 -1 0"/>
-      <limit lower="-2.443461" upper="2.443461" effort="0" velocity="6.283185" />
-    </joint>
-    <joint name="${prefix}joint_6" type="revolute">
-      <origin xyz="0.100 0 0" rpy="0 0 0"/>
-      <parent link="${prefix}link_5"/>
-      <child link="${prefix}link_6"/>
-      <axis xyz="-1 0 0"/>
-      <limit lower="-4.712389" upper="4.712389" effort="0" velocity="9.599311" />
-    </joint>
-    <joint name="${prefix}joint_6-tool0" type="fixed">
-      <origin xyz="0 0 0" rpy="${m_pi} ${-m_pi_2} 0" />
-      <parent link="${prefix}link_6"/>
-      <child link="${prefix}tool0"/>
-    </joint>
+        <!-- joints -->
+        <joint name="${prefix}joint_1" type="revolute">
+            <origin xyz="0 0 0.525" rpy="0 0 0"/>
+            <parent link="${prefix}base_link"/>
+            <child link="${prefix}link_1"/>
+            <axis xyz="0 0 1"/>
+            <limit lower="-2.967060" upper="2.967060" effort="0" velocity="3.403392" />
+        </joint>
+        <joint name="${prefix}joint_2" type="revolute">
+            <origin xyz="0.150 0 0" rpy="0 0 0"/>
+            <parent link="${prefix}link_1"/>
+            <child link="${prefix}link_2"/>
+            <axis xyz="0 1 0"/>
+            <limit lower="-1.745329" upper="2.792527" effort="0" velocity="3.054326" />
+        </joint>
+        <joint name="${prefix}joint_3" type="revolute">
+            <origin xyz="0 0 0.790" rpy="0 0 0"/>
+            <parent link="${prefix}link_2"/>
+            <child link="${prefix}link_3"/>
+            <axis xyz="0 -1 0"/>
+            <limit lower="-3.228859" upper="4.766843" effort="0" velocity="3.141593" />
+        </joint>
+        <joint name="${prefix}joint_4" type="revolute">
+            <origin xyz="0 0 0.250" rpy="0 0 0"/>
+            <parent link="${prefix}link_3"/>
+            <child link="${prefix}link_4"/>
+            <axis xyz="-1 0 0"/>
+            <limit lower="-3.490658" upper="3.490658" effort="0" velocity="6.283185" />
+        </joint>
+        <joint name="${prefix}joint_5" type="revolute">
+            <origin xyz="0.835 0 0" rpy="0 0 0"/>
+            <parent link="${prefix}link_4"/>
+            <child link="${prefix}link_5"/>
+            <axis xyz="0 -1 0"/>
+            <limit lower="-2.443461" upper="2.443461" effort="0" velocity="6.283185" />
+        </joint>
+        <joint name="${prefix}joint_6" type="revolute">
+            <origin xyz="0.100 0 0" rpy="0 0 0"/>
+            <parent link="${prefix}link_5"/>
+            <child link="${prefix}link_6"/>
+            <axis xyz="-1 0 0"/>
+            <limit lower="-4.712389" upper="4.712389" effort="0" velocity="9.599311" />
+        </joint>
+        <joint name="${prefix}joint_6-tool0" type="fixed">
+            <origin xyz="0 0 0" rpy="${m_pi} ${-m_pi_2} 0" />
+            <parent link="${prefix}link_6"/>
+            <child link="${prefix}tool0"/>
+        </joint>
 
-    <!-- ROS base_link to Fanuc World Coordinates transform -->
-    <link name="${prefix}base" />
-    <joint name="${prefix}base_link-base" type="fixed">
-      <origin xyz="0 0 0.525" rpy="0 0 0"/>
-      <parent link="${prefix}base_link"/>
-      <child link="${prefix}base"/>
-    </joint>
-  </xacro:macro>
+        <!-- ROS base_link to Fanuc World Coordinates transform -->
+        <link name="${prefix}base" />
+        <joint name="${prefix}base_link-base" type="fixed">
+            <origin xyz="0 0 0.525" rpy="0 0 0"/>
+            <parent link="${prefix}base_link"/>
+            <child link="${prefix}base"/>
+        </joint>
+    </xacro:macro>
 </robot>

--- a/fanuc_m430ia_support/urdf/m430ia2f.xacro
+++ b/fanuc_m430ia_support/urdf/m430ia2f.xacro
@@ -1,5 +1,5 @@
 <?xml version="1.0" ?>
 <robot name="fanuc_m430ia2f" xmlns:xacro="http://ros.org/wiki/xacro">
-  <xacro:include filename="$(find fanuc_m430ia_support)/urdf/m430ia2f_macro.xacro"/>
-  <xacro:fanuc_m430ia2f prefix=""/>
+    <xacro:include filename="$(find fanuc_m430ia_support)/urdf/m430ia2f_macro.xacro"/>
+    <xacro:fanuc_m430ia2f prefix=""/>
 </robot>

--- a/fanuc_m430ia_support/urdf/m430ia2f_macro.xacro
+++ b/fanuc_m430ia_support/urdf/m430ia2f_macro.xacro
@@ -1,150 +1,150 @@
 <?xml version="1.0"?>
 <robot xmlns:xacro="http://ros.org/wiki/xacro">
-  <xacro:include filename="$(find fanuc_resources)/urdf/common_materials.xacro"/>
-  <xacro:include filename="$(find fanuc_resources)/urdf/common_constants.xacro"/>
+    <xacro:include filename="$(find fanuc_resources)/urdf/common_materials.xacro"/>
+    <xacro:include filename="$(find fanuc_resources)/urdf/common_constants.xacro"/>
 
-  <xacro:macro name="fanuc_m430ia2f" params="prefix">
-    <!-- links -->
-    <link name="${prefix}base_link">
-      <visual>
-        <origin xyz="0 0 0" rpy="0 0 0"/>
-        <geometry>
-          <mesh filename="package://fanuc_m430ia_support/meshes/m430ia2f/visual/base_link.stl"/>
-        </geometry>
-        <xacro:material_fanuc_white />
-      </visual>
-      <collision>
-        <origin xyz="0 0 0" rpy="0 0 0"/>
-        <geometry>
-          <mesh filename="package://fanuc_m430ia_support/meshes/m430ia2f/collision/base_link.stl"/>
-        </geometry>
-      </collision>
-    </link>
-    <link name="${prefix}link_1">
-      <visual>
-        <origin xyz="0 0 0" rpy="0 0 0"/>
-        <geometry>
-          <mesh filename="package://fanuc_m430ia_support/meshes/m430ia2f/visual/link_1.stl"/>
-        </geometry>
-        <xacro:material_fanuc_white />
-      </visual>
-      <collision>
-        <origin xyz="0 0 0" rpy="0 0 0"/>
-        <geometry>
-          <mesh filename="package://fanuc_m430ia_support/meshes/m430ia2f/collision/link_1.stl"/>
-        </geometry>
-      </collision>
-    </link>
-    <link name="${prefix}link_2">
-      <visual>
-        <origin xyz="0 0 0" rpy="0 0 0"/>
-        <geometry>
-          <mesh filename="package://fanuc_m430ia_support/meshes/m430ia2f/visual/link_2.stl"/>
-        </geometry>
-        <xacro:material_fanuc_white />
-      </visual>
-      <collision>
-        <origin xyz="0 0 0" rpy="0 0 0"/>
-        <geometry>
-          <mesh filename="package://fanuc_m430ia_support/meshes/m430ia2f/collision/link_2.stl"/>
-        </geometry>
-      </collision>
-    </link>
-    <link name="${prefix}link_3">
-      <visual>
-        <origin xyz="0 0 0" rpy="0 0 0"/>
-        <geometry>
-          <mesh filename="package://fanuc_m430ia_support/meshes/m430ia2f/visual/link_3.stl"/>
-        </geometry>
-        <xacro:material_fanuc_white />
-      </visual>
-      <collision>
-        <origin xyz="0 0 0" rpy="0 0 0"/>
-        <geometry>
-          <mesh filename="package://fanuc_m430ia_support/meshes/m430ia2f/collision/link_3.stl"/>
-        </geometry>
-      </collision>
-    </link>
-    <link name="${prefix}link_4">
-      <visual>
-        <origin xyz="0 0 0" rpy="0 0 0"/>
-        <geometry>
-          <mesh filename="package://fanuc_m430ia_support/meshes/m430ia2f/visual/link_4.stl"/>
-        </geometry>
-        <xacro:material_fanuc_white />
-      </visual>
-      <collision>
-        <origin xyz="0 0 0" rpy="0 0 0"/>
-        <geometry>
-          <mesh filename="package://fanuc_m430ia_support/meshes/m430ia2f/collision/link_4.stl"/>
-        </geometry>
-      </collision>
-    </link>
-    <link name="${prefix}link_5">
-      <visual>
-        <origin xyz="0 0 0" rpy="0 0 0"/>
-        <geometry>
-          <mesh filename="package://fanuc_m430ia_support/meshes/m430ia2f/visual/link_5.stl"/>
-        </geometry>
-        <xacro:material_fanuc_white />
-      </visual>
-      <collision>
-        <origin xyz="0 0 0" rpy="0 0 0"/>
-        <geometry>
-          <mesh filename="package://fanuc_m430ia_support/meshes/m430ia2f/collision/link_5.stl"/>
-        </geometry>
-      </collision>
-    </link>
-    <link name="${prefix}tool0"/>
+    <xacro:macro name="fanuc_m430ia2f" params="prefix">
+        <!-- links -->
+        <link name="${prefix}base_link">
+            <visual>
+                <origin xyz="0 0 0" rpy="0 0 0"/>
+                <geometry>
+                    <mesh filename="package://fanuc_m430ia_support/meshes/m430ia2f/visual/base_link.stl"/>
+                </geometry>
+                <xacro:material_fanuc_white />
+            </visual>
+            <collision>
+                <origin xyz="0 0 0" rpy="0 0 0"/>
+                <geometry>
+                    <mesh filename="package://fanuc_m430ia_support/meshes/m430ia2f/collision/base_link.stl"/>
+                </geometry>
+            </collision>
+        </link>
+        <link name="${prefix}link_1">
+            <visual>
+                <origin xyz="0 0 0" rpy="0 0 0"/>
+                <geometry>
+                    <mesh filename="package://fanuc_m430ia_support/meshes/m430ia2f/visual/link_1.stl"/>
+                </geometry>
+                <xacro:material_fanuc_white />
+            </visual>
+            <collision>
+                <origin xyz="0 0 0" rpy="0 0 0"/>
+                <geometry>
+                    <mesh filename="package://fanuc_m430ia_support/meshes/m430ia2f/collision/link_1.stl"/>
+                </geometry>
+            </collision>
+        </link>
+        <link name="${prefix}link_2">
+            <visual>
+                <origin xyz="0 0 0" rpy="0 0 0"/>
+                <geometry>
+                    <mesh filename="package://fanuc_m430ia_support/meshes/m430ia2f/visual/link_2.stl"/>
+                </geometry>
+                <xacro:material_fanuc_white />
+            </visual>
+            <collision>
+                <origin xyz="0 0 0" rpy="0 0 0"/>
+                <geometry>
+                    <mesh filename="package://fanuc_m430ia_support/meshes/m430ia2f/collision/link_2.stl"/>
+                </geometry>
+            </collision>
+        </link>
+        <link name="${prefix}link_3">
+            <visual>
+                <origin xyz="0 0 0" rpy="0 0 0"/>
+                <geometry>
+                    <mesh filename="package://fanuc_m430ia_support/meshes/m430ia2f/visual/link_3.stl"/>
+                </geometry>
+                <xacro:material_fanuc_white />
+            </visual>
+            <collision>
+                <origin xyz="0 0 0" rpy="0 0 0"/>
+                <geometry>
+                    <mesh filename="package://fanuc_m430ia_support/meshes/m430ia2f/collision/link_3.stl"/>
+                </geometry>
+            </collision>
+        </link>
+        <link name="${prefix}link_4">
+            <visual>
+                <origin xyz="0 0 0" rpy="0 0 0"/>
+                <geometry>
+                    <mesh filename="package://fanuc_m430ia_support/meshes/m430ia2f/visual/link_4.stl"/>
+                </geometry>
+                <xacro:material_fanuc_white />
+            </visual>
+            <collision>
+                <origin xyz="0 0 0" rpy="0 0 0"/>
+                <geometry>
+                    <mesh filename="package://fanuc_m430ia_support/meshes/m430ia2f/collision/link_4.stl"/>
+                </geometry>
+            </collision>
+        </link>
+        <link name="${prefix}link_5">
+            <visual>
+                <origin xyz="0 0 0" rpy="0 0 0"/>
+                <geometry>
+                    <mesh filename="package://fanuc_m430ia_support/meshes/m430ia2f/visual/link_5.stl"/>
+                </geometry>
+                <xacro:material_fanuc_white />
+            </visual>
+            <collision>
+                <origin xyz="0 0 0" rpy="0 0 0"/>
+                <geometry>
+                    <mesh filename="package://fanuc_m430ia_support/meshes/m430ia2f/collision/link_5.stl"/>
+                </geometry>
+            </collision>
+        </link>
+        <link name="${prefix}tool0"/>
 
-    <!-- joints -->
-    <joint name="${prefix}joint_1" type="revolute">
-      <origin xyz="0 0 0.440" rpy="0 0 0"/>
-      <parent link="${prefix}base_link"/>
-      <child link="${prefix}link_1"/>
-      <axis xyz="0 0 1"/>
-      <limit lower="-3.1415" upper="3.1415" effort="0" velocity="5.24"/>
-    </joint>
-    <joint name="${prefix}joint_2" type="revolute">
-      <origin xyz="0 0 0" rpy="0 0 0"/>
-      <parent link="${prefix}link_1"/>
-      <child link="${prefix}link_2"/>
-      <axis xyz="0 1 0"/>
-      <limit lower="-2.01" upper="2.01" effort="0" velocity="5.59"/>
-    </joint>
-    <joint name="${prefix}joint_3" type="revolute">
-      <origin xyz="0 -0.095 0.350" rpy="0 0 0"/>
-      <parent link="${prefix}link_2"/>
-      <child link="${prefix}link_3"/>
-      <axis xyz="0 1 0"/>
-      <limit lower="-3.34" upper="3.34" effort="0" velocity="5.59"/>
-    </joint>
-    <joint name="${prefix}joint_4" type="revolute">
-      <origin xyz="0 0 0.550" rpy="0 0 0"/>
-      <parent link="${prefix}link_3"/>
-      <child link="${prefix}link_4"/>
-      <axis xyz="0 1 0"/>
-      <limit lower="-2.62" upper="2.62" effort="0" velocity="6.28"/>
-    </joint>
-    <joint name="${prefix}joint_5" type="revolute">
-      <origin xyz="0 0 0.065" rpy="0 0 0"/>
-      <parent link="${prefix}link_4"/>
-      <child link="${prefix}link_5"/>
-      <axis xyz="0 0 1"/>
-      <limit lower="-4.71" upper="4.71" effort="0" velocity="20.94"/>
-    </joint>
-    <joint name="${prefix}joint_5-tool0" type="fixed">
-      <origin xyz="0 0 0" rpy="0 0 0" />
-      <parent link="${prefix}link_5"/>
-      <child link="${prefix}tool0"/>
-    </joint>
+        <!-- joints -->
+        <joint name="${prefix}joint_1" type="revolute">
+            <origin xyz="0 0 0.440" rpy="0 0 0"/>
+            <parent link="${prefix}base_link"/>
+            <child link="${prefix}link_1"/>
+            <axis xyz="0 0 1"/>
+            <limit lower="-3.1415" upper="3.1415" effort="0" velocity="5.24"/>
+        </joint>
+        <joint name="${prefix}joint_2" type="revolute">
+            <origin xyz="0 0 0" rpy="0 0 0"/>
+            <parent link="${prefix}link_1"/>
+            <child link="${prefix}link_2"/>
+            <axis xyz="0 1 0"/>
+            <limit lower="-2.01" upper="2.01" effort="0" velocity="5.59"/>
+        </joint>
+        <joint name="${prefix}joint_3" type="revolute">
+            <origin xyz="0 -0.095 0.350" rpy="0 0 0"/>
+            <parent link="${prefix}link_2"/>
+            <child link="${prefix}link_3"/>
+            <axis xyz="0 1 0"/>
+            <limit lower="-3.34" upper="3.34" effort="0" velocity="5.59"/>
+        </joint>
+        <joint name="${prefix}joint_4" type="revolute">
+            <origin xyz="0 0 0.550" rpy="0 0 0"/>
+            <parent link="${prefix}link_3"/>
+            <child link="${prefix}link_4"/>
+            <axis xyz="0 1 0"/>
+            <limit lower="-2.62" upper="2.62" effort="0" velocity="6.28"/>
+        </joint>
+        <joint name="${prefix}joint_5" type="revolute">
+            <origin xyz="0 0 0.065" rpy="0 0 0"/>
+            <parent link="${prefix}link_4"/>
+            <child link="${prefix}link_5"/>
+            <axis xyz="0 0 1"/>
+            <limit lower="-4.71" upper="4.71" effort="0" velocity="20.94"/>
+        </joint>
+        <joint name="${prefix}joint_5-tool0" type="fixed">
+            <origin xyz="0 0 0" rpy="0 0 0" />
+            <parent link="${prefix}link_5"/>
+            <child link="${prefix}tool0"/>
+        </joint>
 
-    <!-- ROS base_link to Fanuc World Coordinates transform -->
-    <link name="${prefix}base" />
-    <joint name="${prefix}base_link-base" type="fixed">
-      <origin xyz="0 0 0.440" rpy="0 0 0"/>
-      <parent link="${prefix}base_link"/>
-      <child link="${prefix}base"/>
-    </joint>
-  </xacro:macro>
+        <!-- ROS base_link to Fanuc World Coordinates transform -->
+        <link name="${prefix}base" />
+        <joint name="${prefix}base_link-base" type="fixed">
+            <origin xyz="0 0 0.440" rpy="0 0 0"/>
+            <parent link="${prefix}base_link"/>
+            <child link="${prefix}base"/>
+        </joint>
+    </xacro:macro>
 </robot>

--- a/fanuc_m430ia_support/urdf/m430ia2p.xacro
+++ b/fanuc_m430ia_support/urdf/m430ia2p.xacro
@@ -1,5 +1,5 @@
 <?xml version="1.0" ?>
 <robot name="fanuc_m430ia2p" xmlns:xacro="http://ros.org/wiki/xacro">
-  <xacro:include filename="$(find fanuc_m430ia_support)/urdf/m430ia2p_macro.xacro"/>
-  <xacro:fanuc_m430ia2p prefix=""/>
+    <xacro:include filename="$(find fanuc_m430ia_support)/urdf/m430ia2p_macro.xacro"/>
+    <xacro:fanuc_m430ia2p prefix=""/>
 </robot>

--- a/fanuc_m430ia_support/urdf/m430ia2p_macro.xacro
+++ b/fanuc_m430ia_support/urdf/m430ia2p_macro.xacro
@@ -1,172 +1,172 @@
 <?xml version="1.0" ?>
 <robot xmlns:xacro="http://ros.org/wiki/xacro">
-  <xacro:include filename="$(find fanuc_resources)/urdf/common_materials.xacro"/>
-  <xacro:include filename="$(find fanuc_resources)/urdf/common_constants.xacro"/>
+    <xacro:include filename="$(find fanuc_resources)/urdf/common_materials.xacro"/>
+    <xacro:include filename="$(find fanuc_resources)/urdf/common_constants.xacro"/>
 
-  <xacro:macro name="fanuc_m430ia2p" params="prefix">
-    <!-- links -->
-    <link name="${prefix}base_link">
-      <visual>
-        <origin xyz="0 0 0" rpy="0 0 0"/>
-        <geometry>
-          <mesh filename="package://fanuc_m430ia_support/meshes/m430ia2p/visual/base_link.stl"/>
-        </geometry>
-        <xacro:material_fanuc_E6E6E6 />
-      </visual>
-      <collision>
-        <origin xyz="0 0 0" rpy="0 0 0"/>
-        <geometry>
-          <mesh filename="package://fanuc_m430ia_support/meshes/m430ia2p/collision/base_link.stl"/>
-        </geometry>
-      </collision>
-    </link>
-    <link name="${prefix}link_1">
-      <visual>
-        <origin xyz="0 0 0" rpy="0 0 0"/>
-        <geometry>
-          <mesh filename="package://fanuc_m430ia_support/meshes/m430ia2p/visual/link_1.stl"/>
-        </geometry>
-        <xacro:material_fanuc_E6E6E6 />
-      </visual>
-      <collision>
-        <origin xyz="0 0 0" rpy="0 0 0"/>
-        <geometry>
-          <mesh filename="package://fanuc_m430ia_support/meshes/m430ia2p/collision/link_1.stl"/>
-        </geometry>
-      </collision>
-    </link>
-    <link name="${prefix}link_2">
-      <visual>
-        <origin xyz="0 0 0" rpy="0 0 0"/>
-        <geometry>
-          <mesh filename="package://fanuc_m430ia_support/meshes/m430ia2p/visual/link_2.stl"/>
-        </geometry>
-        <xacro:material_fanuc_E6E6E6 />
-      </visual>
-      <collision>
-        <origin xyz="0 0 0" rpy="0 0 0"/>
-        <geometry>
-          <mesh filename="package://fanuc_m430ia_support/meshes/m430ia2p/collision/link_2.stl"/>
-        </geometry>
-      </collision>
-    </link>
-    <link name="${prefix}link_3">
-      <visual>
-        <origin xyz="0 0 0" rpy="0 0 0"/>
-        <geometry>
-          <mesh filename="package://fanuc_m430ia_support/meshes/m430ia2p/visual/link_3.stl"/>
-        </geometry>
-        <xacro:material_fanuc_E6E6E6 />
-      </visual>
-      <collision>
-        <origin xyz="0 0 0" rpy="0 0 0"/>
-        <geometry>
-          <mesh filename="package://fanuc_m430ia_support/meshes/m430ia2p/collision/link_3.stl"/>
-        </geometry>
-      </collision>
-    </link>
-    <link name="${prefix}link_4">
-      <visual>
-        <origin xyz="0 0 0" rpy="0 0 0"/>
-        <geometry>
-          <mesh filename="package://fanuc_m430ia_support/meshes/m430ia2p/visual/link_4.stl"/>
-        </geometry>
-        <xacro:material_fanuc_E6E6E6 />
-      </visual>
-      <collision>
-        <origin xyz="0 0 0" rpy="0 0 0"/>
-        <geometry>
-          <mesh filename="package://fanuc_m430ia_support/meshes/m430ia2p/collision/link_4.stl"/>
-        </geometry>
-      </collision>
-    </link>
-    <link name="${prefix}link_5">
-      <visual>
-        <origin xyz="0 0 0" rpy="0 0 0"/>
-        <geometry>
-          <mesh filename="package://fanuc_m430ia_support/meshes/m430ia2p/visual/link_5.stl"/>
-        </geometry>
-        <xacro:material_fanuc_E6E6E6 />
-      </visual>
-      <collision>
-        <origin xyz="0 0 0" rpy="0 0 0"/>
-        <geometry>
-          <mesh filename="package://fanuc_m430ia_support/meshes/m430ia2p/collision/link_5.stl"/>
-        </geometry>
-      </collision>
-    </link>
-    <link name="${prefix}link_6">
-      <visual>
-        <origin xyz="0 0 0" rpy="0 0 0"/>
-        <geometry>
-          <mesh filename="package://fanuc_m430ia_support/meshes/m430ia2p/visual/link_6.stl"/>
-        </geometry>
-        <xacro:material_fanuc_E6E6E6 />
-      </visual>
-      <collision>
-        <origin xyz="0 0 0" rpy="0 0 0"/>
-        <geometry>
-          <mesh filename="package://fanuc_m430ia_support/meshes/m430ia2p/collision/link_6.stl"/>
-        </geometry>
-      </collision>
-    </link>
-    <link name="${prefix}tool0" />
+    <xacro:macro name="fanuc_m430ia2p" params="prefix">
+        <!-- links -->
+        <link name="${prefix}base_link">
+            <visual>
+                <origin xyz="0 0 0" rpy="0 0 0"/>
+                <geometry>
+                    <mesh filename="package://fanuc_m430ia_support/meshes/m430ia2p/visual/base_link.stl"/>
+                </geometry>
+                <xacro:material_fanuc_E6E6E6 />
+            </visual>
+            <collision>
+                <origin xyz="0 0 0" rpy="0 0 0"/>
+                <geometry>
+                    <mesh filename="package://fanuc_m430ia_support/meshes/m430ia2p/collision/base_link.stl"/>
+                </geometry>
+            </collision>
+        </link>
+        <link name="${prefix}link_1">
+            <visual>
+                <origin xyz="0 0 0" rpy="0 0 0"/>
+                <geometry>
+                    <mesh filename="package://fanuc_m430ia_support/meshes/m430ia2p/visual/link_1.stl"/>
+                </geometry>
+                <xacro:material_fanuc_E6E6E6 />
+            </visual>
+            <collision>
+                <origin xyz="0 0 0" rpy="0 0 0"/>
+                <geometry>
+                    <mesh filename="package://fanuc_m430ia_support/meshes/m430ia2p/collision/link_1.stl"/>
+                </geometry>
+            </collision>
+        </link>
+        <link name="${prefix}link_2">
+            <visual>
+                <origin xyz="0 0 0" rpy="0 0 0"/>
+                <geometry>
+                    <mesh filename="package://fanuc_m430ia_support/meshes/m430ia2p/visual/link_2.stl"/>
+                </geometry>
+                <xacro:material_fanuc_E6E6E6 />
+            </visual>
+            <collision>
+                <origin xyz="0 0 0" rpy="0 0 0"/>
+                <geometry>
+                    <mesh filename="package://fanuc_m430ia_support/meshes/m430ia2p/collision/link_2.stl"/>
+                </geometry>
+            </collision>
+        </link>
+        <link name="${prefix}link_3">
+            <visual>
+                <origin xyz="0 0 0" rpy="0 0 0"/>
+                <geometry>
+                    <mesh filename="package://fanuc_m430ia_support/meshes/m430ia2p/visual/link_3.stl"/>
+                </geometry>
+                <xacro:material_fanuc_E6E6E6 />
+            </visual>
+            <collision>
+                <origin xyz="0 0 0" rpy="0 0 0"/>
+                <geometry>
+                    <mesh filename="package://fanuc_m430ia_support/meshes/m430ia2p/collision/link_3.stl"/>
+                </geometry>
+            </collision>
+        </link>
+        <link name="${prefix}link_4">
+            <visual>
+                <origin xyz="0 0 0" rpy="0 0 0"/>
+                <geometry>
+                    <mesh filename="package://fanuc_m430ia_support/meshes/m430ia2p/visual/link_4.stl"/>
+                </geometry>
+                <xacro:material_fanuc_E6E6E6 />
+            </visual>
+            <collision>
+                <origin xyz="0 0 0" rpy="0 0 0"/>
+                <geometry>
+                    <mesh filename="package://fanuc_m430ia_support/meshes/m430ia2p/collision/link_4.stl"/>
+                </geometry>
+            </collision>
+        </link>
+        <link name="${prefix}link_5">
+            <visual>
+                <origin xyz="0 0 0" rpy="0 0 0"/>
+                <geometry>
+                    <mesh filename="package://fanuc_m430ia_support/meshes/m430ia2p/visual/link_5.stl"/>
+                </geometry>
+                <xacro:material_fanuc_E6E6E6 />
+            </visual>
+            <collision>
+                <origin xyz="0 0 0" rpy="0 0 0"/>
+                <geometry>
+                    <mesh filename="package://fanuc_m430ia_support/meshes/m430ia2p/collision/link_5.stl"/>
+                </geometry>
+            </collision>
+        </link>
+        <link name="${prefix}link_6">
+            <visual>
+                <origin xyz="0 0 0" rpy="0 0 0"/>
+                <geometry>
+                    <mesh filename="package://fanuc_m430ia_support/meshes/m430ia2p/visual/link_6.stl"/>
+                </geometry>
+                <xacro:material_fanuc_E6E6E6 />
+            </visual>
+            <collision>
+                <origin xyz="0 0 0" rpy="0 0 0"/>
+                <geometry>
+                    <mesh filename="package://fanuc_m430ia_support/meshes/m430ia2p/collision/link_6.stl"/>
+                </geometry>
+            </collision>
+        </link>
+        <link name="${prefix}tool0" />
 
-    <!-- joints -->
-    <joint name="${prefix}joint_1" type="revolute">
-      <origin xyz="0 0 0.410" rpy="0 0 0"/>
-      <parent link="${prefix}base_link"/>
-      <child link="${prefix}link_1"/>
-      <axis xyz="0 0 1"/>
-      <limit lower="-3.14" upper="3.14" effort="0" velocity="5.24"/>
-    </joint>
-    <joint name="${prefix}joint_2" type="revolute">
-      <origin xyz="0 0 0" rpy="0 0 0"/>
-      <parent link="${prefix}link_1"/>
-      <child link="${prefix}link_2"/>
-      <axis xyz="0 1 0"/>
-      <limit lower="-2.01" upper="2.01" effort="0" velocity="5.59"/>
-    </joint>
-    <joint name="${prefix}joint_3" type="revolute">
-      <origin xyz="0 0 0.350" rpy="0 0 0"/>
-      <parent link="${prefix}link_2"/>
-      <child link="${prefix}link_3"/>
-      <axis xyz="0 1 0"/>
-      <limit lower="-3.49" upper="3.49" effort="0" velocity="5.93"/>
-    </joint>
-    <joint name="${prefix}joint_4" type="revolute">
-      <origin xyz="0 0 0" rpy="0 0 0"/>
-      <parent link="${prefix}link_3"/>
-      <child link="${prefix}link_4"/>
-      <axis xyz="0 0 1"/>
-      <limit lower="-3.32" upper="3.32" effort="0" velocity="5.24"/>
-    </joint>
-    <joint name="${prefix}joint_5" type="revolute">
-      <origin xyz="0 0 0.350" rpy="0 0 0"/>
-      <parent link="${prefix}link_4"/>
-      <child link="${prefix}link_5"/>
-      <axis xyz="0 1 0"/>
-      <limit lower="-2.62" upper="2.62" effort="0" velocity="5.24"/>
-    </joint>
-    <joint name="${prefix}joint_6" type="revolute">
-      <origin xyz="0 -0.095 0.065" rpy="0 0 0"/>
-      <parent link="${prefix}link_5"/>
-      <child link="${prefix}link_6"/>
-      <axis xyz="0 0 1"/>
-      <limit lower="-4.71" upper="4.71" effort="0" velocity="12.57"/>
-    </joint>
-    <joint name="${prefix}joint_6-tool0" type="fixed">
-      <origin xyz="0 0 0" rpy="0 0 0" />
-      <parent link="${prefix}link_6" />
-      <child link="${prefix}tool0" />
-    </joint>
+        <!-- joints -->
+        <joint name="${prefix}joint_1" type="revolute">
+            <origin xyz="0 0 0.410" rpy="0 0 0"/>
+            <parent link="${prefix}base_link"/>
+            <child link="${prefix}link_1"/>
+            <axis xyz="0 0 1"/>
+            <limit lower="-3.14" upper="3.14" effort="0" velocity="5.24"/>
+        </joint>
+        <joint name="${prefix}joint_2" type="revolute">
+            <origin xyz="0 0 0" rpy="0 0 0"/>
+            <parent link="${prefix}link_1"/>
+            <child link="${prefix}link_2"/>
+            <axis xyz="0 1 0"/>
+            <limit lower="-2.01" upper="2.01" effort="0" velocity="5.59"/>
+        </joint>
+        <joint name="${prefix}joint_3" type="revolute">
+            <origin xyz="0 0 0.350" rpy="0 0 0"/>
+            <parent link="${prefix}link_2"/>
+            <child link="${prefix}link_3"/>
+            <axis xyz="0 1 0"/>
+            <limit lower="-3.49" upper="3.49" effort="0" velocity="5.93"/>
+        </joint>
+        <joint name="${prefix}joint_4" type="revolute">
+            <origin xyz="0 0 0" rpy="0 0 0"/>
+            <parent link="${prefix}link_3"/>
+            <child link="${prefix}link_4"/>
+            <axis xyz="0 0 1"/>
+            <limit lower="-3.32" upper="3.32" effort="0" velocity="5.24"/>
+        </joint>
+        <joint name="${prefix}joint_5" type="revolute">
+            <origin xyz="0 0 0.350" rpy="0 0 0"/>
+            <parent link="${prefix}link_4"/>
+            <child link="${prefix}link_5"/>
+            <axis xyz="0 1 0"/>
+            <limit lower="-2.62" upper="2.62" effort="0" velocity="5.24"/>
+        </joint>
+        <joint name="${prefix}joint_6" type="revolute">
+            <origin xyz="0 -0.095 0.065" rpy="0 0 0"/>
+            <parent link="${prefix}link_5"/>
+            <child link="${prefix}link_6"/>
+            <axis xyz="0 0 1"/>
+            <limit lower="-4.71" upper="4.71" effort="0" velocity="12.57"/>
+        </joint>
+        <joint name="${prefix}joint_6-tool0" type="fixed">
+            <origin xyz="0 0 0" rpy="0 0 0" />
+            <parent link="${prefix}link_6" />
+            <child link="${prefix}tool0" />
+        </joint>
 
-    <!-- ROS base_link to Fanuc World Coordinates transform -->
-    <link name="${prefix}base" />
-    <joint name="${prefix}base_link-base" type="fixed">
-      <origin xyz="0 0 0.410" rpy="0 0 0"/>
-      <parent link="${prefix}base_link"/>
-      <child link="${prefix}base"/>
-    </joint>
-  </xacro:macro>
+        <!-- ROS base_link to Fanuc World Coordinates transform -->
+        <link name="${prefix}base" />
+        <joint name="${prefix}base_link-base" type="fixed">
+            <origin xyz="0 0 0.410" rpy="0 0 0"/>
+            <parent link="${prefix}base_link"/>
+            <child link="${prefix}base"/>
+        </joint>
+    </xacro:macro>
 </robot>

--- a/fanuc_resources/urdf/common_colours.xacro
+++ b/fanuc_resources/urdf/common_colours.xacro
@@ -1,31 +1,31 @@
 <?xml version="1.0"?>
 <robot xmlns:xacro="http://ros.org/wiki/xacro">
 
-  <!-- RAL 1021: Rape yellow -->
-  <xacro:property name="color_fanuc_yellow"   value="0.96 0.76 0.13 1.0" />
-  <!-- RAL 9002: Grey white -->
-  <xacro:property name="color_fanuc_white"    value="0.86 0.85 0.81 1.0" />
-  <!-- RAL 7024: Graphite grey -->
-  <xacro:property name="color_fanuc_grey"     value="0.34 0.35 0.36 1.0" />
+    <!-- RAL 1021: Rape yellow -->
+    <xacro:property name="color_fanuc_yellow"   value="0.96 0.76 0.13 1.0" />
+    <!-- RAL 9002: Grey white -->
+    <xacro:property name="color_fanuc_white"    value="0.86 0.85 0.81 1.0" />
+    <!-- RAL 7024: Graphite grey -->
+    <xacro:property name="color_fanuc_grey"     value="0.34 0.35 0.36 1.0" />
 
-  <!-- Roboguide colours -->
-  <!-- #3D3D3D -->
-  <xacro:property name="color_fanuc_gray24"   value="${ 61/255} ${ 61/255} ${ 61/255} 1.0" />
-  <!-- #474747 -->
-  <xacro:property name="color_fanuc_gray28"   value="${ 71/255} ${ 71/255} ${ 71/255} 1.0" />
-  <!-- #4F4F4F -->
-  <xacro:property name="color_fanuc_gray31"   value="${ 79/255} ${ 79/255} ${ 79/255} 1.0" />
-  <!-- #666666 -->
-  <xacro:property name="color_fanuc_gray40"   value="${102/255} ${102/255} ${102/255} 1.0" />
-  <!-- #FFFF00 -->
-  <xacro:property name="color_fanuc_yellow1"  value="${255/255} ${255/255} ${  0/255} 1.0" />
-  <!-- #BAB0B0 -->
-  <xacro:property name="color_fanuc_BAB0B0"   value="${186/255} ${176/255} ${176/255} 1.0" />
-  <!-- #E6E6E6 -->
-  <xacro:property name="color_fanuc_E6E6E6"   value="${230/255} ${230/255} ${230/255} 1.0" />
+    <!-- Roboguide colours -->
+    <!-- #3D3D3D -->
+    <xacro:property name="color_fanuc_gray24"   value="${ 61/255} ${ 61/255} ${ 61/255} 1.0" />
+    <!-- #474747 -->
+    <xacro:property name="color_fanuc_gray28"   value="${ 71/255} ${ 71/255} ${ 71/255} 1.0" />
+    <!-- #4F4F4F -->
+    <xacro:property name="color_fanuc_gray31"   value="${ 79/255} ${ 79/255} ${ 79/255} 1.0" />
+    <!-- #666666 -->
+    <xacro:property name="color_fanuc_gray40"   value="${102/255} ${102/255} ${102/255} 1.0" />
+    <!-- #FFFF00 -->
+    <xacro:property name="color_fanuc_yellow1"  value="${255/255} ${255/255} ${  0/255} 1.0" />
+    <!-- #BAB0B0 -->
+    <xacro:property name="color_fanuc_BAB0B0"   value="${186/255} ${176/255} ${176/255} 1.0" />
+    <!-- #E6E6E6 -->
+    <xacro:property name="color_fanuc_E6E6E6"   value="${230/255} ${230/255} ${230/255} 1.0" />
 
-  <!-- approximations -->
-  <xacro:property name="color_fanuc_black"    value="0.15 0.15 0.15 1.0" />
-  <xacro:property name="color_fanuc_greyish"  value="0.75 0.75 0.75 1.0" />
+    <!-- approximations -->
+    <xacro:property name="color_fanuc_black"    value="0.15 0.15 0.15 1.0" />
+    <xacro:property name="color_fanuc_greyish"  value="0.75 0.75 0.75 1.0" />
 
 </robot>

--- a/fanuc_resources/urdf/common_constants.xacro
+++ b/fanuc_resources/urdf/common_constants.xacro
@@ -1,11 +1,11 @@
 <?xml version="1.0"?>
 <robot xmlns:xacro="http://ros.org/wiki/xacro">
 
-  <!-- Pi, the ratio of a circle's circumference to its diameter -->
-  <xacro:property name="m_pi" value="3.1415926535" />
-  <!-- Pi divided by two -->
-  <xacro:property name="m_pi_2" value="1.570796327" />
-  <!-- Pi divided by four -->
-  <xacro:property name="m_pi_4" value="0.785398163" />
+    <!-- Pi, the ratio of a circle's circumference to its diameter -->
+    <xacro:property name="m_pi" value="3.1415926535" />
+    <!-- Pi divided by two -->
+    <xacro:property name="m_pi_2" value="1.570796327" />
+    <!-- Pi divided by four -->
+    <xacro:property name="m_pi_4" value="0.785398163" />
 
 </robot>

--- a/fanuc_resources/urdf/common_materials.xacro
+++ b/fanuc_resources/urdf/common_materials.xacro
@@ -1,77 +1,77 @@
 <?xml version="1.0"?>
 <robot xmlns:xacro="http://ros.org/wiki/xacro">
-  <xacro:include filename="$(find fanuc_resources)/urdf/common_colours.xacro"/>
+    <xacro:include filename="$(find fanuc_resources)/urdf/common_colours.xacro"/>
 
-  <xacro:macro name="material_fanuc_yellow">
-    <material name="">
-      <color rgba="${color_fanuc_yellow}"/>
-    </material>
-  </xacro:macro>
+    <xacro:macro name="material_fanuc_yellow">
+        <material name="">
+            <color rgba="${color_fanuc_yellow}"/>
+        </material>
+    </xacro:macro>
 
-  <xacro:macro name="material_fanuc_white">
-    <material name="">
-      <color rgba="${color_fanuc_white}"/>
-    </material>
-  </xacro:macro>
+    <xacro:macro name="material_fanuc_white">
+        <material name="">
+            <color rgba="${color_fanuc_white}"/>
+        </material>
+    </xacro:macro>
 
-  <xacro:macro name="material_fanuc_grey">
-    <material name="">
-      <color rgba="${color_fanuc_grey}"/>
-    </material>
-  </xacro:macro>
+    <xacro:macro name="material_fanuc_grey">
+        <material name="">
+            <color rgba="${color_fanuc_grey}"/>
+        </material>
+    </xacro:macro>
 
-  <xacro:macro name="material_fanuc_gray24">
-    <material name="">
-      <color rgba="${color_fanuc_gray24}"/>
-    </material>
-  </xacro:macro>
+    <xacro:macro name="material_fanuc_gray24">
+        <material name="">
+            <color rgba="${color_fanuc_gray24}"/>
+        </material>
+    </xacro:macro>
 
-  <xacro:macro name="material_fanuc_gray28">
-    <material name="">
-      <color rgba="${color_fanuc_gray28}"/>
-    </material>
-  </xacro:macro>
+    <xacro:macro name="material_fanuc_gray28">
+        <material name="">
+            <color rgba="${color_fanuc_gray28}"/>
+        </material>
+    </xacro:macro>
 
-  <xacro:macro name="material_fanuc_gray31">
-    <material name="">
-      <color rgba="${color_fanuc_gray31}"/>
-    </material>
-  </xacro:macro>
+    <xacro:macro name="material_fanuc_gray31">
+        <material name="">
+            <color rgba="${color_fanuc_gray31}"/>
+        </material>
+    </xacro:macro>
 
-  <xacro:macro name="material_fanuc_gray40">
-    <material name="">
-      <color rgba="${color_fanuc_gray40}"/>
-    </material>
-  </xacro:macro>
+    <xacro:macro name="material_fanuc_gray40">
+        <material name="">
+            <color rgba="${color_fanuc_gray40}"/>
+        </material>
+    </xacro:macro>
 
-  <xacro:macro name="material_fanuc_yellow1">
-    <material name="">
-      <color rgba="${color_fanuc_yellow1}"/>
-    </material>
-  </xacro:macro>
+    <xacro:macro name="material_fanuc_yellow1">
+        <material name="">
+            <color rgba="${color_fanuc_yellow1}"/>
+        </material>
+    </xacro:macro>
 
-  <xacro:macro name="material_fanuc_BAB0B0">
-    <material name="">
-      <color rgba="${color_fanuc_BAB0B0}"/>
-    </material>
-  </xacro:macro>
+    <xacro:macro name="material_fanuc_BAB0B0">
+        <material name="">
+            <color rgba="${color_fanuc_BAB0B0}"/>
+        </material>
+    </xacro:macro>
 
-  <xacro:macro name="material_fanuc_E6E6E6">
-    <material name="">
-      <color rgba="${color_fanuc_E6E6E6}"/>
-    </material>
-  </xacro:macro>
+    <xacro:macro name="material_fanuc_E6E6E6">
+        <material name="">
+            <color rgba="${color_fanuc_E6E6E6}"/>
+        </material>
+    </xacro:macro>
 
-  <xacro:macro name="material_fanuc_black">
-    <material name="">
-      <color rgba="${color_fanuc_black}"/>
-    </material>
-  </xacro:macro>
+    <xacro:macro name="material_fanuc_black">
+        <material name="">
+            <color rgba="${color_fanuc_black}"/>
+        </material>
+    </xacro:macro>
 
-  <xacro:macro name="material_fanuc_greyish">
-    <material name="">
-      <color rgba="${color_fanuc_greyish}"/>
-    </material>
-  </xacro:macro>
+    <xacro:macro name="material_fanuc_greyish">
+        <material name="">
+            <color rgba="${color_fanuc_greyish}"/>
+        </material>
+    </xacro:macro>
 
 </robot>


### PR DESCRIPTION
Just cosmetics

My script: (https://help.ubuntu.com/community/NautilusScriptsHowto)

``` bash
#!/bin/bash
#sudo apt-get install xmlindent
count=0

# Check if xmlindent is installed
pkg_ok=$(dpkg-query -W --showformat='${Status}\n' xmlindent|grep "install ok installed")
if [ "" == "$pkg_ok" ]; then
    notify-send "Missing package" -t 1 "Please install xmlindent"
    exit 0
fi

IFS="
"

for file in $(find ${NEMO_SCRIPT_SELECTED_FILE_PATHS} -iname '*.xacro'); do
    xmlindent "$file" -w -i 2
    sed -i 's/[ \t]*$//' "$file" # Removing trailing spaces
    ((count++))
done

find ${NEMO_SCRIPT_SELECTED_FILE_PATHS} -iname '*.xacro~' -exec rm {} \; # Remove xmlindent backup files
notify-send "xacro indent" -t 1 "$count files were indented"
```
