### PR TITLE
Removed rviz dependency on 'support' packages

### DIFF
--- a/fanuc_lrmate200ib_support/package.xml
+++ b/fanuc_lrmate200ib_support/package.xml
@@ -45,7 +45,6 @@
   <exec_depend>fanuc_resources</exec_depend>
   <exec_depend>joint_state_publisher</exec_depend>
   <exec_depend>robot_state_publisher</exec_depend>
-  <exec_depend>rviz</exec_depend>
   <exec_depend>xacro</exec_depend>
 
   <export>

--- a/fanuc_lrmate200ic_support/package.xml
+++ b/fanuc_lrmate200ic_support/package.xml
@@ -49,7 +49,6 @@
   <exec_depend>fanuc_resources</exec_depend>
   <exec_depend>joint_state_publisher</exec_depend>
   <exec_depend>robot_state_publisher</exec_depend>
-  <exec_depend>rviz</exec_depend>
   <exec_depend>xacro</exec_depend>
 
   <export>

--- a/fanuc_m10ia_support/package.xml
+++ b/fanuc_m10ia_support/package.xml
@@ -46,7 +46,6 @@
   <exec_depend>fanuc_resources</exec_depend>
   <exec_depend>joint_state_publisher</exec_depend>
   <exec_depend>robot_state_publisher</exec_depend>
-  <exec_depend>rviz</exec_depend>
   <exec_depend>xacro</exec_depend>
 
   <export>

--- a/fanuc_m16ib_support/package.xml
+++ b/fanuc_m16ib_support/package.xml
@@ -46,7 +46,6 @@
   <exec_depend>fanuc_resources</exec_depend>
   <exec_depend>joint_state_publisher</exec_depend>
   <exec_depend>robot_state_publisher</exec_depend>
-  <exec_depend>rviz</exec_depend>
   <exec_depend>xacro</exec_depend>
 
   <export>

--- a/fanuc_m20ia_support/package.xml
+++ b/fanuc_m20ia_support/package.xml
@@ -51,7 +51,6 @@
   <exec_depend>fanuc_resources</exec_depend>
   <exec_depend>joint_state_publisher</exec_depend>
   <exec_depend>robot_state_publisher</exec_depend>
-  <exec_depend>rviz</exec_depend>
   <exec_depend>xacro</exec_depend>
 
   <export>

--- a/fanuc_m430ia_support/package.xml
+++ b/fanuc_m430ia_support/package.xml
@@ -45,7 +45,6 @@
   <exec_depend>fanuc_resources</exec_depend>
   <exec_depend>joint_state_publisher</exec_depend>
   <exec_depend>robot_state_publisher</exec_depend>
-  <exec_depend>rviz</exec_depend>
   <exec_depend>xacro</exec_depend>
 
   <export>

--- a/fanuc_m6ib_support/package.xml
+++ b/fanuc_m6ib_support/package.xml
@@ -45,7 +45,6 @@
   <exec_depend>fanuc_resources</exec_depend>
   <exec_depend>joint_state_publisher</exec_depend>
   <exec_depend>robot_state_publisher</exec_depend>
-  <exec_depend>rviz</exec_depend>
   <exec_depend>xacro</exec_depend>
 
   <export>


### PR DESCRIPTION
Based on https://github.com/ros-industrial/ros_industrial_issues/issues/50