### PR TITLE
moveit_plugins: enable C++11 when and where needed

### DIFF
--- a/fanuc_lrmate200ic_moveit_plugins/CMakeLists.txt
+++ b/fanuc_lrmate200ic_moveit_plugins/CMakeLists.txt
@@ -8,6 +8,11 @@ find_package(catkin REQUIRED COMPONENTS
   tf_conversions
 )
 
+# enable C++11 if needed for MoveIt on Kinetic
+if (moveit_core_VERSION VERSION_GREATER "0.9.0")
+  add_definitions(-std=c++11)
+endif()
+
 include_directories(${catkin_INCLUDE_DIRS})
 
 find_package(LAPACK REQUIRED)

--- a/fanuc_m10ia_moveit_plugins/CMakeLists.txt
+++ b/fanuc_m10ia_moveit_plugins/CMakeLists.txt
@@ -8,6 +8,11 @@ find_package(catkin REQUIRED COMPONENTS
   tf_conversions
 )
 
+# enable C++11 if needed for MoveIt on Kinetic
+if (moveit_core_VERSION VERSION_GREATER "0.9.0")
+  add_definitions(-std=c++11)
+endif()
+
 include_directories(${catkin_INCLUDE_DIRS})
 
 find_package(LAPACK REQUIRED)

--- a/fanuc_m16ib_moveit_plugins/CMakeLists.txt
+++ b/fanuc_m16ib_moveit_plugins/CMakeLists.txt
@@ -8,6 +8,11 @@ find_package(catkin REQUIRED COMPONENTS
   tf_conversions
 )
 
+# enable C++11 if needed for MoveIt on Kinetic
+if (moveit_core_VERSION VERSION_GREATER "0.9.0")
+  add_definitions(-std=c++11)
+endif()
+
 include_directories(${catkin_INCLUDE_DIRS})
 
 find_package(LAPACK REQUIRED)

--- a/fanuc_m20ia_moveit_plugins/CMakeLists.txt
+++ b/fanuc_m20ia_moveit_plugins/CMakeLists.txt
@@ -8,6 +8,11 @@ find_package(catkin REQUIRED COMPONENTS
   tf_conversions
 )
 
+# enable C++11 if needed for MoveIt on Kinetic
+if (moveit_core_VERSION VERSION_GREATER "0.9.0")
+  add_definitions(-std=c++11)
+endif()
+
 include_directories(${catkin_INCLUDE_DIRS})
 
 find_package(LAPACK REQUIRED)

--- a/fanuc_m430ia_moveit_plugins/CMakeLists.txt
+++ b/fanuc_m430ia_moveit_plugins/CMakeLists.txt
@@ -8,6 +8,11 @@ find_package(catkin REQUIRED COMPONENTS
   tf_conversions
 )
 
+# enable C++11 if needed for MoveIt on Kinetic
+if (moveit_core_VERSION VERSION_GREATER "0.9.0")
+  add_definitions(-std=c++11)
+endif()
+
 include_directories(${catkin_INCLUDE_DIRS})
 
 find_package(LAPACK REQUIRED)


### PR DESCRIPTION
As per subject.

This allows building the plugins on Kinetic.

`0.9.0` is the major version nr of MoveIt on Kinetic.
