### PR TITLE
readme: add license badges.

### DIFF
--- a/readme.md
+++ b/readme.md
@@ -1,8 +1,11 @@
 # Fanuc
 
 [![Build Status](http://build.ros.org/job/Idev__fanuc__ubuntu_trusty_amd64/badge/icon)](http://build.ros.org/job/Idev__fanuc__ubuntu_trusty_amd64)
+[![license - apache 2.0](https://img.shields.io/:license-Apache%202.0-yellowgreen.svg)](https://opensource.org/licenses/Apache-2.0)
+[![license - bsd 3 clause](https://img.shields.io/:license-BSD%203--Clause-blue.svg)](https://opensource.org/licenses/BSD-3-Clause)
 
 [![support level: community](https://img.shields.io/badge/support%20level-community-lightgray.png)](http://rosindustrial.org/news/2016/10/7/better-supporting-a-growing-ros-industrial-software-platform)
+
 
 
 [ROS-Industrial][] Fanuc meta-package. See the [ROS wiki][] page for more information.


### PR DESCRIPTION
As per subject. [Rendered version](https://github.com/ros-industrial/fanuc/blob/992e4d85d9f026749e90d08e3e509e0ce5e6f5b0/readme.md).

This ties in with #242 a bit, but not enough to add it there I believe.

This was done manually, but there are tools that can do this for you. I haven't looked at those yet though.

No functional changes, just a readme update.
