### PR TITLE
Add explicit 'support level' badge and pkg manifest element

### DIFF
--- a/fanuc/package.xml
+++ b/fanuc/package.xml
@@ -50,5 +50,8 @@
         <tag>ros-industrial</tag>
       </tags>
     </rosindex>
+    <ros_industrial>
+      <support_level value="community" />
+    </ros_industrial>
   </export>
 </package>

--- a/fanuc_driver/package.xml
+++ b/fanuc_driver/package.xml
@@ -40,5 +40,8 @@
         <tag>R-30iB</tag>
       </tags>
     </rosindex>
+    <ros_industrial>
+      <support_level value="community" />
+    </ros_industrial>
   </export>
 </package>

--- a/fanuc_lrmate200ic5h_moveit_config/package.xml
+++ b/fanuc_lrmate200ic5h_moveit_config/package.xml
@@ -58,5 +58,8 @@
         <tag>lrmate200ic</tag>
       </tags>
     </rosindex>
+    <ros_industrial>
+      <support_level value="community" />
+    </ros_industrial>
   </export>
 </package>

--- a/fanuc_lrmate200ic5l_moveit_config/package.xml
+++ b/fanuc_lrmate200ic5l_moveit_config/package.xml
@@ -58,5 +58,8 @@
         <tag>lrmate200ic</tag>
       </tags>
     </rosindex>
+    <ros_industrial>
+      <support_level value="community" />
+    </ros_industrial>
   </export>
 </package>

--- a/fanuc_lrmate200ic_moveit_config/package.xml
+++ b/fanuc_lrmate200ic_moveit_config/package.xml
@@ -58,5 +58,8 @@
         <tag>lrmate200ic</tag>
       </tags>
     </rosindex>
+    <ros_industrial>
+      <support_level value="community" />
+    </ros_industrial>
   </export>
 </package>

--- a/fanuc_lrmate200ic_moveit_plugins/package.xml
+++ b/fanuc_lrmate200ic_moveit_plugins/package.xml
@@ -53,5 +53,8 @@
         <tag>lrmate200ic</tag>
       </tags>
     </rosindex>
+    <ros_industrial>
+      <support_level value="community" />
+    </ros_industrial>
   </export>
 </package>

--- a/fanuc_lrmate200ic_support/package.xml
+++ b/fanuc_lrmate200ic_support/package.xml
@@ -64,5 +64,8 @@
         <tag>lrmate200ic</tag>
       </tags>
     </rosindex>
+    <ros_industrial>
+      <support_level value="community" />
+    </ros_industrial>
   </export>
 </package>

--- a/fanuc_m10ia_moveit_config/package.xml
+++ b/fanuc_m10ia_moveit_config/package.xml
@@ -58,5 +58,8 @@
         <tag>m10ia</tag>
       </tags>
     </rosindex>
+    <ros_industrial>
+      <support_level value="community" />
+    </ros_industrial>
   </export>
 </package>

--- a/fanuc_m10ia_moveit_plugins/package.xml
+++ b/fanuc_m10ia_moveit_plugins/package.xml
@@ -48,5 +48,8 @@
         <tag>m10ia</tag>
       </tags>
     </rosindex>
+    <ros_industrial>
+      <support_level value="community" />
+    </ros_industrial>
   </export>
 </package>

--- a/fanuc_m10ia_support/package.xml
+++ b/fanuc_m10ia_support/package.xml
@@ -61,5 +61,8 @@
         <tag>m10ia</tag>
       </tags>
     </rosindex>
+    <ros_industrial>
+      <support_level value="community" />
+    </ros_industrial>
   </export>
 </package>

--- a/fanuc_m16ib20_moveit_config/package.xml
+++ b/fanuc_m16ib20_moveit_config/package.xml
@@ -58,5 +58,8 @@
         <tag>m16ib</tag>
       </tags>
     </rosindex>
+    <ros_industrial>
+      <support_level value="community" />
+    </ros_industrial>
   </export>
 </package>

--- a/fanuc_m16ib_moveit_plugins/package.xml
+++ b/fanuc_m16ib_moveit_plugins/package.xml
@@ -48,5 +48,8 @@
         <tag>m16ib</tag>
       </tags>
     </rosindex>
+    <ros_industrial>
+      <support_level value="community" />
+    </ros_industrial>
   </export>
 </package>

--- a/fanuc_m16ib_support/package.xml
+++ b/fanuc_m16ib_support/package.xml
@@ -61,5 +61,8 @@
         <tag>m16ib</tag>
       </tags>
     </rosindex>
+    <ros_industrial>
+      <support_level value="community" />
+    </ros_industrial>
   </export>
 </package>

--- a/fanuc_m20ia10l_moveit_config/package.xml
+++ b/fanuc_m20ia10l_moveit_config/package.xml
@@ -58,5 +58,8 @@
         <tag>m20ia</tag>
       </tags>
     </rosindex>
+    <ros_industrial>
+      <support_level value="community" />
+    </ros_industrial>
   </export>
 </package>

--- a/fanuc_m20ia_moveit_config/package.xml
+++ b/fanuc_m20ia_moveit_config/package.xml
@@ -58,5 +58,8 @@
         <tag>m20ia</tag>
       </tags>
     </rosindex>
+    <ros_industrial>
+      <support_level value="community" />
+    </ros_industrial>
   </export>
 </package>

--- a/fanuc_m20ia_moveit_plugins/package.xml
+++ b/fanuc_m20ia_moveit_plugins/package.xml
@@ -53,5 +53,8 @@
         <tag>m20ia</tag>
       </tags>
     </rosindex>
+    <ros_industrial>
+      <support_level value="community" />
+    </ros_industrial>
   </export>
 </package>

--- a/fanuc_m20ia_support/package.xml
+++ b/fanuc_m20ia_support/package.xml
@@ -66,5 +66,8 @@
         <tag>m20ia</tag>
       </tags>
     </rosindex>
+    <ros_industrial>
+      <support_level value="community" />
+    </ros_industrial>
   </export>
 </package>

--- a/fanuc_m430ia2f_moveit_config/package.xml
+++ b/fanuc_m430ia2f_moveit_config/package.xml
@@ -58,5 +58,8 @@
         <tag>m430ia</tag>
       </tags>
     </rosindex>
+    <ros_industrial>
+      <support_level value="community" />
+    </ros_industrial>
   </export>
 </package>

--- a/fanuc_m430ia2p_moveit_config/package.xml
+++ b/fanuc_m430ia2p_moveit_config/package.xml
@@ -58,5 +58,8 @@
         <tag>m430ia</tag>
       </tags>
     </rosindex>
+    <ros_industrial>
+      <support_level value="community" />
+    </ros_industrial>
   </export>
 </package>

--- a/fanuc_m430ia_moveit_plugins/package.xml
+++ b/fanuc_m430ia_moveit_plugins/package.xml
@@ -49,5 +49,8 @@
         <tag>m430ia</tag>
       </tags>
     </rosindex>
+    <ros_industrial>
+      <support_level value="community" />
+    </ros_industrial>
   </export>
 </package>

--- a/fanuc_m430ia_support/package.xml
+++ b/fanuc_m430ia_support/package.xml
@@ -60,5 +60,8 @@
         <tag>m430ia</tag>
       </tags>
     </rosindex>
+    <ros_industrial>
+      <support_level value="community" />
+    </ros_industrial>
   </export>
 </package>

--- a/fanuc_resources/package.xml
+++ b/fanuc_resources/package.xml
@@ -42,5 +42,8 @@
         <tag>ros-industrial</tag>
       </tags>
     </rosindex>
+    <ros_industrial>
+      <support_level value="community" />
+    </ros_industrial>
   </export>
 </package>


### PR DESCRIPTION
As per subject.

To avoid potential conflicts with future other additions to the `export` element I added a `ros_industrial` 'namespace' with the `support_level` element as it's child. This is not documented anywhere, nor used at the moment.

The change to the repository-level readme adds the actual badge.

No functional changes.
