### PR TITLE
Fix for issue #104: add roslaunch testing to MoveIt configurations

### DIFF
--- a/fanuc_lrmate200ic5h_moveit_config/CMakeLists.txt
+++ b/fanuc_lrmate200ic5h_moveit_config/CMakeLists.txt
@@ -5,6 +5,12 @@ find_package(catkin REQUIRED)
 
 catkin_package()
 
+if (CATKIN_ENABLE_TESTING)
+  find_package(roslaunch REQUIRED)
+  roslaunch_add_file_check(launch/demo.launch)
+  roslaunch_add_file_check(tests/moveit_planning_execution.xml)
+endif()
+
 install(DIRECTORY launch DESTINATION ${CATKIN_PACKAGE_SHARE_DESTINATION})
 install(DIRECTORY config DESTINATION ${CATKIN_PACKAGE_SHARE_DESTINATION})
 

--- a/fanuc_lrmate200ic5h_moveit_config/package.xml
+++ b/fanuc_lrmate200ic5h_moveit_config/package.xml
@@ -29,6 +29,8 @@
 
   <buildtool_depend>catkin</buildtool_depend>
 
+  <test_depend>roslaunch</test_depend>
+
   <exec_depend>fanuc_lrmate200ic_moveit_plugins</exec_depend>
   <exec_depend>fanuc_lrmate200ic_support</exec_depend>
   <exec_depend>industrial_robot_simulator</exec_depend>

--- a/fanuc_lrmate200ic5h_moveit_config/package.xml
+++ b/fanuc_lrmate200ic5h_moveit_config/package.xml
@@ -39,8 +39,11 @@
   <exec_depend>moveit_planners_ompl</exec_depend>
   <exec_depend>moveit_ros_move_group</exec_depend>
   <exec_depend>moveit_ros_visualization</exec_depend>
+  <exec_depend>moveit_ros_warehouse</exec_depend>
   <exec_depend>moveit_simple_controller_manager</exec_depend>
   <exec_depend>robot_state_publisher</exec_depend>
+  <exec_depend>rviz</exec_depend>
+  <exec_depend>warehouse_ros</exec_depend>
   <exec_depend>xacro</exec_depend>
 
   <export>

--- a/fanuc_lrmate200ic5h_moveit_config/tests/moveit_planning_execution.xml
+++ b/fanuc_lrmate200ic5h_moveit_config/tests/moveit_planning_execution.xml
@@ -1,0 +1,19 @@
+<?xml version="1.0"?>
+<launch>
+  <arg name="ip_str" value="127.0.0.1" />
+
+  <group>
+    <include file="$(find fanuc_lrmate200ic5h_moveit_config)/launch/moveit_planning_execution.launch">
+      <arg name="sim" value="false" />
+      <arg name="robot_ip" value="$(arg ip_str)" />
+    </include>
+  </group>
+
+  <group ns="with_db">
+    <include file="$(find fanuc_lrmate200ic5h_moveit_config)/launch/moveit_planning_execution.launch">
+      <arg name="sim" value="false" />
+      <arg name="robot_ip" value="$(arg ip_str)" />
+      <arg name="db" value="true" />
+    </include>
+  </group>
+</launch>

--- a/fanuc_lrmate200ic5l_moveit_config/CMakeLists.txt
+++ b/fanuc_lrmate200ic5l_moveit_config/CMakeLists.txt
@@ -5,6 +5,12 @@ find_package(catkin REQUIRED)
 
 catkin_package()
 
+if (CATKIN_ENABLE_TESTING)
+  find_package(roslaunch REQUIRED)
+  roslaunch_add_file_check(launch/demo.launch)
+  roslaunch_add_file_check(tests/moveit_planning_execution.xml)
+endif()
+
 install(DIRECTORY launch DESTINATION ${CATKIN_PACKAGE_SHARE_DESTINATION})
 install(DIRECTORY config DESTINATION ${CATKIN_PACKAGE_SHARE_DESTINATION})
 

--- a/fanuc_lrmate200ic5l_moveit_config/package.xml
+++ b/fanuc_lrmate200ic5l_moveit_config/package.xml
@@ -29,6 +29,8 @@
 
   <buildtool_depend>catkin</buildtool_depend>
 
+  <test_depend>roslaunch</test_depend>
+
   <exec_depend>fanuc_lrmate200ic_moveit_plugins</exec_depend>
   <exec_depend>fanuc_lrmate200ic_support</exec_depend>
   <exec_depend>industrial_robot_simulator</exec_depend>

--- a/fanuc_lrmate200ic5l_moveit_config/package.xml
+++ b/fanuc_lrmate200ic5l_moveit_config/package.xml
@@ -39,8 +39,11 @@
   <exec_depend>moveit_planners_ompl</exec_depend>
   <exec_depend>moveit_ros_move_group</exec_depend>
   <exec_depend>moveit_ros_visualization</exec_depend>
+  <exec_depend>moveit_ros_warehouse</exec_depend>
   <exec_depend>moveit_simple_controller_manager</exec_depend>
   <exec_depend>robot_state_publisher</exec_depend>
+  <exec_depend>rviz</exec_depend>
+  <exec_depend>warehouse_ros</exec_depend>
   <exec_depend>xacro</exec_depend>
 
   <export>

--- a/fanuc_lrmate200ic5l_moveit_config/tests/moveit_planning_execution.xml
+++ b/fanuc_lrmate200ic5l_moveit_config/tests/moveit_planning_execution.xml
@@ -1,0 +1,19 @@
+<?xml version="1.0"?>
+<launch>
+  <arg name="ip_str" value="127.0.0.1" />
+
+  <group>
+    <include file="$(find fanuc_lrmate200ic5l_moveit_config)/launch/moveit_planning_execution.launch">
+      <arg name="sim" value="false" />
+      <arg name="robot_ip" value="$(arg ip_str)" />
+    </include>
+  </group>
+
+  <group ns="with_db">
+    <include file="$(find fanuc_lrmate200ic5l_moveit_config)/launch/moveit_planning_execution.launch">
+      <arg name="sim" value="false" />
+      <arg name="robot_ip" value="$(arg ip_str)" />
+      <arg name="db" value="true" />
+    </include>
+  </group>
+</launch>

--- a/fanuc_lrmate200ic_moveit_config/CMakeLists.txt
+++ b/fanuc_lrmate200ic_moveit_config/CMakeLists.txt
@@ -5,6 +5,12 @@ find_package(catkin REQUIRED)
 
 catkin_package()
 
+if (CATKIN_ENABLE_TESTING)
+  find_package(roslaunch REQUIRED)
+  roslaunch_add_file_check(launch/demo.launch)
+  roslaunch_add_file_check(tests/moveit_planning_execution.xml)
+endif()
+
 install(DIRECTORY launch DESTINATION ${CATKIN_PACKAGE_SHARE_DESTINATION})
 install(DIRECTORY config DESTINATION ${CATKIN_PACKAGE_SHARE_DESTINATION})
 

--- a/fanuc_lrmate200ic_moveit_config/package.xml
+++ b/fanuc_lrmate200ic_moveit_config/package.xml
@@ -29,6 +29,8 @@
 
   <buildtool_depend>catkin</buildtool_depend>
 
+  <test_depend>roslaunch</test_depend>
+
   <exec_depend>fanuc_lrmate200ic_moveit_plugins</exec_depend>
   <exec_depend>fanuc_lrmate200ic_support</exec_depend>
   <exec_depend>industrial_robot_simulator</exec_depend>

--- a/fanuc_lrmate200ic_moveit_config/package.xml
+++ b/fanuc_lrmate200ic_moveit_config/package.xml
@@ -39,8 +39,11 @@
   <exec_depend>moveit_planners_ompl</exec_depend>
   <exec_depend>moveit_ros_move_group</exec_depend>
   <exec_depend>moveit_ros_visualization</exec_depend>
+  <exec_depend>moveit_ros_warehouse</exec_depend>
   <exec_depend>moveit_simple_controller_manager</exec_depend>
   <exec_depend>robot_state_publisher</exec_depend>
+  <exec_depend>rviz</exec_depend>
+  <exec_depend>warehouse_ros</exec_depend>
   <exec_depend>xacro</exec_depend>
 
   <export>

--- a/fanuc_lrmate200ic_moveit_config/tests/moveit_planning_execution.xml
+++ b/fanuc_lrmate200ic_moveit_config/tests/moveit_planning_execution.xml
@@ -1,0 +1,19 @@
+<?xml version="1.0"?>
+<launch>
+  <arg name="ip_str" value="127.0.0.1" />
+
+  <group>
+    <include file="$(find fanuc_lrmate200ic_moveit_config)/launch/moveit_planning_execution.launch">
+      <arg name="sim" value="false" />
+      <arg name="robot_ip" value="$(arg ip_str)" />
+    </include>
+  </group>
+
+  <group ns="with_db">
+    <include file="$(find fanuc_lrmate200ic_moveit_config)/launch/moveit_planning_execution.launch">
+      <arg name="sim" value="false" />
+      <arg name="robot_ip" value="$(arg ip_str)" />
+      <arg name="db" value="true" />
+    </include>
+  </group>
+</launch>

--- a/fanuc_m10ia_moveit_config/CMakeLists.txt
+++ b/fanuc_m10ia_moveit_config/CMakeLists.txt
@@ -5,6 +5,12 @@ find_package(catkin REQUIRED)
 
 catkin_package()
 
+if (CATKIN_ENABLE_TESTING)
+  find_package(roslaunch REQUIRED)
+  roslaunch_add_file_check(launch/demo.launch)
+  roslaunch_add_file_check(tests/moveit_planning_execution.xml)
+endif()
+
 install(DIRECTORY launch DESTINATION ${CATKIN_PACKAGE_SHARE_DESTINATION})
 install(DIRECTORY config DESTINATION ${CATKIN_PACKAGE_SHARE_DESTINATION})
 

--- a/fanuc_m10ia_moveit_config/package.xml
+++ b/fanuc_m10ia_moveit_config/package.xml
@@ -29,6 +29,8 @@
 
   <buildtool_depend>catkin</buildtool_depend>
 
+  <test_depend>roslaunch</test_depend>
+
   <exec_depend>fanuc_m10ia_moveit_plugins</exec_depend>
   <exec_depend>fanuc_m10ia_support</exec_depend>
   <exec_depend>industrial_robot_simulator</exec_depend>

--- a/fanuc_m10ia_moveit_config/package.xml
+++ b/fanuc_m10ia_moveit_config/package.xml
@@ -39,8 +39,11 @@
   <exec_depend>moveit_planners_ompl</exec_depend>
   <exec_depend>moveit_ros_move_group</exec_depend>
   <exec_depend>moveit_ros_visualization</exec_depend>
+  <exec_depend>moveit_ros_warehouse</exec_depend>
   <exec_depend>moveit_simple_controller_manager</exec_depend>
   <exec_depend>robot_state_publisher</exec_depend>
+  <exec_depend>rviz</exec_depend>
+  <exec_depend>warehouse_ros</exec_depend>
   <exec_depend>xacro</exec_depend>
 
   <export>

--- a/fanuc_m10ia_moveit_config/tests/moveit_planning_execution.xml
+++ b/fanuc_m10ia_moveit_config/tests/moveit_planning_execution.xml
@@ -1,0 +1,19 @@
+<?xml version="1.0"?>
+<launch>
+  <arg name="ip_str" value="127.0.0.1" />
+
+  <group>
+    <include file="$(find fanuc_m10ia_moveit_config)/launch/moveit_planning_execution.launch">
+      <arg name="sim" value="false" />
+      <arg name="robot_ip" value="$(arg ip_str)" />
+    </include>
+  </group>
+
+  <group ns="with_db">
+    <include file="$(find fanuc_m10ia_moveit_config)/launch/moveit_planning_execution.launch">
+      <arg name="sim" value="false" />
+      <arg name="robot_ip" value="$(arg ip_str)" />
+      <arg name="db" value="true" />
+    </include>
+  </group>
+</launch>

--- a/fanuc_m16ib20_moveit_config/CMakeLists.txt
+++ b/fanuc_m16ib20_moveit_config/CMakeLists.txt
@@ -5,6 +5,12 @@ find_package(catkin REQUIRED)
 
 catkin_package()
 
+if (CATKIN_ENABLE_TESTING)
+  find_package(roslaunch REQUIRED)
+  roslaunch_add_file_check(launch/demo.launch)
+  roslaunch_add_file_check(tests/moveit_planning_execution.xml)
+endif()
+
 install(DIRECTORY launch DESTINATION ${CATKIN_PACKAGE_SHARE_DESTINATION})
 install(DIRECTORY config DESTINATION ${CATKIN_PACKAGE_SHARE_DESTINATION})
 

--- a/fanuc_m16ib20_moveit_config/package.xml
+++ b/fanuc_m16ib20_moveit_config/package.xml
@@ -39,8 +39,11 @@
   <exec_depend>moveit_planners_ompl</exec_depend>
   <exec_depend>moveit_ros_move_group</exec_depend>
   <exec_depend>moveit_ros_visualization</exec_depend>
+  <exec_depend>moveit_ros_warehouse</exec_depend>
   <exec_depend>moveit_simple_controller_manager</exec_depend>
   <exec_depend>robot_state_publisher</exec_depend>
+  <exec_depend>rviz</exec_depend>
+  <exec_depend>warehouse_ros</exec_depend>
   <exec_depend>xacro</exec_depend>
 
   <export>

--- a/fanuc_m16ib20_moveit_config/package.xml
+++ b/fanuc_m16ib20_moveit_config/package.xml
@@ -29,6 +29,8 @@
 
   <buildtool_depend>catkin</buildtool_depend>
 
+  <test_depend>roslaunch</test_depend>
+
   <exec_depend>fanuc_m16ib_moveit_plugins</exec_depend>
   <exec_depend>fanuc_m16ib_support</exec_depend>
   <exec_depend>industrial_robot_simulator</exec_depend>

--- a/fanuc_m16ib20_moveit_config/tests/moveit_planning_execution.xml
+++ b/fanuc_m16ib20_moveit_config/tests/moveit_planning_execution.xml
@@ -1,0 +1,19 @@
+<?xml version="1.0"?>
+<launch>
+  <arg name="ip_str" value="127.0.0.1" />
+
+  <group>
+    <include file="$(find fanuc_m16ib20_moveit_config)/launch/moveit_planning_execution.launch">
+      <arg name="sim" value="false" />
+      <arg name="robot_ip" value="$(arg ip_str)" />
+    </include>
+  </group>
+
+  <group ns="with_db">
+    <include file="$(find fanuc_m16ib20_moveit_config)/launch/moveit_planning_execution.launch">
+      <arg name="sim" value="false" />
+      <arg name="robot_ip" value="$(arg ip_str)" />
+      <arg name="db" value="true" />
+    </include>
+  </group>
+</launch>

--- a/fanuc_m20ia10l_moveit_config/CMakeLists.txt
+++ b/fanuc_m20ia10l_moveit_config/CMakeLists.txt
@@ -5,6 +5,12 @@ find_package(catkin REQUIRED)
 
 catkin_package()
 
+if (CATKIN_ENABLE_TESTING)
+  find_package(roslaunch REQUIRED)
+  roslaunch_add_file_check(launch/demo.launch)
+  roslaunch_add_file_check(tests/moveit_planning_execution.xml)
+endif()
+
 install(DIRECTORY launch DESTINATION ${CATKIN_PACKAGE_SHARE_DESTINATION})
 install(DIRECTORY config DESTINATION ${CATKIN_PACKAGE_SHARE_DESTINATION})
 

--- a/fanuc_m20ia10l_moveit_config/package.xml
+++ b/fanuc_m20ia10l_moveit_config/package.xml
@@ -39,8 +39,11 @@
   <exec_depend>moveit_planners_ompl</exec_depend>
   <exec_depend>moveit_ros_move_group</exec_depend>
   <exec_depend>moveit_ros_visualization</exec_depend>
+  <exec_depend>moveit_ros_warehouse</exec_depend>
   <exec_depend>moveit_simple_controller_manager</exec_depend>
   <exec_depend>robot_state_publisher</exec_depend>
+  <exec_depend>rviz</exec_depend>
+  <exec_depend>warehouse_ros</exec_depend>
   <exec_depend>xacro</exec_depend>
 
   <export>

--- a/fanuc_m20ia10l_moveit_config/package.xml
+++ b/fanuc_m20ia10l_moveit_config/package.xml
@@ -29,6 +29,8 @@
 
   <buildtool_depend>catkin</buildtool_depend>
 
+  <test_depend>roslaunch</test_depend>
+
   <exec_depend>fanuc_m20ia_moveit_plugins</exec_depend>
   <exec_depend>fanuc_m20ia_support</exec_depend>
   <exec_depend>industrial_robot_simulator</exec_depend>

--- a/fanuc_m20ia10l_moveit_config/tests/moveit_planning_execution.xml
+++ b/fanuc_m20ia10l_moveit_config/tests/moveit_planning_execution.xml
@@ -1,0 +1,19 @@
+<?xml version="1.0"?>
+<launch>
+  <arg name="ip_str" value="127.0.0.1" />
+
+  <group>
+    <include file="$(find fanuc_m20ia10l_moveit_config)/launch/moveit_planning_execution.launch">
+      <arg name="sim" value="false" />
+      <arg name="robot_ip" value="$(arg ip_str)" />
+    </include>
+  </group>
+
+  <group ns="with_db">
+    <include file="$(find fanuc_m20ia10l_moveit_config)/launch/moveit_planning_execution.launch">
+      <arg name="sim" value="false" />
+      <arg name="robot_ip" value="$(arg ip_str)" />
+      <arg name="db" value="true" />
+    </include>
+  </group>
+</launch>

--- a/fanuc_m20ia_moveit_config/CMakeLists.txt
+++ b/fanuc_m20ia_moveit_config/CMakeLists.txt
@@ -5,6 +5,12 @@ find_package(catkin REQUIRED)
 
 catkin_package()
 
+if (CATKIN_ENABLE_TESTING)
+  find_package(roslaunch REQUIRED)
+  roslaunch_add_file_check(launch/demo.launch)
+  roslaunch_add_file_check(tests/moveit_planning_execution.xml)
+endif()
+
 install(DIRECTORY launch DESTINATION ${CATKIN_PACKAGE_SHARE_DESTINATION})
 install(DIRECTORY config DESTINATION ${CATKIN_PACKAGE_SHARE_DESTINATION})
 

--- a/fanuc_m20ia_moveit_config/package.xml
+++ b/fanuc_m20ia_moveit_config/package.xml
@@ -39,8 +39,11 @@
   <exec_depend>moveit_planners_ompl</exec_depend>
   <exec_depend>moveit_ros_move_group</exec_depend>
   <exec_depend>moveit_ros_visualization</exec_depend>
+  <exec_depend>moveit_ros_warehouse</exec_depend>
   <exec_depend>moveit_simple_controller_manager</exec_depend>
   <exec_depend>robot_state_publisher</exec_depend>
+  <exec_depend>rviz</exec_depend>
+  <exec_depend>warehouse_ros</exec_depend>
   <exec_depend>xacro</exec_depend>
 
   <export>

--- a/fanuc_m20ia_moveit_config/package.xml
+++ b/fanuc_m20ia_moveit_config/package.xml
@@ -29,6 +29,8 @@
 
   <buildtool_depend>catkin</buildtool_depend>
 
+  <test_depend>roslaunch</test_depend>
+
   <exec_depend>fanuc_m20ia_moveit_plugins</exec_depend>
   <exec_depend>fanuc_m20ia_support</exec_depend>
   <exec_depend>industrial_robot_simulator</exec_depend>

--- a/fanuc_m20ia_moveit_config/tests/moveit_planning_execution.xml
+++ b/fanuc_m20ia_moveit_config/tests/moveit_planning_execution.xml
@@ -1,0 +1,19 @@
+<?xml version="1.0"?>
+<launch>
+  <arg name="ip_str" value="127.0.0.1" />
+
+  <group>
+    <include file="$(find fanuc_m20ia_moveit_config)/launch/moveit_planning_execution.launch">
+      <arg name="sim" value="false" />
+      <arg name="robot_ip" value="$(arg ip_str)" />
+    </include>
+  </group>
+
+  <group ns="with_db">
+    <include file="$(find fanuc_m20ia_moveit_config)/launch/moveit_planning_execution.launch">
+      <arg name="sim" value="false" />
+      <arg name="robot_ip" value="$(arg ip_str)" />
+      <arg name="db" value="true" />
+    </include>
+  </group>
+</launch>

--- a/fanuc_m430ia2f_moveit_config/CMakeLists.txt
+++ b/fanuc_m430ia2f_moveit_config/CMakeLists.txt
@@ -5,6 +5,12 @@ find_package(catkin REQUIRED)
 
 catkin_package()
 
+if (CATKIN_ENABLE_TESTING)
+  find_package(roslaunch REQUIRED)
+  roslaunch_add_file_check(launch/demo.launch)
+  roslaunch_add_file_check(tests/moveit_planning_execution.xml)
+endif()
+
 install(DIRECTORY launch DESTINATION ${CATKIN_PACKAGE_SHARE_DESTINATION})
 install(DIRECTORY config DESTINATION ${CATKIN_PACKAGE_SHARE_DESTINATION})
 

--- a/fanuc_m430ia2f_moveit_config/package.xml
+++ b/fanuc_m430ia2f_moveit_config/package.xml
@@ -39,8 +39,11 @@
   <exec_depend>moveit_planners_ompl</exec_depend>
   <exec_depend>moveit_ros_move_group</exec_depend>
   <exec_depend>moveit_ros_visualization</exec_depend>
+  <exec_depend>moveit_ros_warehouse</exec_depend>
   <exec_depend>moveit_simple_controller_manager</exec_depend>
   <exec_depend>robot_state_publisher</exec_depend>
+  <exec_depend>rviz</exec_depend>
+  <exec_depend>warehouse_ros</exec_depend>
   <exec_depend>xacro</exec_depend>
 
   <export>

--- a/fanuc_m430ia2f_moveit_config/package.xml
+++ b/fanuc_m430ia2f_moveit_config/package.xml
@@ -29,6 +29,8 @@
 
   <buildtool_depend>catkin</buildtool_depend>
 
+  <test_depend>roslaunch</test_depend>
+
   <exec_depend>fanuc_m430ia_moveit_plugins</exec_depend>
   <exec_depend>fanuc_m430ia_support</exec_depend>
   <exec_depend>industrial_robot_simulator</exec_depend>

--- a/fanuc_m430ia2f_moveit_config/tests/moveit_planning_execution.xml
+++ b/fanuc_m430ia2f_moveit_config/tests/moveit_planning_execution.xml
@@ -1,0 +1,19 @@
+<?xml version="1.0"?>
+<launch>
+  <arg name="ip_str" value="127.0.0.1" />
+
+  <group>
+    <include file="$(find fanuc_m430ia2f_moveit_config)/launch/moveit_planning_execution.launch">
+      <arg name="sim" value="false" />
+      <arg name="robot_ip" value="$(arg ip_str)" />
+    </include>
+  </group>
+
+  <group ns="with_db">
+    <include file="$(find fanuc_m430ia2f_moveit_config)/launch/moveit_planning_execution.launch">
+      <arg name="sim" value="false" />
+      <arg name="robot_ip" value="$(arg ip_str)" />
+      <arg name="db" value="true" />
+    </include>
+  </group>
+</launch>

--- a/fanuc_m430ia2p_moveit_config/CMakeLists.txt
+++ b/fanuc_m430ia2p_moveit_config/CMakeLists.txt
@@ -5,6 +5,12 @@ find_package(catkin REQUIRED)
 
 catkin_package()
 
+if (CATKIN_ENABLE_TESTING)
+  find_package(roslaunch REQUIRED)
+  roslaunch_add_file_check(launch/demo.launch)
+  roslaunch_add_file_check(tests/moveit_planning_execution.xml)
+endif()
+
 install(DIRECTORY launch DESTINATION ${CATKIN_PACKAGE_SHARE_DESTINATION})
 install(DIRECTORY config DESTINATION ${CATKIN_PACKAGE_SHARE_DESTINATION})
 

--- a/fanuc_m430ia2p_moveit_config/package.xml
+++ b/fanuc_m430ia2p_moveit_config/package.xml
@@ -39,8 +39,11 @@
   <exec_depend>moveit_planners_ompl</exec_depend>
   <exec_depend>moveit_ros_move_group</exec_depend>
   <exec_depend>moveit_ros_visualization</exec_depend>
+  <exec_depend>moveit_ros_warehouse</exec_depend>
   <exec_depend>moveit_simple_controller_manager</exec_depend>
   <exec_depend>robot_state_publisher</exec_depend>
+  <exec_depend>rviz</exec_depend>
+  <exec_depend>warehouse_ros</exec_depend>
   <exec_depend>xacro</exec_depend>
 
   <export>

--- a/fanuc_m430ia2p_moveit_config/package.xml
+++ b/fanuc_m430ia2p_moveit_config/package.xml
@@ -29,6 +29,8 @@
 
   <buildtool_depend>catkin</buildtool_depend>
 
+  <test_depend>roslaunch</test_depend>
+
   <exec_depend>fanuc_m430ia_moveit_plugins</exec_depend>
   <exec_depend>fanuc_m430ia_support</exec_depend>
   <exec_depend>industrial_robot_simulator</exec_depend>

--- a/fanuc_m430ia2p_moveit_config/tests/moveit_planning_execution.xml
+++ b/fanuc_m430ia2p_moveit_config/tests/moveit_planning_execution.xml
@@ -1,0 +1,19 @@
+<?xml version="1.0"?>
+<launch>
+  <arg name="ip_str" value="127.0.0.1" />
+
+  <group>
+    <include file="$(find fanuc_m430ia2p_moveit_config)/launch/moveit_planning_execution.launch">
+      <arg name="sim" value="false" />
+      <arg name="robot_ip" value="$(arg ip_str)" />
+    </include>
+  </group>
+
+  <group ns="with_db">
+    <include file="$(find fanuc_m430ia2p_moveit_config)/launch/moveit_planning_execution.launch">
+      <arg name="sim" value="false" />
+      <arg name="robot_ip" value="$(arg ip_str)" />
+      <arg name="db" value="true" />
+    </include>
+  </group>
+</launch>


### PR DESCRIPTION
As per subject.

This adds `roslaunch` launch file testing to the MoveIt configuration packages, similar to how this is already done in the support packages. See 6da2858 for more details.

The added tests revealed that all package manifests were missing three dependency declarations, so those were added in 32da02e.
