### PR TITLE
Fix for issue #179: set default moveit/ompl planner to RRTConnect.

### DIFF
--- a/fanuc_lrmate200ic5h_moveit_config/config/ompl_planning.yaml
+++ b/fanuc_lrmate200ic5h_moveit_config/config/ompl_planning.yaml
@@ -53,6 +53,7 @@ planner_configs:
   PRMstarkConfigDefault:
     type: geometric::PRMstar
 manipulator:
+  default_planner_config: RRTConnectkConfigDefault
   planner_configs:
     - SBLkConfigDefault
     - ESTkConfigDefault

--- a/fanuc_lrmate200ic5l_moveit_config/config/ompl_planning.yaml
+++ b/fanuc_lrmate200ic5l_moveit_config/config/ompl_planning.yaml
@@ -53,6 +53,7 @@ planner_configs:
   PRMstarkConfigDefault:
     type: geometric::PRMstar
 manipulator:
+  default_planner_config: RRTConnectkConfigDefault
   planner_configs:
     - SBLkConfigDefault
     - ESTkConfigDefault

--- a/fanuc_lrmate200ic_moveit_config/config/ompl_planning.yaml
+++ b/fanuc_lrmate200ic_moveit_config/config/ompl_planning.yaml
@@ -53,6 +53,7 @@ planner_configs:
   PRMstarkConfigDefault:
     type: geometric::PRMstar
 manipulator:
+  default_planner_config: RRTConnectkConfigDefault
   planner_configs:
     - SBLkConfigDefault
     - ESTkConfigDefault

--- a/fanuc_m10ia_moveit_config/config/ompl_planning.yaml
+++ b/fanuc_m10ia_moveit_config/config/ompl_planning.yaml
@@ -53,6 +53,7 @@ planner_configs:
   PRMstarkConfigDefault:
     type: geometric::PRMstar
 manipulator:
+  default_planner_config: RRTConnectkConfigDefault
   planner_configs:
     - SBLkConfigDefault
     - ESTkConfigDefault

--- a/fanuc_m16ib20_moveit_config/config/ompl_planning.yaml
+++ b/fanuc_m16ib20_moveit_config/config/ompl_planning.yaml
@@ -53,6 +53,7 @@ planner_configs:
   PRMstarkConfigDefault:
     type: geometric::PRMstar
 manipulator:
+  default_planner_config: RRTConnectkConfigDefault
   planner_configs:
     - SBLkConfigDefault
     - ESTkConfigDefault

--- a/fanuc_m20ia10l_moveit_config/config/ompl_planning.yaml
+++ b/fanuc_m20ia10l_moveit_config/config/ompl_planning.yaml
@@ -53,6 +53,7 @@ planner_configs:
   PRMstarkConfigDefault:
     type: geometric::PRMstar
 manipulator:
+  default_planner_config: RRTConnectkConfigDefault
   planner_configs:
     - SBLkConfigDefault
     - ESTkConfigDefault

--- a/fanuc_m20ia_moveit_config/config/ompl_planning.yaml
+++ b/fanuc_m20ia_moveit_config/config/ompl_planning.yaml
@@ -53,6 +53,7 @@ planner_configs:
   PRMstarkConfigDefault:
     type: geometric::PRMstar
 manipulator:
+  default_planner_config: RRTConnectkConfigDefault
   planner_configs:
     - SBLkConfigDefault
     - ESTkConfigDefault

--- a/fanuc_m430ia2f_moveit_config/config/ompl_planning.yaml
+++ b/fanuc_m430ia2f_moveit_config/config/ompl_planning.yaml
@@ -53,6 +53,7 @@ planner_configs:
   PRMstarkConfigDefault:
     type: geometric::PRMstar
 manipulator:
+  default_planner_config: RRTConnectkConfigDefault
   planner_configs:
     - SBLkConfigDefault
     - ESTkConfigDefault

--- a/fanuc_m430ia2p_moveit_config/config/ompl_planning.yaml
+++ b/fanuc_m430ia2p_moveit_config/config/ompl_planning.yaml
@@ -53,6 +53,7 @@ planner_configs:
   PRMstarkConfigDefault:
     type: geometric::PRMstar
 manipulator:
+  default_planner_config: RRTConnectkConfigDefault
   planner_configs:
     - SBLkConfigDefault
     - ESTkConfigDefault


### PR DESCRIPTION
As per subject.

See #179 and #156 for some discussion.

This is supported since MoveIt 0.7.0, which has been released on 2016-01-30.
