### PR TITLE
readme: add build instructions.

### DIFF
--- a/readme.md
+++ b/readme.md
@@ -2,21 +2,77 @@
 
 [![Build Status](http://build.ros.org/job/Idev__fanuc__ubuntu_trusty_amd64/badge/icon)](http://build.ros.org/job/Idev__fanuc__ubuntu_trusty_amd64)
 
-[ROS-Industrial][] Fanuc meta-package. See the [ROS wiki][] page for more
-information.
+[ROS-Industrial][] Fanuc meta-package. See the [ROS wiki][] page for more information.
 
 The [fanuc_experimental][] repository contains additional packages.
 
 
 ## Contents
 
-Branch naming follows the ROS distribution they are compatible with. `-devel`
-branches may be unstable. Releases are made from the distribution branches
-(`hydro`, `indigo`).
+Branch naming follows the ROS distribution they are compatible with. `-devel` branches may be unstable. Releases are made from the distribution branches (`hydro`, `indigo`).
 
-Older releases may be found in the old ROS-Industrial [subversion repository][].
+Older releases may be found in the Github mirror of the old ROS-Industrial [subversion repository][].
+
+
+## Building
+
+### On newer (or older) versions of ROS
+
+Building the packages on newer (or older) versions of ROS is in most cases possible and supported. For example: building the packages in this repository on a Ubuntu Xenial/ROS Kinetic system is supported. This will require creating a Catkin workspace, cloning this repository, installing all required dependencies and finally building the workspace.
+
+### Catkin tools
+
+It is recommended to use [catkin_tools][] instead of the default [catkin][] when building ROS workspaces. `catkin_tools` provides a number of benefits over regular `catkin_make` and will be used in the instructions below. All packages can be built using `catkin_make` however: use `catkin_make` in place of `catkin build` where appropriate.
+
+### Building the packages
+
+The following instructions assume that a [Catkin workspace][] has been created at `$HOME/catkin_ws` and that the *source space* is at `$HOME/catkin_ws/src`. Update paths appropriately if they are different on the build machine.
+
+These instructions build the `indigo-devel` branch on a ROS Kinetic system:
+
+```bash
+# change to the root of the Catkin workspace
+$ cd $HOME/catkin_ws
+
+# retrieve the latest development version of fanuc. If you'd rather
+# use the latest released version, replace 'indigo-devel' with 'indigo'
+$ git clone -b indigo-devel https://github.com/ros-industrial/fanuc.git src/fanuc
+
+# check build dependencies. Note: this may install additional packages,
+# depending on the software installed on the machine
+$ rosdep update
+$ rosdep install --from-paths src/ --ignore-src --rosdistro kinetic
+
+# build the workspace (using catkin_tools)
+$ catkin build
+```
+
+### Activating the workspace
+
+Finally, activate the workspace to get access to the packages just built:
+
+```bash
+$ source $HOME/catkin_ws/devel/setup.bash
+```
+
+At this point all packages should be usable (ie: `roslaunch` should be able to auto-complete package names starting with `fanuc_..`). In case the workspace contains additional packages (ie: not from this repository), those should also still be available.
+
+
+## Installation and usage
+
+Refer to [Working With ROS-Industrial Robot Support Packages][] for information on how to use the files provided by the robot support and MoveIt configuration packages. See also the other pages on the [ROS wiki][].
+
+Refer to the [tutorials][] for information on installation and configuration of the controller-specific software components.
+
+
+
 
 [ROS-Industrial]: http://wiki.ros.org/Industrial
 [ROS wiki]: http://wiki.ros.org/fanuc
 [fanuc_experimental]: https://github.com/ros-industrial/fanuc_experimental
-[subversion repository]: https://swri-ros-pkg.googlecode.com/svn/tags/fanuc/fanuc-0.1.1
+[subversion repository]: https://github.com/ros-industrial/swri-ros-pkg
+[Catkin workspace]: http://wiki.ros.org/catkin/Tutorials/create_a_workspace
+[catkin]: http://wiki.ros.org/catkin
+[catkin_tools]: https://catkin-tools.readthedocs.io/en/latest
+[Working With ROS-Industrial Robot Support Packages]: http://wiki.ros.org/Industrial/Tutorials/WorkingWithRosIndustrialRobotSupportPackages
+[tutorials]: http://wiki.ros.org/fanuc/Tutorials


### PR DESCRIPTION
As per subject.

This commit updates the main repository readme with instructions on how to build the packages in a Catkin workspace and additionally clarifies how they can be used with ROS distributions they have not (yet) been released for.

No functional changes.
