### PR TITLE
Fix for issue 217: enable Jade+ xacro in MSA when loading xacros

### DIFF
--- a/fanuc_lrmate200ic5h_moveit_config/.setup_assistant
+++ b/fanuc_lrmate200ic5h_moveit_config/.setup_assistant
@@ -2,6 +2,7 @@ moveit_setup_assistant_config:
   URDF:
     package: fanuc_lrmate200ic_support
     relative_path: urdf/lrmate200ic5h.xacro
+    use_jade_xacro: true
   SRDF:
     relative_path: config/fanuc_lrmate200ic5h.srdf
   CONFIG:

--- a/fanuc_lrmate200ic5l_moveit_config/.setup_assistant
+++ b/fanuc_lrmate200ic5l_moveit_config/.setup_assistant
@@ -2,6 +2,7 @@ moveit_setup_assistant_config:
   URDF:
     package: fanuc_lrmate200ic_support
     relative_path: urdf/lrmate200ic5l.xacro
+    use_jade_xacro: true
   SRDF:
     relative_path: config/fanuc_lrmate200ic5l.srdf
   CONFIG:

--- a/fanuc_lrmate200ic_moveit_config/.setup_assistant
+++ b/fanuc_lrmate200ic_moveit_config/.setup_assistant
@@ -2,6 +2,7 @@ moveit_setup_assistant_config:
   URDF:
     package: fanuc_lrmate200ic_support
     relative_path: urdf/lrmate200ic.xacro
+    use_jade_xacro: true
   SRDF:
     relative_path: config/fanuc_lrmate200ic.srdf
   CONFIG:

--- a/fanuc_m10ia_moveit_config/.setup_assistant
+++ b/fanuc_m10ia_moveit_config/.setup_assistant
@@ -2,6 +2,7 @@ moveit_setup_assistant_config:
   URDF:
     package: fanuc_m10ia_support
     relative_path: urdf/m10ia.xacro
+    use_jade_xacro: true
   SRDF:
     relative_path: config/fanuc_m10ia.srdf
   CONFIG:

--- a/fanuc_m16ib20_moveit_config/.setup_assistant
+++ b/fanuc_m16ib20_moveit_config/.setup_assistant
@@ -2,6 +2,7 @@ moveit_setup_assistant_config:
   URDF:
     package: fanuc_m16ib_support
     relative_path: urdf/m16ib20.xacro
+    use_jade_xacro: true
   SRDF:
     relative_path: config/fanuc_m16ib20.srdf
   CONFIG:

--- a/fanuc_m20ia10l_moveit_config/.setup_assistant
+++ b/fanuc_m20ia10l_moveit_config/.setup_assistant
@@ -2,6 +2,7 @@ moveit_setup_assistant_config:
   URDF:
     package: fanuc_m20ia_support
     relative_path: urdf/m20ia10l.xacro
+    use_jade_xacro: true
   SRDF:
     relative_path: config/fanuc_m20ia10l.srdf
   CONFIG:

--- a/fanuc_m20ia_moveit_config/.setup_assistant
+++ b/fanuc_m20ia_moveit_config/.setup_assistant
@@ -2,6 +2,7 @@ moveit_setup_assistant_config:
   URDF:
     package: fanuc_m20ia_support
     relative_path: urdf/m20ia.xacro
+    use_jade_xacro: true
   SRDF:
     relative_path: config/fanuc_m20ia.srdf
   CONFIG:

--- a/fanuc_m430ia2f_moveit_config/.setup_assistant
+++ b/fanuc_m430ia2f_moveit_config/.setup_assistant
@@ -2,6 +2,7 @@ moveit_setup_assistant_config:
   URDF:
     package: fanuc_m430ia_support
     relative_path: urdf/m430ia2f.xacro
+    use_jade_xacro: true
   SRDF:
     relative_path: config/fanuc_m430ia2f.srdf
   CONFIG:

--- a/fanuc_m430ia2p_moveit_config/.setup_assistant
+++ b/fanuc_m430ia2p_moveit_config/.setup_assistant
@@ -2,6 +2,7 @@ moveit_setup_assistant_config:
   URDF:
     package: fanuc_m430ia_support
     relative_path: urdf/m430ia2p.xacro
+    use_jade_xacro: true
   SRDF:
     relative_path: config/fanuc_m430ia2p.srdf
   CONFIG:


### PR DESCRIPTION
Depends on ros-planning/moveit#540.

This will make loading of the xacros in this repository (that were updated in #201, #209 and #210) in MoveIt's Setup Assistant work again.

This key would normally be added by the MSA when config pkgs are generated, but since these packages have been manually updated, it needs to be added manually as well.
