### PR TITLE
Harmonise pkg version numbers.

### DIFF
--- a/fanuc_cr35ia_support/package.xml
+++ b/fanuc_cr35ia_support/package.xml
@@ -2,7 +2,7 @@
 <?xml-model href="http://download.ros.org/schema/package_format2.xsd" schematypens="http://www.w3.org/2001/XMLSchema"?>
 <package format="2">
   <name>fanuc_cr35ia_support</name>
-  <version>0.1.0</version>
+  <version>0.4.4</version>
   <description>
     <p>
       ROS-Industrial support for the Fanuc CR-35iA (and variants).

--- a/fanuc_cr7ia_moveit_config/package.xml
+++ b/fanuc_cr7ia_moveit_config/package.xml
@@ -2,7 +2,7 @@
 <?xml-model href="http://download.ros.org/schema/package_format2.xsd" schematypens="http://www.w3.org/2001/XMLSchema"?>
 <package format="2">
   <name>fanuc_cr7ia_moveit_config</name>
-  <version>0.1.0</version>
+  <version>0.4.4</version>
   <description>
     <p>
       MoveIt package for the Fanuc CR-7iA.

--- a/fanuc_cr7ia_support/package.xml
+++ b/fanuc_cr7ia_support/package.xml
@@ -2,7 +2,7 @@
 <?xml-model href="http://download.ros.org/schema/package_format2.xsd" schematypens="http://www.w3.org/2001/XMLSchema"?>
 <package format="2">
   <name>fanuc_cr7ia_support</name>
-  <version>0.1.0</version>
+  <version>0.4.4</version>
   <description>
     <p>
       ROS-Industrial support for the Fanuc CR-7iA (and variants).

--- a/fanuc_cr7ial_moveit_config/package.xml
+++ b/fanuc_cr7ial_moveit_config/package.xml
@@ -2,7 +2,7 @@
 <?xml-model href="http://download.ros.org/schema/package_format2.xsd" schematypens="http://www.w3.org/2001/XMLSchema"?>
 <package format="2">
   <name>fanuc_cr7ial_moveit_config</name>
-  <version>0.1.0</version>
+  <version>0.4.4</version>
   <description>
     <p>
       MoveIt package for the Fanuc CR-7iA/L.

--- a/fanuc_lrmate200i_moveit_config/package.xml
+++ b/fanuc_lrmate200i_moveit_config/package.xml
@@ -2,7 +2,7 @@
 <?xml-model href="http://download.ros.org/schema/package_format2.xsd" schematypens="http://www.w3.org/2001/XMLSchema"?>
 <package format="2">
   <name>fanuc_lrmate200i_moveit_config</name>
-  <version>0.1.0</version>
+  <version>0.4.4</version>
   <description>
     <p>
       MoveIt package for the Fanuc LR Mate 200i.

--- a/fanuc_lrmate200i_moveit_plugins/package.xml
+++ b/fanuc_lrmate200i_moveit_plugins/package.xml
@@ -2,7 +2,7 @@
 <?xml-model href="http://download.ros.org/schema/package_format2.xsd" schematypens="http://www.w3.org/2001/XMLSchema"?>
 <package format="2">
   <name>fanuc_lrmate200i_moveit_plugins</name>
-  <version>0.1.0</version>
+  <version>0.4.4</version>
   <description>
     <p>
       MoveIt plugins for the Fanuc LR Mate 200i (and variants).

--- a/fanuc_lrmate200i_support/package.xml
+++ b/fanuc_lrmate200i_support/package.xml
@@ -2,7 +2,7 @@
 <?xml-model href="http://download.ros.org/schema/package_format2.xsd" schematypens="http://www.w3.org/2001/XMLSchema"?>
 <package format="2">
   <name>fanuc_lrmate200i_support</name>
-  <version>0.1.0</version>
+  <version>0.4.4</version>
   <description>
     <p>
       ROS-Industrial support for the Fanuc LR Mate 200i.

--- a/fanuc_m710ic_support/package.xml
+++ b/fanuc_m710ic_support/package.xml
@@ -2,7 +2,7 @@
 <?xml-model href="http://download.ros.org/schema/package_format2.xsd" schematypens="http://www.w3.org/2001/XMLSchema"?>
 <package format="2">
   <name>fanuc_m710ic_support</name>
-  <version>0.1.0</version>
+  <version>0.4.4</version>
   <description>
     <p>
       ROS-Industrial support for the Fanuc M-710iC (and variants).

--- a/fanuc_m900ib_support/package.xml
+++ b/fanuc_m900ib_support/package.xml
@@ -2,7 +2,7 @@
 <?xml-model href="http://download.ros.org/schema/package_format2.xsd" schematypens="http://www.w3.org/2001/XMLSchema"?>
 <package format="2">
   <name>fanuc_m900ib_support</name>
-  <version>0.1.0</version>
+  <version>0.4.4</version>
   <description>
     <p>
       ROS-Industrial support for the Fanuc M-900iB (and variants).

--- a/fanuc_r1000ia80f_moveit_config/package.xml
+++ b/fanuc_r1000ia80f_moveit_config/package.xml
@@ -2,7 +2,7 @@
 <?xml-model href="http://download.ros.org/schema/package_format2.xsd" schematypens="http://www.w3.org/2001/XMLSchema"?>
 <package format="2">
   <name>fanuc_r1000ia80f_moveit_config</name>
-  <version>0.1.0</version>
+  <version>0.4.4</version>
   <description>
     <p>
       MoveIt package for the Fanuc R-1000iA/80F.

--- a/fanuc_r1000ia_moveit_plugins/package.xml
+++ b/fanuc_r1000ia_moveit_plugins/package.xml
@@ -2,7 +2,7 @@
 <?xml-model href="http://download.ros.org/schema/package_format2.xsd" schematypens="http://www.w3.org/2001/XMLSchema"?>
 <package format="2">
   <name>fanuc_r1000ia_moveit_plugins</name>
-  <version>0.1.0</version>
+  <version>0.4.4</version>
   <description>
     <p>
       MoveIt plugins for the Fanuc R-1000iA (and variants).

--- a/fanuc_r1000ia_support/package.xml
+++ b/fanuc_r1000ia_support/package.xml
@@ -2,7 +2,7 @@
 <?xml-model href="http://download.ros.org/schema/package_format2.xsd" schematypens="http://www.w3.org/2001/XMLSchema"?>
 <package format="2">
   <name>fanuc_r1000ia_support</name>
-  <version>0.1.0</version>
+  <version>0.4.4</version>
   <description>
     <p>
       ROS-Industrial support for the Fanuc R-1000iA (and variants).


### PR DESCRIPTION
As per subject.

The packages imported in ros-industrial/fanuc#251, ros-industrial/fanuc#252, ros-industrial/fanuc#254, ros-industrial/fanuc#255, ros-industrial/fanuc#256 and ros-industrial/fanuc#257 still had the `0.1.0` version number all experimental packages get.

Now that they've been migrated to the main repository, they should be harmonised with the version numbers of the other packages.
