### PR TITLE
Fix for issue #211: push traj exec params down into ns

### DIFF
--- a/fanuc_lrmate200ic5h_moveit_config/launch/trajectory_execution.launch.xml
+++ b/fanuc_lrmate200ic5h_moveit_config/launch/trajectory_execution.launch.xml
@@ -7,9 +7,9 @@
   <param name="moveit_manage_controllers" value="$(arg moveit_manage_controllers)"/>
 
   <!-- When determining the expected duration of a trajectory, this multiplicative factor is applied to get the allowed duration of execution -->
-  <param name="allowed_execution_duration_scaling" value="1.2"/> <!-- default 1.2 -->
+  <param name="trajectory_execution/allowed_execution_duration_scaling" value="1.2"/> <!-- default 1.2 -->
   <!-- Allow more than the expected execution time before triggering a trajectory cancel (applied after scaling) -->
-  <param name="allowed_goal_duration_margin" value="0.5"/> <!-- default 0.5 -->
+  <param name="trajectory_execution/allowed_goal_duration_margin" value="0.5"/> <!-- default 0.5 -->
   
   <!-- Load the robot specific controller manager; this sets the moveit_controller_manager ROS parameter -->
   <arg name="moveit_controller_manager" default="fanuc_lrmate200ic5h" />

--- a/fanuc_lrmate200ic5l_moveit_config/launch/trajectory_execution.launch.xml
+++ b/fanuc_lrmate200ic5l_moveit_config/launch/trajectory_execution.launch.xml
@@ -7,9 +7,9 @@
   <param name="moveit_manage_controllers" value="$(arg moveit_manage_controllers)"/>
 
   <!-- When determining the expected duration of a trajectory, this multiplicative factor is applied to get the allowed duration of execution -->
-  <param name="allowed_execution_duration_scaling" value="1.2"/> <!-- default 1.2 -->
+  <param name="trajectory_execution/allowed_execution_duration_scaling" value="1.2"/> <!-- default 1.2 -->
   <!-- Allow more than the expected execution time before triggering a trajectory cancel (applied after scaling) -->
-  <param name="allowed_goal_duration_margin" value="0.5"/> <!-- default 0.5 -->
+  <param name="trajectory_execution/allowed_goal_duration_margin" value="0.5"/> <!-- default 0.5 -->
   
   <!-- Load the robot specific controller manager; this sets the moveit_controller_manager ROS parameter -->
   <arg name="moveit_controller_manager" default="fanuc_lrmate200ic5l" />

--- a/fanuc_lrmate200ic_moveit_config/launch/trajectory_execution.launch.xml
+++ b/fanuc_lrmate200ic_moveit_config/launch/trajectory_execution.launch.xml
@@ -7,9 +7,9 @@
   <param name="moveit_manage_controllers" value="$(arg moveit_manage_controllers)"/>
 
   <!-- When determining the expected duration of a trajectory, this multiplicative factor is applied to get the allowed duration of execution -->
-  <param name="allowed_execution_duration_scaling" value="1.2"/> <!-- default 1.2 -->
+  <param name="trajectory_execution/allowed_execution_duration_scaling" value="1.2"/> <!-- default 1.2 -->
   <!-- Allow more than the expected execution time before triggering a trajectory cancel (applied after scaling) -->
-  <param name="allowed_goal_duration_margin" value="0.5"/> <!-- default 0.5 -->
+  <param name="trajectory_execution/allowed_goal_duration_margin" value="0.5"/> <!-- default 0.5 -->
   
   <!-- Load the robot specific controller manager; this sets the moveit_controller_manager ROS parameter -->
   <arg name="moveit_controller_manager" default="fanuc_lrmate200ic" />

--- a/fanuc_m10ia_moveit_config/launch/trajectory_execution.launch.xml
+++ b/fanuc_m10ia_moveit_config/launch/trajectory_execution.launch.xml
@@ -7,9 +7,9 @@
   <param name="moveit_manage_controllers" value="$(arg moveit_manage_controllers)"/>
 
   <!-- When determining the expected duration of a trajectory, this multiplicative factor is applied to get the allowed duration of execution -->
-  <param name="allowed_execution_duration_scaling" value="1.2"/> <!-- default 1.2 -->
+  <param name="trajectory_execution/allowed_execution_duration_scaling" value="1.2"/> <!-- default 1.2 -->
   <!-- Allow more than the expected execution time before triggering a trajectory cancel (applied after scaling) -->
-  <param name="allowed_goal_duration_margin" value="0.5"/> <!-- default 0.5 -->
+  <param name="trajectory_execution/allowed_goal_duration_margin" value="0.5"/> <!-- default 0.5 -->
   
   <!-- Load the robot specific controller manager; this sets the moveit_controller_manager ROS parameter -->
   <arg name="moveit_controller_manager" default="fanuc_m10ia" />

--- a/fanuc_m16ib20_moveit_config/launch/trajectory_execution.launch.xml
+++ b/fanuc_m16ib20_moveit_config/launch/trajectory_execution.launch.xml
@@ -7,9 +7,9 @@
   <param name="moveit_manage_controllers" value="$(arg moveit_manage_controllers)"/>
 
   <!-- When determining the expected duration of a trajectory, this multiplicative factor is applied to get the allowed duration of execution -->
-  <param name="allowed_execution_duration_scaling" value="1.2"/> <!-- default 1.2 -->
+  <param name="trajectory_execution/allowed_execution_duration_scaling" value="1.2"/> <!-- default 1.2 -->
   <!-- Allow more than the expected execution time before triggering a trajectory cancel (applied after scaling) -->
-  <param name="allowed_goal_duration_margin" value="0.5"/> <!-- default 0.5 -->
+  <param name="trajectory_execution/allowed_goal_duration_margin" value="0.5"/> <!-- default 0.5 -->
   
   <!-- Load the robot specific controller manager; this sets the moveit_controller_manager ROS parameter -->
   <arg name="moveit_controller_manager" default="fanuc_m16ib20" />

--- a/fanuc_m20ia10l_moveit_config/launch/trajectory_execution.launch.xml
+++ b/fanuc_m20ia10l_moveit_config/launch/trajectory_execution.launch.xml
@@ -7,9 +7,9 @@
   <param name="moveit_manage_controllers" value="$(arg moveit_manage_controllers)"/>
 
   <!-- When determining the expected duration of a trajectory, this multiplicative factor is applied to get the allowed duration of execution -->
-  <param name="allowed_execution_duration_scaling" value="1.2"/> <!-- default 1.2 -->
+  <param name="trajectory_execution/allowed_execution_duration_scaling" value="1.2"/> <!-- default 1.2 -->
   <!-- Allow more than the expected execution time before triggering a trajectory cancel (applied after scaling) -->
-  <param name="allowed_goal_duration_margin" value="0.5"/> <!-- default 0.5 -->
+  <param name="trajectory_execution/allowed_goal_duration_margin" value="0.5"/> <!-- default 0.5 -->
   
   <!-- Load the robot specific controller manager; this sets the moveit_controller_manager ROS parameter -->
   <arg name="moveit_controller_manager" default="fanuc_m20ia10l" />

--- a/fanuc_m20ia_moveit_config/launch/trajectory_execution.launch.xml
+++ b/fanuc_m20ia_moveit_config/launch/trajectory_execution.launch.xml
@@ -7,9 +7,9 @@
   <param name="moveit_manage_controllers" value="$(arg moveit_manage_controllers)"/>
 
   <!-- When determining the expected duration of a trajectory, this multiplicative factor is applied to get the allowed duration of execution -->
-  <param name="allowed_execution_duration_scaling" value="1.2"/> <!-- default 1.2 -->
+  <param name="trajectory_execution/allowed_execution_duration_scaling" value="1.2"/> <!-- default 1.2 -->
   <!-- Allow more than the expected execution time before triggering a trajectory cancel (applied after scaling) -->
-  <param name="allowed_goal_duration_margin" value="0.5"/> <!-- default 0.5 -->
+  <param name="trajectory_execution/allowed_goal_duration_margin" value="0.5"/> <!-- default 0.5 -->
   
   <!-- Load the robot specific controller manager; this sets the moveit_controller_manager ROS parameter -->
   <arg name="moveit_controller_manager" default="fanuc_m20ia" />

--- a/fanuc_m430ia2f_moveit_config/launch/trajectory_execution.launch.xml
+++ b/fanuc_m430ia2f_moveit_config/launch/trajectory_execution.launch.xml
@@ -7,9 +7,9 @@
   <param name="moveit_manage_controllers" value="$(arg moveit_manage_controllers)"/>
 
   <!-- When determining the expected duration of a trajectory, this multiplicative factor is applied to get the allowed duration of execution -->
-  <param name="allowed_execution_duration_scaling" value="1.2"/> <!-- default 1.2 -->
+  <param name="trajectory_execution/allowed_execution_duration_scaling" value="1.2"/> <!-- default 1.2 -->
   <!-- Allow more than the expected execution time before triggering a trajectory cancel (applied after scaling) -->
-  <param name="allowed_goal_duration_margin" value="0.5"/> <!-- default 0.5 -->
+  <param name="trajectory_execution/allowed_goal_duration_margin" value="0.5"/> <!-- default 0.5 -->
   
   <!-- Load the robot specific controller manager; this sets the moveit_controller_manager ROS parameter -->
   <arg name="moveit_controller_manager" default="fanuc_m430ia2f" />

--- a/fanuc_m430ia2p_moveit_config/launch/trajectory_execution.launch.xml
+++ b/fanuc_m430ia2p_moveit_config/launch/trajectory_execution.launch.xml
@@ -7,9 +7,9 @@
   <param name="moveit_manage_controllers" value="$(arg moveit_manage_controllers)"/>
 
   <!-- When determining the expected duration of a trajectory, this multiplicative factor is applied to get the allowed duration of execution -->
-  <param name="allowed_execution_duration_scaling" value="1.2"/> <!-- default 1.2 -->
+  <param name="trajectory_execution/allowed_execution_duration_scaling" value="1.2"/> <!-- default 1.2 -->
   <!-- Allow more than the expected execution time before triggering a trajectory cancel (applied after scaling) -->
-  <param name="allowed_goal_duration_margin" value="0.5"/> <!-- default 0.5 -->
+  <param name="trajectory_execution/allowed_goal_duration_margin" value="0.5"/> <!-- default 0.5 -->
   
   <!-- Load the robot specific controller manager; this sets the moveit_controller_manager ROS parameter -->
   <arg name="moveit_controller_manager" default="fanuc_m430ia2p" />


### PR DESCRIPTION
MoveIt has pushed these two parameters down into the `trajectory_execution` namespace some time ago. This just updates the MoveIt configs to be compatible with that.
