### PR TITLE
moveit_plugins: use quoted string for operands of VERSION_GREATER

### DIFF
--- a/fanuc_lrmate200ic_moveit_plugins/CMakeLists.txt
+++ b/fanuc_lrmate200ic_moveit_plugins/CMakeLists.txt
@@ -9,7 +9,7 @@ find_package(catkin REQUIRED COMPONENTS
 )
 
 # enable C++11 if needed for MoveIt on Kinetic
-if (moveit_core_VERSION VERSION_GREATER "0.9.0")
+if ("${moveit_core_VERSION}" VERSION_GREATER "0.9.0")
   add_definitions(-std=c++11)
 endif()
 

--- a/fanuc_m10ia_moveit_plugins/CMakeLists.txt
+++ b/fanuc_m10ia_moveit_plugins/CMakeLists.txt
@@ -9,7 +9,7 @@ find_package(catkin REQUIRED COMPONENTS
 )
 
 # enable C++11 if needed for MoveIt on Kinetic
-if (moveit_core_VERSION VERSION_GREATER "0.9.0")
+if ("${moveit_core_VERSION}" VERSION_GREATER "0.9.0")
   add_definitions(-std=c++11)
 endif()
 

--- a/fanuc_m16ib_moveit_plugins/CMakeLists.txt
+++ b/fanuc_m16ib_moveit_plugins/CMakeLists.txt
@@ -9,7 +9,7 @@ find_package(catkin REQUIRED COMPONENTS
 )
 
 # enable C++11 if needed for MoveIt on Kinetic
-if (moveit_core_VERSION VERSION_GREATER "0.9.0")
+if ("${moveit_core_VERSION}" VERSION_GREATER "0.9.0")
   add_definitions(-std=c++11)
 endif()
 

--- a/fanuc_m20ia_moveit_plugins/CMakeLists.txt
+++ b/fanuc_m20ia_moveit_plugins/CMakeLists.txt
@@ -9,7 +9,7 @@ find_package(catkin REQUIRED COMPONENTS
 )
 
 # enable C++11 if needed for MoveIt on Kinetic
-if (moveit_core_VERSION VERSION_GREATER "0.9.0")
+if ("${moveit_core_VERSION}" VERSION_GREATER "0.9.0")
   add_definitions(-std=c++11)
 endif()
 

--- a/fanuc_m430ia_moveit_plugins/CMakeLists.txt
+++ b/fanuc_m430ia_moveit_plugins/CMakeLists.txt
@@ -9,7 +9,7 @@ find_package(catkin REQUIRED COMPONENTS
 )
 
 # enable C++11 if needed for MoveIt on Kinetic
-if (moveit_core_VERSION VERSION_GREATER "0.9.0")
+if ("${moveit_core_VERSION}" VERSION_GREATER "0.9.0")
   add_definitions(-std=c++11)
 endif()
 


### PR DESCRIPTION
As per subject.

`catkin_lint` complained:
```
fanuc_*_moveit_plugins: CMakeLists.txt(12): notice: operands for operator VERSION_GREATER should be quoted strings
```

No functional changes, compile-tested under Kinetic.
