### PR TITLE
Fix for issue #185: remove roslaunch test DEPENDENCY declarations from CMakeLists

### DIFF
--- a/fanuc_driver/CMakeLists.txt
+++ b/fanuc_driver/CMakeLists.txt
@@ -73,14 +73,20 @@ set_target_properties(${PROJECT_NAME}_motion_streaming_interface_bswap
 
 if (CATKIN_ENABLE_TESTING)
   find_package(roslaunch REQUIRED)
+
+  set(rl_test_deps
+    ${PROJECT_NAME}_robot_state
+    ${PROJECT_NAME}_robot_state_bswap
+    ${PROJECT_NAME}_motion_streaming_interface
+    ${PROJECT_NAME}_motion_streaming_interface_bswap)
+
+  if (TARGET joint_trajectory_action)
+    # not nice, but industrial_robot_client doesn't prefix its targets
+    list(APPEND rl_test_deps joint_trajectory_action)
+  endif()
+
   roslaunch_add_file_check(tests/roslaunch_test.xml
-    DEPENDENCIES
-      # not nice, but industrial_robot_client doesn't prefix its targets
-      joint_trajectory_action
-      ${PROJECT_NAME}_robot_state
-      ${PROJECT_NAME}_robot_state_bswap
-      ${PROJECT_NAME}_motion_streaming_interface
-      ${PROJECT_NAME}_motion_streaming_interface_bswap)
+    DEPENDENCIES ${rl_test_deps})
 endif()
 
 

--- a/fanuc_lrmate200ic_support/CMakeLists.txt
+++ b/fanuc_lrmate200ic_support/CMakeLists.txt
@@ -8,14 +8,7 @@ catkin_package()
 
 if (CATKIN_ENABLE_TESTING)
   find_package(roslaunch REQUIRED)
-  roslaunch_add_file_check(tests/roslaunch_test.xml
-    DEPENDENCIES
-      # not nice, but industrial_robot_client doesn't prefix its targets
-      joint_trajectory_action
-      fanuc_driver_robot_state
-      fanuc_driver_robot_state_bswap
-      fanuc_driver_motion_streaming_interface
-      fanuc_driver_motion_streaming_interface_bswap)
+  roslaunch_add_file_check(tests/roslaunch_test.xml)
 endif()
 
 install(DIRECTORY config launch meshes urdf

--- a/fanuc_m10ia_support/CMakeLists.txt
+++ b/fanuc_m10ia_support/CMakeLists.txt
@@ -8,14 +8,7 @@ catkin_package()
 
 if (CATKIN_ENABLE_TESTING)
   find_package(roslaunch REQUIRED)
-  roslaunch_add_file_check(tests/roslaunch_test.xml
-    DEPENDENCIES
-      # not nice, but industrial_robot_client doesn't prefix its targets
-      joint_trajectory_action
-      fanuc_driver_robot_state
-      fanuc_driver_robot_state_bswap
-      fanuc_driver_motion_streaming_interface
-      fanuc_driver_motion_streaming_interface_bswap)
+  roslaunch_add_file_check(tests/roslaunch_test.xml)
 endif()
 
 install(DIRECTORY config launch meshes urdf

--- a/fanuc_m16ib_support/CMakeLists.txt
+++ b/fanuc_m16ib_support/CMakeLists.txt
@@ -8,14 +8,7 @@ catkin_package()
 
 if (CATKIN_ENABLE_TESTING)
   find_package(roslaunch REQUIRED)
-  roslaunch_add_file_check(tests/roslaunch_test.xml
-    DEPENDENCIES
-      # not nice, but industrial_robot_client doesn't prefix its targets
-      joint_trajectory_action
-      fanuc_driver_robot_state
-      fanuc_driver_robot_state_bswap
-      fanuc_driver_motion_streaming_interface
-      fanuc_driver_motion_streaming_interface_bswap)
+  roslaunch_add_file_check(tests/roslaunch_test.xml)
 endif()
 
 install(DIRECTORY config launch meshes urdf

--- a/fanuc_m20ia_support/CMakeLists.txt
+++ b/fanuc_m20ia_support/CMakeLists.txt
@@ -8,14 +8,7 @@ catkin_package()
 
 if (CATKIN_ENABLE_TESTING)
   find_package(roslaunch REQUIRED)
-  roslaunch_add_file_check(tests/roslaunch_test.xml
-    DEPENDENCIES
-      # not nice, but industrial_robot_client doesn't prefix its targets
-      joint_trajectory_action
-      fanuc_driver_robot_state
-      fanuc_driver_robot_state_bswap
-      fanuc_driver_motion_streaming_interface
-      fanuc_driver_motion_streaming_interface_bswap)
+  roslaunch_add_file_check(tests/roslaunch_test.xml)
 endif()
 
 install(DIRECTORY config launch meshes urdf

--- a/fanuc_m430ia_support/CMakeLists.txt
+++ b/fanuc_m430ia_support/CMakeLists.txt
@@ -8,14 +8,7 @@ catkin_package()
 
 if (CATKIN_ENABLE_TESTING)
   find_package(roslaunch REQUIRED)
-  roslaunch_add_file_check(tests/roslaunch_test.xml
-    DEPENDENCIES
-      # not nice, but industrial_robot_client doesn't prefix its targets
-      joint_trajectory_action
-      fanuc_driver_robot_state
-      fanuc_driver_robot_state_bswap
-      fanuc_driver_motion_streaming_interface
-      fanuc_driver_motion_streaming_interface_bswap)
+  roslaunch_add_file_check(tests/roslaunch_test.xml)
 endif()
 
 install(DIRECTORY config launch meshes urdf


### PR DESCRIPTION
Based on the discussion in #185.

In the end I decided that adding the `if` conditionals is a lot of clutter for something that is actually a very minor (and hypothetical) problem. Tests should only be run _after_ the packages have been built, which is typically the case.
