### PR TITLE
Melodic: Replace all boost::shared_ptr with respective typedefs

### DIFF
--- a/fanuc_lrmate200i_moveit_plugins/lrmate200i_kinematics/src/fanuc_lrmate200i_manipulator_ikfast_moveit_plugin.cpp
+++ b/fanuc_lrmate200i_moveit_plugins/lrmate200i_kinematics/src/fanuc_lrmate200i_manipulator_ikfast_moveit_plugin.cpp
@@ -299,12 +299,12 @@ bool IKFastKinematicsPlugin::initialize(const std::string &robot_description,
 
   ROS_DEBUG_STREAM_NAMED("ikfast","Reading joints and links from URDF");
 
-  boost::shared_ptr<urdf::Link> link = boost::const_pointer_cast<urdf::Link>(robot_model.getLink(getTipFrame()));
+  urdf::LinkConstSharedPtr link = robot_model.getLink(getTipFrame());
   while(link->name != base_frame_ && joint_names_.size() <= num_joints_)
   {
     ROS_DEBUG_NAMED("ikfast","Link %s",link->name.c_str());
     link_names_.push_back(link->name);
-    boost::shared_ptr<urdf::Joint> joint = link->parent_joint;
+    urdf::JointSharedPtr joint = link->parent_joint;
     if(joint)
     {
       if (joint->type != urdf::Joint::UNKNOWN && joint->type != urdf::Joint::FIXED)

--- a/fanuc_lrmate200ib_moveit_plugins/lrmate200ib3l_kinematics/src/fanuc_lrmate200ib3l_manipulator_ikfast_moveit_plugin.cpp
+++ b/fanuc_lrmate200ib_moveit_plugins/lrmate200ib3l_kinematics/src/fanuc_lrmate200ib3l_manipulator_ikfast_moveit_plugin.cpp
@@ -298,12 +298,12 @@ bool IKFastKinematicsPlugin::initialize(const std::string &robot_description,
 
   ROS_DEBUG_STREAM_NAMED("ikfast","Reading joints and links from URDF");
 
-  boost::shared_ptr<urdf::Link> link = boost::const_pointer_cast<urdf::Link>(robot_model.getLink(getTipFrame()));
+  urdf::LinkConstSharedPtr link = robot_model.getLink(getTipFrame());
   while(link->name != base_frame_ && joint_names_.size() <= num_joints_)
   {
     ROS_DEBUG_NAMED("ikfast","Link %s",link->name.c_str());
     link_names_.push_back(link->name);
-    boost::shared_ptr<urdf::Joint> joint = link->parent_joint;
+    urdf::JointSharedPtr joint = link->parent_joint;
     if(joint)
     {
       if (joint->type != urdf::Joint::UNKNOWN && joint->type != urdf::Joint::FIXED)

--- a/fanuc_lrmate200ib_moveit_plugins/lrmate200ib_kinematics/src/fanuc_lrmate200ib_manipulator_ikfast_moveit_plugin.cpp
+++ b/fanuc_lrmate200ib_moveit_plugins/lrmate200ib_kinematics/src/fanuc_lrmate200ib_manipulator_ikfast_moveit_plugin.cpp
@@ -298,12 +298,12 @@ bool IKFastKinematicsPlugin::initialize(const std::string &robot_description,
 
   ROS_DEBUG_STREAM_NAMED("ikfast","Reading joints and links from URDF");
 
-  boost::shared_ptr<urdf::Link> link = boost::const_pointer_cast<urdf::Link>(robot_model.getLink(getTipFrame()));
+  urdf::LinkConstSharedPtr link = robot_model.getLink(getTipFrame());
   while(link->name != base_frame_ && joint_names_.size() <= num_joints_)
   {
     ROS_DEBUG_NAMED("ikfast","Link %s",link->name.c_str());
     link_names_.push_back(link->name);
-    boost::shared_ptr<urdf::Joint> joint = link->parent_joint;
+    urdf::JointSharedPtr joint = link->parent_joint;
     if(joint)
     {
       if (joint->type != urdf::Joint::UNKNOWN && joint->type != urdf::Joint::FIXED)

--- a/fanuc_lrmate200ic_moveit_plugins/lrmate200ic5f_kinematics/src/fanuc_lrmate200ic5f_manipulator_ikfast_moveit_plugin.cpp
+++ b/fanuc_lrmate200ic_moveit_plugins/lrmate200ic5f_kinematics/src/fanuc_lrmate200ic5f_manipulator_ikfast_moveit_plugin.cpp
@@ -299,12 +299,12 @@ bool IKFastKinematicsPlugin::initialize(const std::string &robot_description,
 
   ROS_DEBUG_STREAM_NAMED("ikfast","Reading joints and links from URDF");
 
-  boost::shared_ptr<urdf::Link> link = boost::const_pointer_cast<urdf::Link>(robot_model.getLink(tip_frame_));
+  urdf::LinkConstSharedPtr link = robot_model.getLink(tip_frame_);
   while(link->name != base_frame_ && joint_names_.size() <= num_joints_)
   {
     ROS_DEBUG_NAMED("ikfast","Link %s",link->name.c_str());
     link_names_.push_back(link->name);
-    boost::shared_ptr<urdf::Joint> joint = link->parent_joint;
+    urdf::JointSharedPtr joint = link->parent_joint;
     if(joint)
     {
       if (joint->type != urdf::Joint::UNKNOWN && joint->type != urdf::Joint::FIXED)

--- a/fanuc_lrmate200ic_moveit_plugins/lrmate200ic5h_kinematics/src/fanuc_lrmate200ic5h_manipulator_ikfast_moveit_plugin.cpp
+++ b/fanuc_lrmate200ic_moveit_plugins/lrmate200ic5h_kinematics/src/fanuc_lrmate200ic5h_manipulator_ikfast_moveit_plugin.cpp
@@ -299,12 +299,12 @@ bool IKFastKinematicsPlugin::initialize(const std::string &robot_description,
 
   ROS_DEBUG_STREAM_NAMED("ikfast","Reading joints and links from URDF");
 
-  boost::shared_ptr<urdf::Link> link = boost::const_pointer_cast<urdf::Link>(robot_model.getLink(tip_frame_));
+  urdf::LinkConstSharedPtr link = robot_model.getLink(tip_frame_);
   while(link->name != base_frame_ && joint_names_.size() <= num_joints_)
   {
     ROS_DEBUG_NAMED("ikfast","Link %s",link->name.c_str());
     link_names_.push_back(link->name);
-    boost::shared_ptr<urdf::Joint> joint = link->parent_joint;
+    urdf::JointSharedPtr joint = link->parent_joint;
     if(joint)
     {
       if (joint->type != urdf::Joint::UNKNOWN && joint->type != urdf::Joint::FIXED)

--- a/fanuc_lrmate200ic_moveit_plugins/lrmate200ic5l_kinematics/src/fanuc_lrmate200ic5l_manipulator_ikfast_moveit_plugin.cpp
+++ b/fanuc_lrmate200ic_moveit_plugins/lrmate200ic5l_kinematics/src/fanuc_lrmate200ic5l_manipulator_ikfast_moveit_plugin.cpp
@@ -299,12 +299,12 @@ bool IKFastKinematicsPlugin::initialize(const std::string &robot_description,
 
   ROS_DEBUG_STREAM_NAMED("ikfast","Reading joints and links from URDF");
 
-  boost::shared_ptr<urdf::Link> link = boost::const_pointer_cast<urdf::Link>(robot_model.getLink(getTipFrame()));
+  urdf::LinkConstSharedPtr link = robot_model.getLink(getTipFrame());
   while(link->name != base_frame_ && joint_names_.size() <= num_joints_)
   {
     ROS_DEBUG_NAMED("ikfast","Link %s",link->name.c_str());
     link_names_.push_back(link->name);
-    boost::shared_ptr<urdf::Joint> joint = link->parent_joint;
+    urdf::JointSharedPtr joint = link->parent_joint;
     if(joint)
     {
       if (joint->type != urdf::Joint::UNKNOWN && joint->type != urdf::Joint::FIXED)

--- a/fanuc_lrmate200ic_moveit_plugins/lrmate200ic_kinematics/src/fanuc_lrmate200ic_manipulator_ikfast_moveit_plugin.cpp
+++ b/fanuc_lrmate200ic_moveit_plugins/lrmate200ic_kinematics/src/fanuc_lrmate200ic_manipulator_ikfast_moveit_plugin.cpp
@@ -299,12 +299,12 @@ bool IKFastKinematicsPlugin::initialize(const std::string &robot_description,
 
   ROS_DEBUG_STREAM_NAMED("ikfast","Reading joints and links from URDF");
 
-  boost::shared_ptr<urdf::Link> link = boost::const_pointer_cast<urdf::Link>(robot_model.getLink(tip_frame_));
+  urdf::LinkConstSharedPtr link = robot_model.getLink(tip_frame_);
   while(link->name != base_frame_ && joint_names_.size() <= num_joints_)
   {
     ROS_DEBUG_NAMED("ikfast","Link %s",link->name.c_str());
     link_names_.push_back(link->name);
-    boost::shared_ptr<urdf::Joint> joint = link->parent_joint;
+    urdf::JointSharedPtr joint = link->parent_joint;
     if(joint)
     {
       if (joint->type != urdf::Joint::UNKNOWN && joint->type != urdf::Joint::FIXED)

--- a/fanuc_m10ia_moveit_plugins/m10ia_kinematics/src/fanuc_m10ia_manipulator_ikfast_moveit_plugin.cpp
+++ b/fanuc_m10ia_moveit_plugins/m10ia_kinematics/src/fanuc_m10ia_manipulator_ikfast_moveit_plugin.cpp
@@ -299,12 +299,12 @@ bool IKFastKinematicsPlugin::initialize(const std::string &robot_description,
 
   ROS_DEBUG_STREAM_NAMED("ikfast","Reading joints and links from URDF");
 
-  boost::shared_ptr<urdf::Link> link = boost::const_pointer_cast<urdf::Link>(robot_model.getLink(tip_frame_));
+  urdf::LinkConstSharedPtr link = robot_model.getLink(tip_frame_);
   while(link->name != base_frame_ && joint_names_.size() <= num_joints_)
   {
     ROS_DEBUG_NAMED("ikfast","Link %s",link->name.c_str());
     link_names_.push_back(link->name);
-    boost::shared_ptr<urdf::Joint> joint = link->parent_joint;
+    urdf::JointSharedPtr joint = link->parent_joint;
     if(joint)
     {
       if (joint->type != urdf::Joint::UNKNOWN && joint->type != urdf::Joint::FIXED)

--- a/fanuc_m16ib_moveit_plugins/m16ib20_kinematics/src/fanuc_m16ib20_manipulator_ikfast_moveit_plugin.cpp
+++ b/fanuc_m16ib_moveit_plugins/m16ib20_kinematics/src/fanuc_m16ib20_manipulator_ikfast_moveit_plugin.cpp
@@ -299,12 +299,12 @@ bool IKFastKinematicsPlugin::initialize(const std::string &robot_description,
 
   ROS_DEBUG_STREAM_NAMED("ikfast","Reading joints and links from URDF");
 
-  boost::shared_ptr<urdf::Link> link = boost::const_pointer_cast<urdf::Link>(robot_model.getLink(tip_frame_));
+  urdf::LinkConstSharedPtr link = robot_model.getLink(tip_frame_);
   while(link->name != base_frame_ && joint_names_.size() <= num_joints_)
   {
     ROS_DEBUG_NAMED("ikfast","Link %s",link->name.c_str());
     link_names_.push_back(link->name);
-    boost::shared_ptr<urdf::Joint> joint = link->parent_joint;
+    urdf::JointSharedPtr joint = link->parent_joint;
     if(joint)
     {
       if (joint->type != urdf::Joint::UNKNOWN && joint->type != urdf::Joint::FIXED)

--- a/fanuc_m20ia_moveit_plugins/m20ia10l_kinematics/src/fanuc_m20ia10l_manipulator_ikfast_moveit_plugin.cpp
+++ b/fanuc_m20ia_moveit_plugins/m20ia10l_kinematics/src/fanuc_m20ia10l_manipulator_ikfast_moveit_plugin.cpp
@@ -299,12 +299,12 @@ bool IKFastKinematicsPlugin::initialize(const std::string &robot_description,
 
   ROS_DEBUG_STREAM_NAMED("ikfast","Reading joints and links from URDF");
 
-  boost::shared_ptr<urdf::Link> link = boost::const_pointer_cast<urdf::Link>(robot_model.getLink(tip_frame_));
+  urdf::LinkConstSharedPtr link = robot_model.getLink(tip_frame_);
   while(link->name != base_frame_ && joint_names_.size() <= num_joints_)
   {
     ROS_DEBUG_NAMED("ikfast","Link %s",link->name.c_str());
     link_names_.push_back(link->name);
-    boost::shared_ptr<urdf::Joint> joint = link->parent_joint;
+    urdf::JointSharedPtr joint = link->parent_joint;
     if(joint)
     {
       if (joint->type != urdf::Joint::UNKNOWN && joint->type != urdf::Joint::FIXED)

--- a/fanuc_m20ia_moveit_plugins/m20ia_kinematics/src/fanuc_m20ia_manipulator_ikfast_moveit_plugin.cpp
+++ b/fanuc_m20ia_moveit_plugins/m20ia_kinematics/src/fanuc_m20ia_manipulator_ikfast_moveit_plugin.cpp
@@ -299,12 +299,12 @@ bool IKFastKinematicsPlugin::initialize(const std::string &robot_description,
 
   ROS_DEBUG_STREAM_NAMED("ikfast","Reading joints and links from URDF");
 
-  boost::shared_ptr<urdf::Link> link = boost::const_pointer_cast<urdf::Link>(robot_model.getLink(tip_frame_));
+  urdf::LinkConstSharedPtr link = robot_model.getLink(tip_frame_);
   while(link->name != base_frame_ && joint_names_.size() <= num_joints_)
   {
     ROS_DEBUG_NAMED("ikfast","Link %s",link->name.c_str());
     link_names_.push_back(link->name);
-    boost::shared_ptr<urdf::Joint> joint = link->parent_joint;
+    urdf::JointSharedPtr joint = link->parent_joint;
     if(joint)
     {
       if (joint->type != urdf::Joint::UNKNOWN && joint->type != urdf::Joint::FIXED)

--- a/fanuc_m430ia_moveit_plugins/m430ia2f_kinematics/src/fanuc_m430ia2f_manipulator_ikfast_moveit_plugin.cpp
+++ b/fanuc_m430ia_moveit_plugins/m430ia2f_kinematics/src/fanuc_m430ia2f_manipulator_ikfast_moveit_plugin.cpp
@@ -299,12 +299,12 @@ bool IKFastKinematicsPlugin::initialize(const std::string &robot_description,
 
   ROS_DEBUG_STREAM_NAMED("ikfast","Reading joints and links from URDF");
 
-  boost::shared_ptr<urdf::Link> link = boost::const_pointer_cast<urdf::Link>(robot_model.getLink(tip_frame_));
+  urdf::LinkConstSharedPtr link = robot_model.getLink(tip_frame_);
   while(link->name != base_frame_ && joint_names_.size() <= num_joints_)
   {
     ROS_DEBUG_NAMED("ikfast","Link %s",link->name.c_str());
     link_names_.push_back(link->name);
-    boost::shared_ptr<urdf::Joint> joint = link->parent_joint;
+    urdf::JointSharedPtr joint = link->parent_joint;
     if(joint)
     {
       if (joint->type != urdf::Joint::UNKNOWN && joint->type != urdf::Joint::FIXED)

--- a/fanuc_m430ia_moveit_plugins/m430ia2p_kinematics/src/fanuc_m430ia2p_manipulator_ikfast_moveit_plugin.cpp
+++ b/fanuc_m430ia_moveit_plugins/m430ia2p_kinematics/src/fanuc_m430ia2p_manipulator_ikfast_moveit_plugin.cpp
@@ -299,12 +299,12 @@ bool IKFastKinematicsPlugin::initialize(const std::string &robot_description,
 
   ROS_DEBUG_STREAM_NAMED("ikfast","Reading joints and links from URDF");
 
-  boost::shared_ptr<urdf::Link> link = boost::const_pointer_cast<urdf::Link>(robot_model.getLink(tip_frame_));
+  urdf::LinkConstSharedPtr link = robot_model.getLink(tip_frame_);
   while(link->name != base_frame_ && joint_names_.size() <= num_joints_)
   {
     ROS_DEBUG_NAMED("ikfast","Link %s",link->name.c_str());
     link_names_.push_back(link->name);
-    boost::shared_ptr<urdf::Joint> joint = link->parent_joint;
+    urdf::JointSharedPtr joint = link->parent_joint;
     if(joint)
     {
       if (joint->type != urdf::Joint::UNKNOWN && joint->type != urdf::Joint::FIXED)

--- a/fanuc_m6ib_moveit_plugins/m6ib_kinematics/src/fanuc_m6ib_manipulator_ikfast_moveit_plugin.cpp
+++ b/fanuc_m6ib_moveit_plugins/m6ib_kinematics/src/fanuc_m6ib_manipulator_ikfast_moveit_plugin.cpp
@@ -298,12 +298,12 @@ bool IKFastKinematicsPlugin::initialize(const std::string &robot_description,
 
   ROS_DEBUG_STREAM_NAMED("ikfast","Reading joints and links from URDF");
 
-  boost::shared_ptr<urdf::Link> link = boost::const_pointer_cast<urdf::Link>(robot_model.getLink(getTipFrame()));
+  urdf::LinkConstSharedPtr link = robot_model.getLink(getTipFrame());
   while(link->name != base_frame_ && joint_names_.size() <= num_joints_)
   {
     ROS_DEBUG_NAMED("ikfast","Link %s",link->name.c_str());
     link_names_.push_back(link->name);
-    boost::shared_ptr<urdf::Joint> joint = link->parent_joint;
+    urdf::JointSharedPtr joint = link->parent_joint;
     if(joint)
     {
       if (joint->type != urdf::Joint::UNKNOWN && joint->type != urdf::Joint::FIXED)

--- a/fanuc_r1000ia_moveit_plugins/r1000ia80f_kinematics/src/fanuc_r1000ia80f_manipulator_ikfast_moveit_plugin.cpp
+++ b/fanuc_r1000ia_moveit_plugins/r1000ia80f_kinematics/src/fanuc_r1000ia80f_manipulator_ikfast_moveit_plugin.cpp
@@ -298,12 +298,12 @@ bool IKFastKinematicsPlugin::initialize(const std::string &robot_description,
 
   ROS_DEBUG_STREAM_NAMED("ikfast","Reading joints and links from URDF");
 
-  boost::shared_ptr<urdf::Link> link = boost::const_pointer_cast<urdf::Link>(robot_model.getLink(getTipFrame()));
+  urdf::LinkConstSharedPtr link = robot_model.getLink(getTipFrame());
   while(link->name != base_frame_ && joint_names_.size() <= num_joints_)
   {
     ROS_DEBUG_NAMED("ikfast","Link %s",link->name.c_str());
     link_names_.push_back(link->name);
-    boost::shared_ptr<urdf::Joint> joint = link->parent_joint;
+    urdf::JointSharedPtr joint = link->parent_joint;
     if(joint)
     {
       if (joint->type != urdf::Joint::UNKNOWN && joint->type != urdf::Joint::FIXED)


### PR DESCRIPTION
```bash
find ./ -type f -exec sed -i 's/boost::shared_ptr<urdf::Joint>/urdf::JointSharedPtr/g'  {} \;
find ./ -type f -exec sed -i 's/boost::shared_ptr<urdf::Link>/urdf::LinkConstSharedPtr/g'  {} \;

find ./ -type f -exec sed -i 's/boost::const_pointer_cast<urdf::Link>(robot_model.getLink(tip_frame_));/robot_model.getLink(tip_frame_);/g'  {} \;
find ./ -type f -exec sed -i 's/boost::const_pointer_cast<urdf::Link>(robot_model.getLink(getTipFrame()));/robot_model.getLink(getTipFrame());/g'  {} \;
```

This enables compilation on melodic