### PR TITLE
support: make flange parent of tool0.

### DIFF
--- a/fanuc_cr35ia_support/urdf/cr35ia_macro.xacro
+++ b/fanuc_cr35ia_support/urdf/cr35ia_macro.xacro
@@ -176,7 +176,7 @@
     <link name="${prefix}tool0" />
     <joint name="${prefix}link_6-tool0" type="fixed">
       <origin xyz="0 0 0" rpy="${pi} ${-pi/2.0} 0" />
-      <parent link="${prefix}link_6" />
+      <parent link="${prefix}flange" />
       <child link="${prefix}tool0" />
     </joint>
   </xacro:macro>

--- a/fanuc_cr7ia_support/urdf/cr7ia_macro.xacro
+++ b/fanuc_cr7ia_support/urdf/cr7ia_macro.xacro
@@ -173,7 +173,7 @@
     <link name="${prefix}tool0" />
     <joint name="${prefix}link_6-tool0" type="fixed">
       <origin xyz="0 0 0" rpy="${pi} ${-pi/2.0} 0" />
-      <parent link="${prefix}link_6" />
+      <parent link="${prefix}flange" />
       <child link="${prefix}tool0" />
     </joint>
   </xacro:macro>

--- a/fanuc_cr7ia_support/urdf/cr7ial_macro.xacro
+++ b/fanuc_cr7ia_support/urdf/cr7ial_macro.xacro
@@ -174,7 +174,7 @@
     <link name="${prefix}tool0" />
     <joint name="${prefix}link_6-tool0" type="fixed">
       <origin xyz="0 0 0" rpy="${pi} ${-pi/2.0} 0" />
-      <parent link="${prefix}link_6" />
+      <parent link="${prefix}flange" />
       <child link="${prefix}tool0" />
     </joint>
   </xacro:macro>

--- a/fanuc_lrmate200i_support/urdf/lrmate200i_macro.xacro
+++ b/fanuc_lrmate200i_support/urdf/lrmate200i_macro.xacro
@@ -174,7 +174,7 @@
     <link name="${prefix}tool0" />
     <joint name="${prefix}link_6-tool0" type="fixed">
       <origin xyz="0 0 0" rpy="${pi} ${-pi/2.0} 0" />
-      <parent link="${prefix}link_6" />
+      <parent link="${prefix}flange" />
       <child link="${prefix}tool0" />
     </joint>
   </xacro:macro>

--- a/fanuc_lrmate200ib_support/urdf/lrmate200ib3l_macro.xacro
+++ b/fanuc_lrmate200ib_support/urdf/lrmate200ib3l_macro.xacro
@@ -174,7 +174,7 @@
     <link name="${prefix}tool0" />
     <joint name="${prefix}link_6-tool0" type="fixed">
       <origin xyz="0 0 0" rpy="${pi} ${-pi/2.0} 0" />
-      <parent link="${prefix}link_6" />
+      <parent link="${prefix}flange" />
       <child link="${prefix}tool0" />
     </joint>
   </xacro:macro>

--- a/fanuc_lrmate200ib_support/urdf/lrmate200ib_macro.xacro
+++ b/fanuc_lrmate200ib_support/urdf/lrmate200ib_macro.xacro
@@ -174,7 +174,7 @@
     <link name="${prefix}tool0" />
     <joint name="${prefix}link_6-tool0" type="fixed">
       <origin xyz="0 0 0" rpy="${pi} ${-pi/2.0} 0" />
-      <parent link="${prefix}link_6" />
+      <parent link="${prefix}flange" />
       <child link="${prefix}tool0" />
     </joint>
   </xacro:macro>

--- a/fanuc_lrmate200ic_support/urdf/lrmate200ic5f_macro.xacro
+++ b/fanuc_lrmate200ic_support/urdf/lrmate200ic5f_macro.xacro
@@ -152,7 +152,7 @@
     <link name="${prefix}tool0" />
     <joint name="${prefix}link_5-tool0" type="fixed">
       <origin xyz="0 0 0" rpy="${pi} ${-pi/2.0} 0" />
-      <parent link="${prefix}link_5" />
+      <parent link="${prefix}flange" />
       <child link="${prefix}tool0" />
     </joint>
   </xacro:macro>

--- a/fanuc_lrmate200ic_support/urdf/lrmate200ic5h_macro.xacro
+++ b/fanuc_lrmate200ic_support/urdf/lrmate200ic5h_macro.xacro
@@ -152,7 +152,7 @@
     <link name="${prefix}tool0" />
     <joint name="${prefix}link_5-tool0" type="fixed">
       <origin xyz="0 0 0" rpy="${pi} ${-pi/2.0} 0" />
-      <parent link="${prefix}link_5" />
+      <parent link="${prefix}flange" />
       <child link="${prefix}tool0" />
     </joint>
   </xacro:macro>

--- a/fanuc_lrmate200ic_support/urdf/lrmate200ic5hs_macro.xacro
+++ b/fanuc_lrmate200ic_support/urdf/lrmate200ic5hs_macro.xacro
@@ -152,7 +152,7 @@
     <link name="${prefix}tool0" />
     <joint name="${prefix}link_5-tool0" type="fixed">
       <origin xyz="0 0 0" rpy="${pi} ${-pi/2.0} 0" />
-      <parent link="${prefix}link_5" />
+      <parent link="${prefix}flange" />
       <child link="${prefix}tool0" />
     </joint>
   </xacro:macro>

--- a/fanuc_lrmate200ic_support/urdf/lrmate200ic5l_macro.xacro
+++ b/fanuc_lrmate200ic_support/urdf/lrmate200ic5l_macro.xacro
@@ -174,7 +174,7 @@
     <link name="${prefix}tool0" />
     <joint name="${prefix}link_6-tool0" type="fixed">
       <origin xyz="0 0 0" rpy="${pi} ${-pi/2.0} 0" />
-      <parent link="${prefix}link_6" />
+      <parent link="${prefix}flange" />
       <child link="${prefix}tool0" />
     </joint>
   </xacro:macro>

--- a/fanuc_lrmate200ic_support/urdf/lrmate200ic_macro.xacro
+++ b/fanuc_lrmate200ic_support/urdf/lrmate200ic_macro.xacro
@@ -174,7 +174,7 @@
     <link name="${prefix}tool0" />
     <joint name="${prefix}link_6-tool0" type="fixed">
       <origin xyz="0 0 0" rpy="${pi} ${-pi/2.0} 0" />
-      <parent link="${prefix}link_6" />
+      <parent link="${prefix}flange" />
       <child link="${prefix}tool0" />
     </joint>
   </xacro:macro>

--- a/fanuc_m10ia_support/urdf/m10ia7l_macro.xacro
+++ b/fanuc_m10ia_support/urdf/m10ia7l_macro.xacro
@@ -174,7 +174,7 @@
     <link name="${prefix}tool0" />
     <joint name="${prefix}link_6-tool0" type="fixed">
       <origin xyz="0 0 0" rpy="${pi} ${-pi/2.0} 0" />
-      <parent link="${prefix}link_6" />
+      <parent link="${prefix}flange" />
       <child link="${prefix}tool0" />
     </joint>
   </xacro:macro>

--- a/fanuc_m10ia_support/urdf/m10ia_macro.xacro
+++ b/fanuc_m10ia_support/urdf/m10ia_macro.xacro
@@ -174,7 +174,7 @@
     <link name="${prefix}tool0" />
     <joint name="${prefix}link_6-tool0" type="fixed">
       <origin xyz="0 0 0" rpy="${pi} ${-pi/2.0} 0" />
-      <parent link="${prefix}link_6" />
+      <parent link="${prefix}flange" />
       <child link="${prefix}tool0" />
     </joint>
   </xacro:macro>

--- a/fanuc_m16ib_support/urdf/m16ib20_macro.xacro
+++ b/fanuc_m16ib_support/urdf/m16ib20_macro.xacro
@@ -174,7 +174,7 @@
     <link name="${prefix}tool0" />
     <joint name="${prefix}link_6-tool0" type="fixed">
       <origin xyz="0 0 0" rpy="${pi} ${-pi/2.0} 0" />
-      <parent link="${prefix}link_6" />
+      <parent link="${prefix}flange" />
       <child link="${prefix}tool0" />
     </joint>
   </xacro:macro>

--- a/fanuc_m20ia_support/urdf/m20ia10l_macro.xacro
+++ b/fanuc_m20ia_support/urdf/m20ia10l_macro.xacro
@@ -174,7 +174,7 @@
     <link name="${prefix}tool0" />
     <joint name="${prefix}link_6-tool0" type="fixed">
       <origin xyz="0 0 0" rpy="${pi} ${-pi/2.0} 0" />
-      <parent link="${prefix}link_6" />
+      <parent link="${prefix}flange" />
       <child link="${prefix}tool0" />
     </joint>
   </xacro:macro>

--- a/fanuc_m20ia_support/urdf/m20ia_macro.xacro
+++ b/fanuc_m20ia_support/urdf/m20ia_macro.xacro
@@ -174,7 +174,7 @@
     <link name="${prefix}tool0" />
     <joint name="${prefix}link_6-tool0" type="fixed">
       <origin xyz="0 0 0" rpy="${pi} ${-pi/2.0} 0" />
-      <parent link="${prefix}link_6" />
+      <parent link="${prefix}flange" />
       <child link="${prefix}tool0" />
     </joint>
   </xacro:macro>

--- a/fanuc_m20ib_support/urdf/m20ib25_macro.xacro
+++ b/fanuc_m20ib_support/urdf/m20ib25_macro.xacro
@@ -174,7 +174,7 @@
     <link name="${prefix}tool0" />
     <joint name="${prefix}link_6-tool0" type="fixed">
       <origin xyz="0 0 0" rpy="${pi} ${-pi/2.0} 0" />
-      <parent link="${prefix}link_6" />
+      <parent link="${prefix}flange" />
       <child link="${prefix}tool0" />
     </joint>
   </xacro:macro>

--- a/fanuc_m430ia_support/urdf/m430ia2f_macro.xacro
+++ b/fanuc_m430ia_support/urdf/m430ia2f_macro.xacro
@@ -150,6 +150,11 @@
 
     <!-- ROS-Industrial 'tool0' frame: all-zeros tool frame -->
     <link name="${prefix}tool0" />
+    <!-- Note: instead of 'flange', we use 'link_5' as parent of this frame
+               as it already has the correct orientation and location for
+               'tool0'. Using 'flange' here would require additional rotations
+               to undo the rotation introduced by 'joint_5-flange'.
+     -->
     <joint name="${prefix}link_5-tool0" type="fixed">
       <origin xyz="0 0 0" rpy="0 0 0" />
       <parent link="${prefix}link_5" />

--- a/fanuc_m430ia_support/urdf/m430ia2p_macro.xacro
+++ b/fanuc_m430ia_support/urdf/m430ia2p_macro.xacro
@@ -172,6 +172,11 @@
 
     <!-- ROS-Industrial 'tool0' frame: all-zeros tool frame -->
     <link name="${prefix}tool0" />
+    <!-- Note: instead of 'flange', we use 'link_6' as parent of this frame
+               as it already has the correct orientation and location for
+               'tool0'. Using 'flange' here would require additional rotations
+               to undo the rotation introduced by 'joint_6-flange'.
+     -->
     <joint name="${prefix}link_6-tool0" type="fixed">
       <origin xyz="0 0 0" rpy="0 0 0" />
       <parent link="${prefix}link_6" />

--- a/fanuc_m6ib_support/urdf/m6ib_macro.xacro
+++ b/fanuc_m6ib_support/urdf/m6ib_macro.xacro
@@ -174,7 +174,7 @@
     <link name="${prefix}tool0" />
     <joint name="${prefix}link_6-tool0" type="fixed">
       <origin xyz="0 0 0" rpy="${pi} ${-pi/2.0} 0" />
-      <parent link="${prefix}link_6" />
+      <parent link="${prefix}flange" />
       <child link="${prefix}tool0" />
     </joint>
   </xacro:macro>

--- a/fanuc_m710ic_support/urdf/m710ic45m_macro.xacro
+++ b/fanuc_m710ic_support/urdf/m710ic45m_macro.xacro
@@ -175,7 +175,7 @@
     <link name="${prefix}tool0" />
     <joint name="${prefix}link_6-tool0" type="fixed">
       <origin xyz="0 0 0" rpy="${pi} ${-pi/2.0} 0" />
-      <parent link="${prefix}link_6" />
+      <parent link="${prefix}flange" />
       <child link="${prefix}tool0" />
     </joint>
   </xacro:macro>

--- a/fanuc_m710ic_support/urdf/m710ic50_macro.xacro
+++ b/fanuc_m710ic_support/urdf/m710ic50_macro.xacro
@@ -174,7 +174,7 @@
     <link name="${prefix}tool0" />
     <joint name="${prefix}link_6-tool0" type="fixed">
       <origin xyz="0 0 0" rpy="${pi} ${-pi/2.0} 0" />
-      <parent link="${prefix}link_6" />
+      <parent link="${prefix}flange" />
       <child link="${prefix}tool0" />
     </joint>
   </xacro:macro>

--- a/fanuc_m900ia_support/urdf/m900ia260l_macro.xacro
+++ b/fanuc_m900ia_support/urdf/m900ia260l_macro.xacro
@@ -220,7 +220,7 @@
     <link name="${prefix}tool0" />
     <joint name="${prefix}link_6-tool0" type="fixed">
       <origin xyz="0 0 0" rpy="${pi} ${-pi/2.0} 0" />
-      <parent link="${prefix}link_6" />
+      <parent link="${prefix}flange" />
       <child link="${prefix}tool0" />
     </joint>
   </xacro:macro>

--- a/fanuc_m900ib_support/urdf/m900ib700_macro.xacro
+++ b/fanuc_m900ib_support/urdf/m900ib700_macro.xacro
@@ -346,7 +346,7 @@
     <link name="${prefix}tool0" />
     <joint name="${prefix}link_6-tool0" type="fixed">
       <origin xyz="0 0 0" rpy="${pi} ${-pi/2.0} 0" />
-      <parent link="${prefix}link_6" />
+      <parent link="${prefix}flange" />
       <child link="${prefix}tool0" />
     </joint>
   </xacro:macro>

--- a/fanuc_r1000ia_support/urdf/r1000ia80f_macro.xacro
+++ b/fanuc_r1000ia_support/urdf/r1000ia80f_macro.xacro
@@ -174,7 +174,7 @@
     <link name="${prefix}tool0" />
     <joint name="${prefix}link_6-tool0" type="fixed">
       <origin xyz="0 0 0" rpy="${pi} ${-pi/2.0} 0" />
-      <parent link="${prefix}link_6" />
+      <parent link="${prefix}flange" />
       <child link="${prefix}tool0" />
     </joint>
   </xacro:macro>


### PR DESCRIPTION
As per subject.

This is in preparation of compliance with [Coordinate Frames for Serial Industrial
Manipulators](http://gavanderhoorn.github.io/rep/rep-0199.html) (but even without that REP makes sense, as `tool0` is not an attachment point, but a 'mathematical construct' (ie: coordinate frame)).
