### PR TITLE
Add 'flange' frames to all robot models

### DIFF
--- a/fanuc_lrmate200ic_support/urdf/lrmate200ic5f_macro.xacro
+++ b/fanuc_lrmate200ic_support/urdf/lrmate200ic5f_macro.xacro
@@ -3,6 +3,7 @@
   <xacro:include filename="$(find fanuc_resources)/urdf/common_materials.xacro"/>
 
   <xacro:macro name="fanuc_lrmate200ic5f" params="prefix">
+    <!-- links: main serial chain -->
     <link name="${prefix}base_link">
       <visual>
         <origin xyz="0 0 0" rpy="0 0 0" />
@@ -93,8 +94,8 @@
         </geometry>
       </collision>
     </link>
-    <link name="${prefix}tool0" />
 
+    <!-- joints: main serial chain -->
     <joint name="${prefix}joint_1" type="revolute">
       <origin xyz="0 0 0.330" rpy="0 0 0" />
       <parent link="${prefix}base_link" />
@@ -130,18 +131,29 @@
       <axis xyz="-1 0 0" />
       <limit effort="0" lower="-6.285" upper="6.285" velocity="20.94395" />
     </joint>
-    <joint name="${prefix}joint_5-tool0" type="fixed">
-      <origin xyz="0 0 0" rpy="${pi} ${-pi/2.0} 0" />
-      <parent link="${prefix}link_5" />
-      <child link="${prefix}tool0" />
-    </joint>
 
-    <!-- ROS base_link to Fanuc World Coordinates transform -->
+    <!-- ROS-Industrial 'base' frame: base_link to Fanuc World Coordinates transform -->
     <link name="${prefix}base" />
     <joint name="${prefix}base_link-base" type="fixed">
       <origin xyz="0 0 0.330" rpy="0 0 0"/>
       <parent link="${prefix}base_link"/>
       <child link="${prefix}base"/>
+    </joint>
+
+    <!-- ROS-Industrial 'flange' frame: attachment point for EEF models -->
+    <link name="${prefix}flange" />
+    <joint name="${prefix}joint_5-flange" type="fixed">
+      <origin xyz="0 0 0" rpy="0 0 0" />
+      <parent link="${prefix}link_5" />
+      <child link="${prefix}flange" />
+    </joint>
+
+    <!-- ROS-Industrial 'tool0' frame: all-zeros tool frame -->
+    <link name="${prefix}tool0" />
+    <joint name="${prefix}link_5-tool0" type="fixed">
+      <origin xyz="0 0 0" rpy="${pi} ${-pi/2.0} 0" />
+      <parent link="${prefix}link_5" />
+      <child link="${prefix}tool0" />
     </joint>
   </xacro:macro>
 </robot>

--- a/fanuc_lrmate200ic_support/urdf/lrmate200ic5h_macro.xacro
+++ b/fanuc_lrmate200ic_support/urdf/lrmate200ic5h_macro.xacro
@@ -3,6 +3,7 @@
   <xacro:include filename="$(find fanuc_resources)/urdf/common_materials.xacro"/>
 
   <xacro:macro name="fanuc_lrmate200ic5h" params="prefix">
+    <!-- links: main serial chain -->
     <link name="${prefix}base_link">
       <visual>
         <origin xyz="0 0 0" rpy="0 0 0" />
@@ -93,8 +94,8 @@
         </geometry>
       </collision>
     </link>
-    <link name="${prefix}tool0" />
 
+    <!-- joints: main serial chain -->
     <joint name="${prefix}joint_1" type="revolute">
       <origin xyz="0 0 0.330" rpy="0 0 0" />
       <parent link="${prefix}base_link" />
@@ -130,18 +131,29 @@
       <axis xyz="-1 0 0" />
       <limit effort="0" lower="-6.285" upper="6.285" velocity="12.5664" />
     </joint>
-    <joint name="${prefix}joint_5-tool0" type="fixed">
-      <origin xyz="0 0 0" rpy="${pi} ${-pi/2.0} 0" />
-      <parent link="${prefix}link_5" />
-      <child link="${prefix}tool0" />
-    </joint>
 
-    <!-- ROS base_link to Fanuc World Coordinates transform -->
+    <!-- ROS-Industrial 'base' frame: base_link to Fanuc World Coordinates transform -->
     <link name="${prefix}base" />
     <joint name="${prefix}base_link-base" type="fixed">
       <origin xyz="0 0 0.330" rpy="0 0 0"/>
       <parent link="${prefix}base_link"/>
       <child link="${prefix}base"/>
+    </joint>
+
+    <!-- ROS-Industrial 'flange' frame: attachment point for EEF models -->
+    <link name="${prefix}flange" />
+    <joint name="${prefix}joint_5-flange" type="fixed">
+      <origin xyz="0 0 0" rpy="0 0 0" />
+      <parent link="${prefix}link_5" />
+      <child link="${prefix}flange" />
+    </joint>
+
+    <!-- ROS-Industrial 'tool0' frame: all-zeros tool frame -->
+    <link name="${prefix}tool0" />
+    <joint name="${prefix}link_5-tool0" type="fixed">
+      <origin xyz="0 0 0" rpy="${pi} ${-pi/2.0} 0" />
+      <parent link="${prefix}link_5" />
+      <child link="${prefix}tool0" />
     </joint>
   </xacro:macro>
 </robot>

--- a/fanuc_lrmate200ic_support/urdf/lrmate200ic5hs_macro.xacro
+++ b/fanuc_lrmate200ic_support/urdf/lrmate200ic5hs_macro.xacro
@@ -3,6 +3,7 @@
   <xacro:include filename="$(find fanuc_resources)/urdf/common_materials.xacro"/>
 
   <xacro:macro name="fanuc_lrmate200ic5hs" params="prefix">
+    <!-- links: main serial chain -->
     <link name="${prefix}base_link">
       <visual>
         <origin xyz="0 0 0" rpy="0 0 0" />
@@ -93,8 +94,8 @@
         </geometry>
       </collision>
     </link>
-    <link name="${prefix}tool0" />
 
+    <!-- joints: main serial chain -->
     <joint name="${prefix}joint_1" type="revolute">
       <origin xyz="0 0 0.330" rpy="0 0 0" />
       <parent link="${prefix}base_link" />
@@ -130,18 +131,29 @@
       <axis xyz="-1 0 0" />
       <limit effort="0" lower="-6.285" upper="6.285" velocity="20.94395" />
     </joint>
-    <joint name="${prefix}joint_5-tool0" type="fixed">
-      <origin xyz="0 0 0" rpy="${pi} ${-pi/2.0} 0" />
-      <parent link="${prefix}link_5" />
-      <child link="${prefix}tool0" />
-    </joint>
 
-    <!-- ROS base_link to Fanuc World Coordinates transform -->
+    <!-- ROS-Industrial 'base' frame: base_link to Fanuc World Coordinates transform -->
     <link name="${prefix}base" />
     <joint name="${prefix}base_link-base" type="fixed">
       <origin xyz="0 0 0.330" rpy="0 0 0"/>
       <parent link="${prefix}base_link"/>
       <child link="${prefix}base"/>
+    </joint>
+
+    <!-- ROS-Industrial 'flange' frame: attachment point for EEF models -->
+    <link name="${prefix}flange" />
+    <joint name="${prefix}joint_5-flange" type="fixed">
+      <origin xyz="0 0 0" rpy="0 0 0" />
+      <parent link="${prefix}link_5" />
+      <child link="${prefix}flange" />
+    </joint>
+
+    <!-- ROS-Industrial 'tool0' frame: all-zeros tool frame -->
+    <link name="${prefix}tool0" />
+    <joint name="${prefix}link_5-tool0" type="fixed">
+      <origin xyz="0 0 0" rpy="${pi} ${-pi/2.0} 0" />
+      <parent link="${prefix}link_5" />
+      <child link="${prefix}tool0" />
     </joint>
   </xacro:macro>
 </robot>

--- a/fanuc_lrmate200ic_support/urdf/lrmate200ic5l_macro.xacro
+++ b/fanuc_lrmate200ic_support/urdf/lrmate200ic5l_macro.xacro
@@ -3,6 +3,7 @@
   <xacro:include filename="$(find fanuc_resources)/urdf/common_materials.xacro"/>
 
   <xacro:macro name="fanuc_lrmate200ic5l" params="prefix">
+    <!-- links: main serial chain -->
     <link name="${prefix}base_link">
       <visual>
         <origin xyz="0 0 0" rpy="0 0 0"/>
@@ -108,8 +109,8 @@
         </geometry>
       </collision>
     </link>
-    <link name="${prefix}tool0" />
 
+    <!-- joints: main serial chain -->
     <joint name="${prefix}joint_1" type="revolute">
       <origin xyz="0 0 0.330" rpy="0 0 0" />
       <parent link="${prefix}base_link" />
@@ -152,18 +153,29 @@
       <axis xyz="-1 0 0"/>
       <limit effort="0" lower="-6.2832" upper="6.2832" velocity="12.5664" />
     </joint>
-    <joint name="${prefix}joint_6-tool0" type="fixed">
-      <origin xyz="0 0 0" rpy="${pi} ${-pi/2.0} 0" />
-      <parent link="${prefix}link_6" />
-      <child link="${prefix}tool0" />
-    </joint>
 
-    <!-- ROS base_link to Fanuc World Coordinates transform -->
+    <!-- ROS-Industrial 'base' frame: base_link to Fanuc World Coordinates transform -->
     <link name="${prefix}base" />
     <joint name="${prefix}base_link-base" type="fixed">
       <origin xyz="0 0 0.330" rpy="0 0 0"/>
       <parent link="${prefix}base_link"/>
       <child link="${prefix}base"/>
+    </joint>
+
+    <!-- ROS-Industrial 'flange' frame: attachment point for EEF models -->
+    <link name="${prefix}flange" />
+    <joint name="${prefix}joint_6-flange" type="fixed">
+      <origin xyz="0 0 0" rpy="0 0 0" />
+      <parent link="${prefix}link_6" />
+      <child link="${prefix}flange" />
+    </joint>
+
+    <!-- ROS-Industrial 'tool0' frame: all-zeros tool frame -->
+    <link name="${prefix}tool0" />
+    <joint name="${prefix}link_6-tool0" type="fixed">
+      <origin xyz="0 0 0" rpy="${pi} ${-pi/2.0} 0" />
+      <parent link="${prefix}link_6" />
+      <child link="${prefix}tool0" />
     </joint>
   </xacro:macro>
 </robot>

--- a/fanuc_lrmate200ic_support/urdf/lrmate200ic_macro.xacro
+++ b/fanuc_lrmate200ic_support/urdf/lrmate200ic_macro.xacro
@@ -3,6 +3,7 @@
   <xacro:include filename="$(find fanuc_resources)/urdf/common_materials.xacro"/>
 
   <xacro:macro name="fanuc_lrmate200ic" params="prefix">
+    <!-- links: main serial chain -->
     <link name="${prefix}base_link">
       <visual>
         <origin xyz="0 0 0" rpy="0 0 0"/>
@@ -108,8 +109,8 @@
         </geometry>
       </collision>
     </link>
-    <link name="${prefix}tool0" />
 
+    <!-- joints: main serial chain -->
     <joint name="${prefix}joint_1" type="revolute">
       <origin xyz="0 0 0.330" rpy="0 0 0" />
       <parent link="${prefix}base_link" />
@@ -152,18 +153,29 @@
       <axis xyz="-1 0 0"/>
       <limit effort="0" lower="-6.2832" upper="6.2832" velocity="12.5664" />
     </joint>
-    <joint name="${prefix}joint_6-tool0" type="fixed">
-      <origin xyz="0 0 0" rpy="${pi} ${-pi/2.0} 0" />
-      <parent link="${prefix}link_6" />
-      <child link="${prefix}tool0" />
-    </joint>
 
-    <!-- ROS base_link to Fanuc World Coordinates transform -->
+    <!-- ROS-Industrial 'base' frame: base_link to Fanuc World Coordinates transform -->
     <link name="${prefix}base" />
     <joint name="${prefix}base_link-base" type="fixed">
       <origin xyz="0 0 0.330" rpy="0 0 0"/>
       <parent link="${prefix}base_link"/>
       <child link="${prefix}base"/>
+    </joint>
+
+    <!-- ROS-Industrial 'flange' frame: attachment point for EEF models -->
+    <link name="${prefix}flange" />
+    <joint name="${prefix}joint_6-flange" type="fixed">
+      <origin xyz="0 0 0" rpy="0 0 0" />
+      <parent link="${prefix}link_6" />
+      <child link="${prefix}flange" />
+    </joint>
+
+    <!-- ROS-Industrial 'tool0' frame: all-zeros tool frame -->
+    <link name="${prefix}tool0" />
+    <joint name="${prefix}link_6-tool0" type="fixed">
+      <origin xyz="0 0 0" rpy="${pi} ${-pi/2.0} 0" />
+      <parent link="${prefix}link_6" />
+      <child link="${prefix}tool0" />
     </joint>
   </xacro:macro>
 </robot>

--- a/fanuc_m10ia_support/urdf/m10ia7l_macro.xacro
+++ b/fanuc_m10ia_support/urdf/m10ia7l_macro.xacro
@@ -3,7 +3,7 @@
   <xacro:include filename="$(find fanuc_resources)/urdf/common_materials.xacro"/>
 
   <xacro:macro name="fanuc_m10ia7l" params="prefix">
-    <!-- links -->
+    <!-- links: main serial chain -->
     <link name="${prefix}base_link">
       <visual>
         <origin xyz="0 0 0" rpy="0 0 0"/>
@@ -109,9 +109,8 @@
         </geometry>
       </collision>
     </link>
-    <link name="${prefix}tool0"/>
 
-    <!-- joints -->
+    <!-- joints: main serial chain -->
     <joint name="${prefix}joint_1" type="revolute">
       <origin xyz="0 0 0.450" rpy="0 0 0"/>
       <parent link="${prefix}base_link"/>
@@ -154,18 +153,29 @@
       <axis xyz="-1 0 0"/>
       <limit lower="-6.28" upper="6.28" effort="0" velocity="11.00"/>
     </joint>
-    <joint name="${prefix}joint_6-tool0" type="fixed">
-      <origin xyz="0 0 0" rpy="${pi} ${-pi/2.0} 0" />
-      <parent link="${prefix}link_6"/>
-      <child link="${prefix}tool0"/>
-    </joint>
 
-    <!-- ROS base_link to Fanuc World Coordinates transform -->
+    <!-- ROS-Industrial 'base' frame: base_link to Fanuc World Coordinates transform -->
     <link name="${prefix}base" />
     <joint name="${prefix}base_link-base" type="fixed">
       <origin xyz="0 0 0.450" rpy="0 0 0"/>
       <parent link="${prefix}base_link"/>
       <child link="${prefix}base"/>
+    </joint>
+
+    <!-- ROS-Industrial 'flange' frame: attachment point for EEF models -->
+    <link name="${prefix}flange" />
+    <joint name="${prefix}joint_6-flange" type="fixed">
+      <origin xyz="0 0 0" rpy="0 0 0" />
+      <parent link="${prefix}link_6" />
+      <child link="${prefix}flange" />
+    </joint>
+
+    <!-- ROS-Industrial 'tool0' frame: all-zeros tool frame -->
+    <link name="${prefix}tool0" />
+    <joint name="${prefix}link_6-tool0" type="fixed">
+      <origin xyz="0 0 0" rpy="${pi} ${-pi/2.0} 0" />
+      <parent link="${prefix}link_6" />
+      <child link="${prefix}tool0" />
     </joint>
   </xacro:macro>
 </robot>

--- a/fanuc_m10ia_support/urdf/m10ia_macro.xacro
+++ b/fanuc_m10ia_support/urdf/m10ia_macro.xacro
@@ -3,7 +3,7 @@
   <xacro:include filename="$(find fanuc_resources)/urdf/common_materials.xacro"/>
 
   <xacro:macro name="fanuc_m10ia" params="prefix">
-    <!-- links -->
+    <!-- links: main serial chain -->
     <link name="${prefix}base_link">
       <visual>
         <origin xyz="0 0 0" rpy="0 0 0"/>
@@ -109,9 +109,8 @@
         </geometry>
       </collision>
     </link>
-    <link name="${prefix}tool0"/>
 
-    <!-- joints -->
+    <!-- joints: main serial chain -->
     <joint name="${prefix}joint_1" type="revolute">
       <origin xyz="0 0 0.450" rpy="0 0 0"/>
       <parent link="${prefix}base_link"/>
@@ -154,18 +153,29 @@
       <axis xyz="-1 0 0"/>
       <limit lower="-6.28" upper="6.28" effort="0" velocity="10.47"/>
     </joint>
-    <joint name="${prefix}joint_6-tool0" type="fixed">
-      <origin xyz="0 0 0" rpy="${pi} ${-pi/2.0} 0" />
-      <parent link="${prefix}link_6"/>
-      <child link="${prefix}tool0"/>
-    </joint>
 
-    <!-- ROS base_link to Fanuc World Coordinates transform -->
+    <!-- ROS-Industrial 'base' frame: base_link to Fanuc World Coordinates transform -->
     <link name="${prefix}base" />
     <joint name="${prefix}base_link-base" type="fixed">
       <origin xyz="0 0 0.450" rpy="0 0 0"/>
       <parent link="${prefix}base_link"/>
       <child link="${prefix}base"/>
+    </joint>
+
+    <!-- ROS-Industrial 'flange' frame: attachment point for EEF models -->
+    <link name="${prefix}flange" />
+    <joint name="${prefix}joint_6-flange" type="fixed">
+      <origin xyz="0 0 0" rpy="0 0 0" />
+      <parent link="${prefix}link_6" />
+      <child link="${prefix}flange" />
+    </joint>
+
+    <!-- ROS-Industrial 'tool0' frame: all-zeros tool frame -->
+    <link name="${prefix}tool0" />
+    <joint name="${prefix}link_6-tool0" type="fixed">
+      <origin xyz="0 0 0" rpy="${pi} ${-pi/2.0} 0" />
+      <parent link="${prefix}link_6" />
+      <child link="${prefix}tool0" />
     </joint>
   </xacro:macro>
 </robot>

--- a/fanuc_m16ib_support/urdf/m16ib20_macro.xacro
+++ b/fanuc_m16ib_support/urdf/m16ib20_macro.xacro
@@ -3,7 +3,7 @@
   <xacro:include filename="$(find fanuc_resources)/urdf/common_materials.xacro"/>
 
   <xacro:macro name="fanuc_m16ib20" params="prefix">
-    <!-- links -->
+    <!-- links: main serial chain -->
     <link name="${prefix}base_link">
       <visual>
         <origin xyz="0 0 0" rpy="0 0 0"/>
@@ -109,9 +109,8 @@
         </geometry>
       </collision>
     </link>
-    <link name="${prefix}tool0"/>
 
-    <!-- joints -->
+    <!-- joints: main serial chain -->
     <joint name="${prefix}joint_1" type="revolute">
       <origin xyz="0 0 0.525" rpy="0 0 0"/>
       <parent link="${prefix}base_link"/>
@@ -154,18 +153,29 @@
       <axis xyz="-1 0 0"/>
       <limit effort="0" lower="-7.8540" upper="7.8540" velocity="9.0757" />
     </joint>
-    <joint name="${prefix}joint_6-tool0" type="fixed">
-      <origin xyz="0 0 0" rpy="${pi} ${-pi/2.0} 0" />
-      <parent link="${prefix}link_6"/>
-      <child link="${prefix}tool0"/>
-    </joint>
 
-    <!-- ROS base_link to Fanuc World Coordinates transform -->
+    <!-- ROS-Industrial 'base' frame: base_link to Fanuc World Coordinates transform -->
     <link name="${prefix}base" />
     <joint name="${prefix}base_link-base" type="fixed">
       <origin xyz="0 0 0.525" rpy="0 0 0"/>
       <parent link="${prefix}base_link"/>
       <child link="${prefix}base"/>
+    </joint>
+
+    <!-- ROS-Industrial 'flange' frame: attachment point for EEF models -->
+    <link name="${prefix}flange" />
+    <joint name="${prefix}joint_6-flange" type="fixed">
+      <origin xyz="0 0 0" rpy="0 0 0" />
+      <parent link="${prefix}link_6" />
+      <child link="${prefix}flange" />
+    </joint>
+
+    <!-- ROS-Industrial 'tool0' frame: all-zeros tool frame -->
+    <link name="${prefix}tool0" />
+    <joint name="${prefix}link_6-tool0" type="fixed">
+      <origin xyz="0 0 0" rpy="${pi} ${-pi/2.0} 0" />
+      <parent link="${prefix}link_6" />
+      <child link="${prefix}tool0" />
     </joint>
   </xacro:macro>
 </robot>

--- a/fanuc_m20ia_support/urdf/m20ia10l_macro.xacro
+++ b/fanuc_m20ia_support/urdf/m20ia10l_macro.xacro
@@ -3,7 +3,7 @@
   <xacro:include filename="$(find fanuc_resources)/urdf/common_materials.xacro"/>
 
   <xacro:macro name="fanuc_m20ia10l" params="prefix">
-    <!-- links -->
+    <!-- links: main serial chain -->
     <link name="${prefix}base_link">
       <visual>
         <origin xyz="0 0 0" rpy="0 0 0"/>
@@ -109,9 +109,8 @@
         </geometry>
       </collision>
     </link>
-    <link name="${prefix}tool0"/>
 
-    <!-- joints -->
+    <!-- joints: main serial chain -->
     <joint name="${prefix}joint_1" type="revolute">
       <origin xyz="0 0 0.525" rpy="0 0 0"/>
       <parent link="${prefix}base_link"/>
@@ -154,18 +153,29 @@
       <axis xyz="-1 0 0"/>
       <limit lower="-4.712389" upper="4.712389" effort="0" velocity="10.471980" />
     </joint>
-    <joint name="${prefix}joint_6-tool0" type="fixed">
-      <origin xyz="0 0 0" rpy="${pi} ${-pi/2.0} 0" />
-      <parent link="${prefix}link_6"/>
-      <child link="${prefix}tool0"/>
-    </joint>
 
-    <!-- ROS base_link to Fanuc World Coordinates transform -->
+    <!-- ROS-Industrial 'base' frame: base_link to Fanuc World Coordinates transform -->
     <link name="${prefix}base" />
     <joint name="${prefix}base_link-base" type="fixed">
       <origin xyz="0 0 0.525" rpy="0 0 0"/>
       <parent link="${prefix}base_link"/>
       <child link="${prefix}base"/>
+    </joint>
+
+    <!-- ROS-Industrial 'flange' frame: attachment point for EEF models -->
+    <link name="${prefix}flange" />
+    <joint name="${prefix}joint_6-flange" type="fixed">
+      <origin xyz="0 0 0" rpy="0 0 0" />
+      <parent link="${prefix}link_6" />
+      <child link="${prefix}flange" />
+    </joint>
+
+    <!-- ROS-Industrial 'tool0' frame: all-zeros tool frame -->
+    <link name="${prefix}tool0" />
+    <joint name="${prefix}link_6-tool0" type="fixed">
+      <origin xyz="0 0 0" rpy="${pi} ${-pi/2.0} 0" />
+      <parent link="${prefix}link_6" />
+      <child link="${prefix}tool0" />
     </joint>
   </xacro:macro>
 </robot>

--- a/fanuc_m20ia_support/urdf/m20ia_macro.xacro
+++ b/fanuc_m20ia_support/urdf/m20ia_macro.xacro
@@ -3,7 +3,7 @@
   <xacro:include filename="$(find fanuc_resources)/urdf/common_materials.xacro"/>
 
   <xacro:macro name="fanuc_m20ia" params="prefix">
-    <!-- links -->
+    <!-- links: main serial chain -->
     <link name="${prefix}base_link">
       <visual>
         <origin xyz="0 0 0" rpy="0 0 0"/>
@@ -109,9 +109,8 @@
         </geometry>
       </collision>
     </link>
-    <link name="${prefix}tool0"/>
 
-    <!-- joints -->
+    <!-- joints: main serial chain -->
     <joint name="${prefix}joint_1" type="revolute">
       <origin xyz="0 0 0.525" rpy="0 0 0"/>
       <parent link="${prefix}base_link"/>
@@ -154,18 +153,29 @@
       <axis xyz="-1 0 0"/>
       <limit lower="-4.712389" upper="4.712389" effort="0" velocity="9.599311" />
     </joint>
-    <joint name="${prefix}joint_6-tool0" type="fixed">
-      <origin xyz="0 0 0" rpy="${pi} ${-pi/2.0} 0" />
-      <parent link="${prefix}link_6"/>
-      <child link="${prefix}tool0"/>
-    </joint>
 
-    <!-- ROS base_link to Fanuc World Coordinates transform -->
+    <!-- ROS-Industrial 'base' frame: base_link to Fanuc World Coordinates transform -->
     <link name="${prefix}base" />
     <joint name="${prefix}base_link-base" type="fixed">
       <origin xyz="0 0 0.525" rpy="0 0 0"/>
       <parent link="${prefix}base_link"/>
       <child link="${prefix}base"/>
+    </joint>
+
+    <!-- ROS-Industrial 'flange' frame: attachment point for EEF models -->
+    <link name="${prefix}flange" />
+    <joint name="${prefix}joint_6-flange" type="fixed">
+      <origin xyz="0 0 0" rpy="0 0 0" />
+      <parent link="${prefix}link_6" />
+      <child link="${prefix}flange" />
+    </joint>
+
+    <!-- ROS-Industrial 'tool0' frame: all-zeros tool frame -->
+    <link name="${prefix}tool0" />
+    <joint name="${prefix}link_6-tool0" type="fixed">
+      <origin xyz="0 0 0" rpy="${pi} ${-pi/2.0} 0" />
+      <parent link="${prefix}link_6" />
+      <child link="${prefix}tool0" />
     </joint>
   </xacro:macro>
 </robot>

--- a/fanuc_m430ia_support/urdf/m430ia2f_macro.xacro
+++ b/fanuc_m430ia_support/urdf/m430ia2f_macro.xacro
@@ -3,7 +3,7 @@
   <xacro:include filename="$(find fanuc_resources)/urdf/common_materials.xacro"/>
 
   <xacro:macro name="fanuc_m430ia2f" params="prefix">
-    <!-- links -->
+    <!-- links: main serial chain -->
     <link name="${prefix}base_link">
       <visual>
         <origin xyz="0 0 0" rpy="0 0 0"/>
@@ -94,9 +94,8 @@
         </geometry>
       </collision>
     </link>
-    <link name="${prefix}tool0"/>
 
-    <!-- joints -->
+    <!-- joints: main serial chain -->
     <joint name="${prefix}joint_1" type="revolute">
       <origin xyz="0 0 0.440" rpy="0 0 0"/>
       <parent link="${prefix}base_link"/>
@@ -132,18 +131,29 @@
       <axis xyz="0 0 1"/>
       <limit lower="-4.71" upper="4.71" effort="0" velocity="20.94"/>
     </joint>
-    <joint name="${prefix}joint_5-tool0" type="fixed">
-      <origin xyz="0 0 0" rpy="0 0 0" />
-      <parent link="${prefix}link_5"/>
-      <child link="${prefix}tool0"/>
-    </joint>
 
-    <!-- ROS base_link to Fanuc World Coordinates transform -->
+    <!-- ROS-Industrial 'base' frame: base_link to Fanuc World Coordinates transform -->
     <link name="${prefix}base" />
     <joint name="${prefix}base_link-base" type="fixed">
       <origin xyz="0 0 0.440" rpy="0 0 0"/>
       <parent link="${prefix}base_link"/>
       <child link="${prefix}base"/>
+    </joint>
+
+    <!-- ROS-Industrial 'flange' frame: attachment point for EEF models -->
+    <link name="${prefix}flange" />
+    <joint name="${prefix}joint_5-flange" type="fixed">
+      <origin xyz="0 0 0" rpy="0 ${-pi/2.0} 0" />
+      <parent link="${prefix}link_5" />
+      <child link="${prefix}flange" />
+    </joint>
+
+    <!-- ROS-Industrial 'tool0' frame: all-zeros tool frame -->
+    <link name="${prefix}tool0" />
+    <joint name="${prefix}link_5-tool0" type="fixed">
+      <origin xyz="0 0 0" rpy="0 0 0" />
+      <parent link="${prefix}link_5" />
+      <child link="${prefix}tool0" />
     </joint>
   </xacro:macro>
 </robot>

--- a/fanuc_m430ia_support/urdf/m430ia2p_macro.xacro
+++ b/fanuc_m430ia_support/urdf/m430ia2p_macro.xacro
@@ -3,7 +3,7 @@
   <xacro:include filename="$(find fanuc_resources)/urdf/common_materials.xacro"/>
 
   <xacro:macro name="fanuc_m430ia2p" params="prefix">
-    <!-- links -->
+    <!-- links: main serial chain -->
     <link name="${prefix}base_link">
       <visual>
         <origin xyz="0 0 0" rpy="0 0 0"/>
@@ -109,9 +109,8 @@
         </geometry>
       </collision>
     </link>
-    <link name="${prefix}tool0" />
 
-    <!-- joints -->
+    <!-- joints: main serial chain -->
     <joint name="${prefix}joint_1" type="revolute">
       <origin xyz="0 0 0.410" rpy="0 0 0"/>
       <parent link="${prefix}base_link"/>
@@ -154,18 +153,29 @@
       <axis xyz="0 0 1"/>
       <limit lower="-4.71" upper="4.71" effort="0" velocity="12.57"/>
     </joint>
-    <joint name="${prefix}joint_6-tool0" type="fixed">
-      <origin xyz="0 0 0" rpy="0 0 0" />
-      <parent link="${prefix}link_6" />
-      <child link="${prefix}tool0" />
-    </joint>
 
-    <!-- ROS base_link to Fanuc World Coordinates transform -->
+    <!-- ROS-Industrial 'base' frame: base_link to Fanuc World Coordinates transform -->
     <link name="${prefix}base" />
     <joint name="${prefix}base_link-base" type="fixed">
       <origin xyz="0 0 0.410" rpy="0 0 0"/>
       <parent link="${prefix}base_link"/>
       <child link="${prefix}base"/>
+    </joint>
+
+    <!-- ROS-Industrial 'flange' frame: attachment point for EEF models -->
+    <link name="${prefix}flange" />
+    <joint name="${prefix}joint_6-flange" type="fixed">
+      <origin xyz="0 0 0" rpy="0 ${-pi/2.0} 0" />
+      <parent link="${prefix}link_6" />
+      <child link="${prefix}flange" />
+    </joint>
+
+    <!-- ROS-Industrial 'tool0' frame: all-zeros tool frame -->
+    <link name="${prefix}tool0" />
+    <joint name="${prefix}link_6-tool0" type="fixed">
+      <origin xyz="0 0 0" rpy="0 0 0" />
+      <parent link="${prefix}link_6" />
+      <child link="${prefix}tool0" />
     </joint>
   </xacro:macro>
 </robot>


### PR DESCRIPTION
As per subject. Commit comment from 71b7ae9:

> Similar to 'tool0', but without the orientation change (to make Z+ parallel to X+).
> 
> The 'flange' frame is intended as attachment point for EEFs, while 'tool0' is meant to be a immutable frame that always encodes an "all-zeros tool centre point" configuration.
> 
> Both 'tool0' and 'flange' should not be changed.

There should be no functional changes.

Composite URDFs that attach EEFs to `tool0` should be unaffected: `flange` is inserted between `link_6` (or `link_5`) and `tool0` which maintains its original orientation. In addition, since `flange` is connected to both by a `fixed` joint, no kinematics changes are required.

---

Edit: updated the commit msg:

> The 'flange' frame is intended to function as an 'attachment point' for EEF xacros. In order to easily swap robot models, it is beneficial for such attachment points -- typically the last link in a robot xacro -- to have a consistent orientation.
> 
> 'flange' is defined as always having x+ pointing out of the (physical) flange link. For robots that happen to have the link-local coordinate frame of their last link in their zero pose already aligned with REP-103 conventions (x+ forward, y+ left, z+ up), 'flange' will be an identity transform. In other cases, 'flange' includes appropriate rotations to orient x+ such that it again follows the above described convention.
> 
> Note that the above does not mean that 'flange' will *always* be world aligned, only that x+ will always point away from the (physical) flange / last link of the robot model. Rotations and translations will impact 'flange's pose just as they do other robot links.
> 
> It's sibling frame, 'tool0', is similar, but this frame is *always* located and oriented such that it corresponds to whatever is configured on the robot controller as an 'all zeros' tool frame.
> 
> Both 'tool0' and 'flange' are to be considered immutable frames, and are not intended to be changed or updated by consumers of xacro macros including them.
