### PR TITLE
Update old xacro xmlns uri

### DIFF
--- a/fanuc_lrmate200ib_support/urdf/lrmate200ib.xacro
+++ b/fanuc_lrmate200ib_support/urdf/lrmate200ib.xacro
@@ -1,5 +1,5 @@
 <?xml version="1.0"?>
-<robot name="fanuc_lrmate200ib" xmlns:xacro="http://ros.org/wiki/xacro">
+<robot name="fanuc_lrmate200ib" xmlns:xacro="http://wiki.ros.org/xacro">
   <xacro:include filename="$(find fanuc_lrmate200ib_support)/urdf/lrmate200ib_macro.xacro"/>
   <xacro:fanuc_lrmate200ib prefix=""/>
 </robot>

--- a/fanuc_lrmate200ib_support/urdf/lrmate200ib3l.xacro
+++ b/fanuc_lrmate200ib_support/urdf/lrmate200ib3l.xacro
@@ -1,5 +1,5 @@
 <?xml version="1.0"?>
-<robot name="fanuc_lrmate200ib3l" xmlns:xacro="http://ros.org/wiki/xacro">
+<robot name="fanuc_lrmate200ib3l" xmlns:xacro="http://wiki.ros.org/xacro">
   <xacro:include filename="$(find fanuc_lrmate200ib_support)/urdf/lrmate200ib3l_macro.xacro"/>
   <xacro:fanuc_lrmate200ib3l prefix=""/>
 </robot>

--- a/fanuc_lrmate200ib_support/urdf/lrmate200ib3l_macro.xacro
+++ b/fanuc_lrmate200ib_support/urdf/lrmate200ib3l_macro.xacro
@@ -1,5 +1,5 @@
 <?xml version="1.0"?>
-<robot xmlns:xacro="http://ros.org/wiki/xacro">
+<robot xmlns:xacro="http://wiki.ros.org/xacro">
   <xacro:include filename="$(find fanuc_resources)/urdf/common_materials.xacro"/>
 
   <xacro:macro name="fanuc_lrmate200ib3l" params="prefix">

--- a/fanuc_lrmate200ib_support/urdf/lrmate200ib_macro.xacro
+++ b/fanuc_lrmate200ib_support/urdf/lrmate200ib_macro.xacro
@@ -1,5 +1,5 @@
 <?xml version="1.0"?>
-<robot xmlns:xacro="http://ros.org/wiki/xacro">
+<robot xmlns:xacro="http://wiki.ros.org/xacro">
   <xacro:include filename="$(find fanuc_resources)/urdf/common_materials.xacro"/>
 
   <xacro:macro name="fanuc_lrmate200ib" params="prefix">

--- a/fanuc_lrmate200ic_support/urdf/lrmate200ic.xacro
+++ b/fanuc_lrmate200ic_support/urdf/lrmate200ic.xacro
@@ -1,5 +1,5 @@
 <?xml version="1.0" ?>
-<robot name="fanuc_lrmate200ic" xmlns:xacro="http://ros.org/wiki/xacro">
+<robot name="fanuc_lrmate200ic" xmlns:xacro="http://wiki.ros.org/xacro">
   <xacro:include filename="$(find fanuc_lrmate200ic_support)/urdf/lrmate200ic_macro.xacro"/>
   <xacro:fanuc_lrmate200ic prefix=""/>
 </robot>

--- a/fanuc_lrmate200ic_support/urdf/lrmate200ic5f.xacro
+++ b/fanuc_lrmate200ic_support/urdf/lrmate200ic5f.xacro
@@ -1,5 +1,5 @@
 <?xml version="1.0" ?>
-<robot name="fanuc_lrmate200ic5f" xmlns:xacro="http://ros.org/wiki/xacro">
+<robot name="fanuc_lrmate200ic5f" xmlns:xacro="http://wiki.ros.org/xacro">
   <xacro:include filename="$(find fanuc_lrmate200ic_support)/urdf/lrmate200ic5f_macro.xacro"/>
   <xacro:fanuc_lrmate200ic5f prefix=""/>
 </robot>

--- a/fanuc_lrmate200ic_support/urdf/lrmate200ic5f_macro.xacro
+++ b/fanuc_lrmate200ic_support/urdf/lrmate200ic5f_macro.xacro
@@ -1,5 +1,5 @@
 <?xml version="1.0" ?>
-<robot xmlns:xacro="http://ros.org/wiki/xacro">
+<robot xmlns:xacro="http://wiki.ros.org/xacro">
   <xacro:include filename="$(find fanuc_resources)/urdf/common_materials.xacro"/>
 
   <xacro:macro name="fanuc_lrmate200ic5f" params="prefix">

--- a/fanuc_lrmate200ic_support/urdf/lrmate200ic5h.xacro
+++ b/fanuc_lrmate200ic_support/urdf/lrmate200ic5h.xacro
@@ -1,5 +1,5 @@
 <?xml version="1.0" ?>
-<robot name="fanuc_lrmate200ic5h" xmlns:xacro="http://ros.org/wiki/xacro">
+<robot name="fanuc_lrmate200ic5h" xmlns:xacro="http://wiki.ros.org/xacro">
   <xacro:include filename="$(find fanuc_lrmate200ic_support)/urdf/lrmate200ic5h_macro.xacro"/>
   <xacro:fanuc_lrmate200ic5h prefix=""/>
 </robot>

--- a/fanuc_lrmate200ic_support/urdf/lrmate200ic5h_macro.xacro
+++ b/fanuc_lrmate200ic_support/urdf/lrmate200ic5h_macro.xacro
@@ -1,5 +1,5 @@
 <?xml version="1.0" ?>
-<robot xmlns:xacro="http://ros.org/wiki/xacro">
+<robot xmlns:xacro="http://wiki.ros.org/xacro">
   <xacro:include filename="$(find fanuc_resources)/urdf/common_materials.xacro"/>
 
   <xacro:macro name="fanuc_lrmate200ic5h" params="prefix">

--- a/fanuc_lrmate200ic_support/urdf/lrmate200ic5hs.xacro
+++ b/fanuc_lrmate200ic_support/urdf/lrmate200ic5hs.xacro
@@ -1,5 +1,5 @@
 <?xml version="1.0" ?>
-<robot name="fanuc_lrmate200ic5hs" xmlns:xacro="http://ros.org/wiki/xacro">
+<robot name="fanuc_lrmate200ic5hs" xmlns:xacro="http://wiki.ros.org/xacro">
   <xacro:include filename="$(find fanuc_lrmate200ic_support)/urdf/lrmate200ic5hs_macro.xacro"/>
   <xacro:fanuc_lrmate200ic5hs prefix=""/>
 </robot>

--- a/fanuc_lrmate200ic_support/urdf/lrmate200ic5hs_macro.xacro
+++ b/fanuc_lrmate200ic_support/urdf/lrmate200ic5hs_macro.xacro
@@ -1,5 +1,5 @@
 <?xml version="1.0" ?>
-<robot xmlns:xacro="http://ros.org/wiki/xacro">
+<robot xmlns:xacro="http://wiki.ros.org/xacro">
   <xacro:include filename="$(find fanuc_resources)/urdf/common_materials.xacro"/>
 
   <xacro:macro name="fanuc_lrmate200ic5hs" params="prefix">

--- a/fanuc_lrmate200ic_support/urdf/lrmate200ic5l.xacro
+++ b/fanuc_lrmate200ic_support/urdf/lrmate200ic5l.xacro
@@ -1,5 +1,5 @@
 <?xml version="1.0" ?>
-<robot name="fanuc_lrmate200ic5l" xmlns:xacro="http://ros.org/wiki/xacro">
+<robot name="fanuc_lrmate200ic5l" xmlns:xacro="http://wiki.ros.org/xacro">
   <xacro:include filename="$(find fanuc_lrmate200ic_support)/urdf/lrmate200ic5l_macro.xacro"/>
   <xacro:fanuc_lrmate200ic5l prefix=""/>
 </robot>

--- a/fanuc_lrmate200ic_support/urdf/lrmate200ic5l_macro.xacro
+++ b/fanuc_lrmate200ic_support/urdf/lrmate200ic5l_macro.xacro
@@ -1,5 +1,5 @@
 <?xml version="1.0" ?>
-<robot xmlns:xacro="http://ros.org/wiki/xacro">
+<robot xmlns:xacro="http://wiki.ros.org/xacro">
   <xacro:include filename="$(find fanuc_resources)/urdf/common_materials.xacro"/>
 
   <xacro:macro name="fanuc_lrmate200ic5l" params="prefix">

--- a/fanuc_lrmate200ic_support/urdf/lrmate200ic_macro.xacro
+++ b/fanuc_lrmate200ic_support/urdf/lrmate200ic_macro.xacro
@@ -1,5 +1,5 @@
 <?xml version="1.0" ?>
-<robot xmlns:xacro="http://ros.org/wiki/xacro">
+<robot xmlns:xacro="http://wiki.ros.org/xacro">
   <xacro:include filename="$(find fanuc_resources)/urdf/common_materials.xacro"/>
 
   <xacro:macro name="fanuc_lrmate200ic" params="prefix">

--- a/fanuc_m10ia_support/urdf/m10ia.xacro
+++ b/fanuc_m10ia_support/urdf/m10ia.xacro
@@ -1,5 +1,5 @@
 <?xml version="1.0" ?>
-<robot name="fanuc_m10ia" xmlns:xacro="http://ros.org/wiki/xacro">
+<robot name="fanuc_m10ia" xmlns:xacro="http://wiki.ros.org/xacro">
   <xacro:include filename="$(find fanuc_m10ia_support)/urdf/m10ia_macro.xacro"/>
   <xacro:fanuc_m10ia prefix=""/>
 </robot>

--- a/fanuc_m10ia_support/urdf/m10ia7l.xacro
+++ b/fanuc_m10ia_support/urdf/m10ia7l.xacro
@@ -1,5 +1,5 @@
 <?xml version="1.0" ?>
-<robot name="fanuc_m10ia7l" xmlns:xacro="http://ros.org/wiki/xacro">
+<robot name="fanuc_m10ia7l" xmlns:xacro="http://wiki.ros.org/xacro">
   <xacro:include filename="$(find fanuc_m10ia_support)/urdf/m10ia7l_macro.xacro"/>
   <xacro:fanuc_m10ia7l prefix=""/>
 </robot>

--- a/fanuc_m10ia_support/urdf/m10ia7l_macro.xacro
+++ b/fanuc_m10ia_support/urdf/m10ia7l_macro.xacro
@@ -1,5 +1,5 @@
 <?xml version="1.0"?>
-<robot xmlns:xacro="http://ros.org/wiki/xacro">
+<robot xmlns:xacro="http://wiki.ros.org/xacro">
   <xacro:include filename="$(find fanuc_resources)/urdf/common_materials.xacro"/>
 
   <xacro:macro name="fanuc_m10ia7l" params="prefix">

--- a/fanuc_m10ia_support/urdf/m10ia_macro.xacro
+++ b/fanuc_m10ia_support/urdf/m10ia_macro.xacro
@@ -1,5 +1,5 @@
 <?xml version="1.0"?>
-<robot xmlns:xacro="http://ros.org/wiki/xacro">
+<robot xmlns:xacro="http://wiki.ros.org/xacro">
   <xacro:include filename="$(find fanuc_resources)/urdf/common_materials.xacro"/>
 
   <xacro:macro name="fanuc_m10ia" params="prefix">

--- a/fanuc_m16ib_support/urdf/m16ib20.xacro
+++ b/fanuc_m16ib_support/urdf/m16ib20.xacro
@@ -1,5 +1,5 @@
 <?xml version="1.0" ?>
-<robot name="fanuc_m16ib20" xmlns:xacro="http://ros.org/wiki/xacro">
+<robot name="fanuc_m16ib20" xmlns:xacro="http://wiki.ros.org/xacro">
   <xacro:include filename="$(find fanuc_m16ib_support)/urdf/m16ib20_macro.xacro"/>
   <xacro:fanuc_m16ib20 prefix=""/>
 </robot>

--- a/fanuc_m16ib_support/urdf/m16ib20_macro.xacro
+++ b/fanuc_m16ib_support/urdf/m16ib20_macro.xacro
@@ -1,5 +1,5 @@
 <?xml version="1.0" ?>
-<robot xmlns:xacro="http://ros.org/wiki/xacro">
+<robot xmlns:xacro="http://wiki.ros.org/xacro">
   <xacro:include filename="$(find fanuc_resources)/urdf/common_materials.xacro"/>
 
   <xacro:macro name="fanuc_m16ib20" params="prefix">

--- a/fanuc_m20ia_support/urdf/m20ia.xacro
+++ b/fanuc_m20ia_support/urdf/m20ia.xacro
@@ -1,5 +1,5 @@
 <?xml version="1.0" ?>
-<robot name="fanuc_m20ia" xmlns:xacro="http://ros.org/wiki/xacro">
+<robot name="fanuc_m20ia" xmlns:xacro="http://wiki.ros.org/xacro">
   <xacro:include filename="$(find fanuc_m20ia_support)/urdf/m20ia_macro.xacro"/>
   <xacro:fanuc_m20ia prefix=""/>
 </robot>

--- a/fanuc_m20ia_support/urdf/m20ia10l.xacro
+++ b/fanuc_m20ia_support/urdf/m20ia10l.xacro
@@ -1,5 +1,5 @@
 <?xml version="1.0" ?>
-<robot name="fanuc_m20ia10l" xmlns:xacro="http://ros.org/wiki/xacro">
+<robot name="fanuc_m20ia10l" xmlns:xacro="http://wiki.ros.org/xacro">
   <xacro:include filename="$(find fanuc_m20ia_support)/urdf/m20ia10l_macro.xacro"/>
   <xacro:fanuc_m20ia10l prefix=""/>
 </robot>

--- a/fanuc_m20ia_support/urdf/m20ia10l_macro.xacro
+++ b/fanuc_m20ia_support/urdf/m20ia10l_macro.xacro
@@ -1,5 +1,5 @@
 <?xml version="1.0"?>
-<robot xmlns:xacro="http://ros.org/wiki/xacro">
+<robot xmlns:xacro="http://wiki.ros.org/xacro">
   <xacro:include filename="$(find fanuc_resources)/urdf/common_materials.xacro"/>
 
   <xacro:macro name="fanuc_m20ia10l" params="prefix">

--- a/fanuc_m20ia_support/urdf/m20ia_macro.xacro
+++ b/fanuc_m20ia_support/urdf/m20ia_macro.xacro
@@ -1,5 +1,5 @@
 <?xml version="1.0"?>
-<robot xmlns:xacro="http://ros.org/wiki/xacro">
+<robot xmlns:xacro="http://wiki.ros.org/xacro">
   <xacro:include filename="$(find fanuc_resources)/urdf/common_materials.xacro"/>
 
   <xacro:macro name="fanuc_m20ia" params="prefix">

--- a/fanuc_m430ia_support/urdf/m430ia2f.xacro
+++ b/fanuc_m430ia_support/urdf/m430ia2f.xacro
@@ -1,5 +1,5 @@
 <?xml version="1.0" ?>
-<robot name="fanuc_m430ia2f" xmlns:xacro="http://ros.org/wiki/xacro">
+<robot name="fanuc_m430ia2f" xmlns:xacro="http://wiki.ros.org/xacro">
   <xacro:include filename="$(find fanuc_m430ia_support)/urdf/m430ia2f_macro.xacro"/>
   <xacro:fanuc_m430ia2f prefix=""/>
 </robot>

--- a/fanuc_m430ia_support/urdf/m430ia2f_macro.xacro
+++ b/fanuc_m430ia_support/urdf/m430ia2f_macro.xacro
@@ -1,5 +1,5 @@
 <?xml version="1.0"?>
-<robot xmlns:xacro="http://ros.org/wiki/xacro">
+<robot xmlns:xacro="http://wiki.ros.org/xacro">
   <xacro:include filename="$(find fanuc_resources)/urdf/common_materials.xacro"/>
 
   <xacro:macro name="fanuc_m430ia2f" params="prefix">

--- a/fanuc_m430ia_support/urdf/m430ia2p.xacro
+++ b/fanuc_m430ia_support/urdf/m430ia2p.xacro
@@ -1,5 +1,5 @@
 <?xml version="1.0" ?>
-<robot name="fanuc_m430ia2p" xmlns:xacro="http://ros.org/wiki/xacro">
+<robot name="fanuc_m430ia2p" xmlns:xacro="http://wiki.ros.org/xacro">
   <xacro:include filename="$(find fanuc_m430ia_support)/urdf/m430ia2p_macro.xacro"/>
   <xacro:fanuc_m430ia2p prefix=""/>
 </robot>

--- a/fanuc_m430ia_support/urdf/m430ia2p_macro.xacro
+++ b/fanuc_m430ia_support/urdf/m430ia2p_macro.xacro
@@ -1,5 +1,5 @@
 <?xml version="1.0" ?>
-<robot xmlns:xacro="http://ros.org/wiki/xacro">
+<robot xmlns:xacro="http://wiki.ros.org/xacro">
   <xacro:include filename="$(find fanuc_resources)/urdf/common_materials.xacro"/>
 
   <xacro:macro name="fanuc_m430ia2p" params="prefix">

--- a/fanuc_m6ib_support/urdf/m6ib.xacro
+++ b/fanuc_m6ib_support/urdf/m6ib.xacro
@@ -1,5 +1,5 @@
 <?xml version="1.0"?>
-<robot name="fanuc_m6ib" xmlns:xacro="http://ros.org/wiki/xacro">
+<robot name="fanuc_m6ib" xmlns:xacro="http://wiki.ros.org/xacro">
   <xacro:include filename="$(find fanuc_m6ib_support)/urdf/m6ib_macro.xacro"/>
   <xacro:fanuc_m6ib prefix=""/>
 </robot>

--- a/fanuc_m6ib_support/urdf/m6ib_macro.xacro
+++ b/fanuc_m6ib_support/urdf/m6ib_macro.xacro
@@ -1,5 +1,5 @@
 <?xml version="1.0"?>
-<robot xmlns:xacro="http://ros.org/wiki/xacro">
+<robot xmlns:xacro="http://wiki.ros.org/xacro">
   <xacro:include filename="$(find fanuc_resources)/urdf/common_materials.xacro"/>
 
   <xacro:macro name="fanuc_m6ib" params="prefix">

--- a/fanuc_resources/urdf/common_colours.xacro
+++ b/fanuc_resources/urdf/common_colours.xacro
@@ -1,5 +1,5 @@
 <?xml version="1.0"?>
-<robot xmlns:xacro="http://ros.org/wiki/xacro">
+<robot xmlns:xacro="http://wiki.ros.org/xacro">
 
   <!-- RAL 1021: Rape yellow -->
   <xacro:property name="color_fanuc_yellow"   value="0.96 0.76 0.13 1.0" />

--- a/fanuc_resources/urdf/common_constants.xacro
+++ b/fanuc_resources/urdf/common_constants.xacro
@@ -1,5 +1,5 @@
 <?xml version="1.0"?>
-<robot xmlns:xacro="http://ros.org/wiki/xacro">
+<robot xmlns:xacro="http://wiki.ros.org/xacro">
 
 
   <!-- The 'pi' constant in this file is DEPRECATED. Use the '(math.)pi'

--- a/fanuc_resources/urdf/common_materials.xacro
+++ b/fanuc_resources/urdf/common_materials.xacro
@@ -1,5 +1,5 @@
 <?xml version="1.0"?>
-<robot xmlns:xacro="http://ros.org/wiki/xacro">
+<robot xmlns:xacro="http://wiki.ros.org/xacro">
   <xacro:include filename="$(find fanuc_resources)/urdf/common_colours.xacro"/>
 
   <xacro:macro name="material_fanuc_yellow">


### PR DESCRIPTION
No functional changes.

The wiki has long since been hosted at `wiki.ros.org` instead of `www.ros.org/wiki`.

Note that the xacros will still 'function', even if the wiki is unreachable under the old link, but with the increase in xacros that use the correct uri, `xacro` starts printing more and more warnings.
