### PR TITLE
driver: remove 'irs_in_mtn' prototype from libind_rs header file

### DIFF
--- a/fanuc_driver/karel/include/libind_rs_h.kl
+++ b/fanuc_driver/karel/include/libind_rs_h.kl
@@ -72,18 +72,6 @@ ROUTINE irs_reset(this : ind_rs_t) FROM libind_rs
 
 --------------------------------------------------------------------------------
 -- 
--- Returns true if robot is in motion
--- 
--- [return    ]      : TRUE if in motion
--- 
---------------------------------------------------------------------------------
-ROUTINE irs_in_mtn: BOOLEAN FROM libind_rs
-
-
-
-
---------------------------------------------------------------------------------
--- 
 -- Update the message with current robot status
 -- 
 -- [in    ]  this    : the message to update


### PR DESCRIPTION
That method is not implemented in `libind_rs`. A left over from a refactoring in the past.

No functional changes (as it was not used anywhere).
