### PR TITLE
Use in-order processing in all xacro loading launch files

### DIFF
--- a/fanuc_lrmate200ic_support/launch/load_lrmate200ic.launch
+++ b/fanuc_lrmate200ic_support/launch/load_lrmate200ic.launch
@@ -1,4 +1,4 @@
 <?xml version="1.0"?>
 <launch>
-  <param name="robot_description" command="$(find xacro)/xacro '$(find fanuc_lrmate200ic_support)/urdf/lrmate200ic.xacro'" />
+  <param name="robot_description" command="$(find xacro)/xacro --inorder '$(find fanuc_lrmate200ic_support)/urdf/lrmate200ic.xacro'" />
 </launch>

--- a/fanuc_lrmate200ic_support/launch/load_lrmate200ic5f.launch
+++ b/fanuc_lrmate200ic_support/launch/load_lrmate200ic5f.launch
@@ -1,4 +1,4 @@
 <?xml version="1.0"?>
 <launch>
-  <param name="robot_description" command="$(find xacro)/xacro '$(find fanuc_lrmate200ic_support)/urdf/lrmate200ic5f.xacro'" />
+  <param name="robot_description" command="$(find xacro)/xacro --inorder '$(find fanuc_lrmate200ic_support)/urdf/lrmate200ic5f.xacro'" />
 </launch>

--- a/fanuc_lrmate200ic_support/launch/load_lrmate200ic5h.launch
+++ b/fanuc_lrmate200ic_support/launch/load_lrmate200ic5h.launch
@@ -1,4 +1,4 @@
 <?xml version="1.0"?>
 <launch>
-  <param name="robot_description" command="$(find xacro)/xacro '$(find fanuc_lrmate200ic_support)/urdf/lrmate200ic5h.xacro'" />
+  <param name="robot_description" command="$(find xacro)/xacro --inorder '$(find fanuc_lrmate200ic_support)/urdf/lrmate200ic5h.xacro'" />
 </launch>

--- a/fanuc_lrmate200ic_support/launch/load_lrmate200ic5hs.launch
+++ b/fanuc_lrmate200ic_support/launch/load_lrmate200ic5hs.launch
@@ -1,4 +1,4 @@
 <?xml version="1.0"?>
 <launch>
-  <param name="robot_description" command="$(find xacro)/xacro '$(find fanuc_lrmate200ic_support)/urdf/lrmate200ic5hs.xacro'" />
+  <param name="robot_description" command="$(find xacro)/xacro --inorder '$(find fanuc_lrmate200ic_support)/urdf/lrmate200ic5hs.xacro'" />
 </launch>

--- a/fanuc_lrmate200ic_support/launch/load_lrmate200ic5l.launch
+++ b/fanuc_lrmate200ic_support/launch/load_lrmate200ic5l.launch
@@ -1,4 +1,4 @@
 <?xml version="1.0"?>
 <launch>
-  <param name="robot_description" command="$(find xacro)/xacro '$(find fanuc_lrmate200ic_support)/urdf/lrmate200ic5l.xacro'" />
+  <param name="robot_description" command="$(find xacro)/xacro --inorder '$(find fanuc_lrmate200ic_support)/urdf/lrmate200ic5l.xacro'" />
 </launch>

--- a/fanuc_m10ia_support/launch/load_m10ia.launch
+++ b/fanuc_m10ia_support/launch/load_m10ia.launch
@@ -1,4 +1,4 @@
 <?xml version="1.0"?>
 <launch>
-  <param name="robot_description" command="$(find xacro)/xacro '$(find fanuc_m10ia_support)/urdf/m10ia.xacro'" />
+  <param name="robot_description" command="$(find xacro)/xacro --inorder '$(find fanuc_m10ia_support)/urdf/m10ia.xacro'" />
 </launch>

--- a/fanuc_m10ia_support/launch/load_m10ia7l.launch
+++ b/fanuc_m10ia_support/launch/load_m10ia7l.launch
@@ -1,4 +1,4 @@
 <?xml version="1.0"?>
 <launch>
-  <param name="robot_description" command="$(find xacro)/xacro '$(find fanuc_m10ia_support)/urdf/m10ia7l.xacro'" />
+  <param name="robot_description" command="$(find xacro)/xacro --inorder '$(find fanuc_m10ia_support)/urdf/m10ia7l.xacro'" />
 </launch>

--- a/fanuc_m16ib_support/launch/load_m16ib20.launch
+++ b/fanuc_m16ib_support/launch/load_m16ib20.launch
@@ -1,4 +1,4 @@
 <?xml version="1.0"?>
 <launch>
-  <param name="robot_description" command="$(find xacro)/xacro '$(find fanuc_m16ib_support)/urdf/m16ib20.xacro'" />
+  <param name="robot_description" command="$(find xacro)/xacro --inorder '$(find fanuc_m16ib_support)/urdf/m16ib20.xacro'" />
 </launch>

--- a/fanuc_m20ia_support/launch/load_m20ia.launch
+++ b/fanuc_m20ia_support/launch/load_m20ia.launch
@@ -1,4 +1,4 @@
 <?xml version="1.0"?>
 <launch>
-  <param name="robot_description" command="$(find xacro)/xacro '$(find fanuc_m20ia_support)/urdf/m20ia.xacro'" />
+  <param name="robot_description" command="$(find xacro)/xacro --inorder '$(find fanuc_m20ia_support)/urdf/m20ia.xacro'" />
 </launch>

--- a/fanuc_m20ia_support/launch/load_m20ia10l.launch
+++ b/fanuc_m20ia_support/launch/load_m20ia10l.launch
@@ -1,4 +1,4 @@
 <?xml version="1.0"?>
 <launch>
-  <param name="robot_description" command="$(find xacro)/xacro '$(find fanuc_m20ia_support)/urdf/m20ia10l.xacro'" />
+  <param name="robot_description" command="$(find xacro)/xacro --inorder '$(find fanuc_m20ia_support)/urdf/m20ia10l.xacro'" />
 </launch>

--- a/fanuc_m430ia_support/launch/load_m430ia2f.launch
+++ b/fanuc_m430ia_support/launch/load_m430ia2f.launch
@@ -1,4 +1,4 @@
 <?xml version="1.0"?>
 <launch>
-  <param name="robot_description" command="$(find xacro)/xacro '$(find fanuc_m430ia_support)/urdf/m430ia2f.xacro'" />
+  <param name="robot_description" command="$(find xacro)/xacro --inorder '$(find fanuc_m430ia_support)/urdf/m430ia2f.xacro'" />
 </launch>

--- a/fanuc_m430ia_support/launch/load_m430ia2p.launch
+++ b/fanuc_m430ia_support/launch/load_m430ia2p.launch
@@ -1,4 +1,4 @@
 <?xml version="1.0"?>
 <launch>
-  <param name="robot_description" command="$(find xacro)/xacro '$(find fanuc_m430ia_support)/urdf/m430ia2p.xacro'" />
+  <param name="robot_description" command="$(find xacro)/xacro --inorder '$(find fanuc_m430ia_support)/urdf/m430ia2p.xacro'" />
 </launch>


### PR DESCRIPTION
Newer versions of `xacro` support this by default, so start using this already.

Fully compatible with Indigo, as the `--inorder` argument triggers loading Jade+ `xacro` on Indigo.
