### PR TITLE
resources: add 'collaborative green' colour.

### DIFF
--- a/fanuc_resources/urdf/common_colours.xacro
+++ b/fanuc_resources/urdf/common_colours.xacro
@@ -23,6 +23,8 @@
   <xacro:property name="color_fanuc_BAB0B0"   value="${186/255} ${176/255} ${176/255} 1.0" />
   <!-- #E6E6E6 -->
   <xacro:property name="color_fanuc_E6E6E6"   value="${230/255} ${230/255} ${230/255} 1.0" />
+  <!-- #00FF73: 'collaborative green' -->
+  <xacro:property name="color_fanuc_00FF73"   value="${  0/255} ${255/255} ${115/255} 1.0" />
 
   <!-- approximations -->
   <xacro:property name="color_fanuc_black"    value="0.15 0.15 0.15 1.0" />

--- a/fanuc_resources/urdf/common_materials.xacro
+++ b/fanuc_resources/urdf/common_materials.xacro
@@ -62,6 +62,12 @@
     </material>
   </xacro:macro>
 
+  <xacro:macro name="material_fanuc_00FF73">
+    <material name="">
+      <color rgba="${color_fanuc_00FF73}"/>
+    </material>
+  </xacro:macro>
+
   <xacro:macro name="material_fanuc_black">
     <material name="">
       <color rgba="${color_fanuc_black}"/>


### PR DESCRIPTION
As per subject. Adds [0x00FF73](http://www.color-hex.com/color/00ff73).

Official name is not 'collaborative green', but it's currently only used on the collaborative CR-35iA, so ..

This was again taken from Roboguide, just as #164.
