### PR TITLE
Update build status badges in readme

### DIFF
--- a/readme.md
+++ b/readme.md
@@ -1,11 +1,12 @@
 # Fanuc
 
-[![Build Status](http://build.ros.org/job/Kdev__fanuc__ubuntu_xenial_amd64/badge/icon)](http://build.ros.org/job/Kdev__fanuc__ubuntu_xenial_amd64)
+[![Build Status: ROS buildfarm](https://build.ros.org/job/Kdev__fanuc__ubuntu_xenial_amd64/badge/icon)](http://build.ros.org/job/Kdev__fanuc__ubuntu_xenial_amd64)
+[![Build Status: Travis CI](https://travis-ci.org/ros-industrial/fanuc.svg?branch=indigo-devel)](https://travis-ci.org/ros-industrial/fanuc)
+
 [![license - apache 2.0](https://img.shields.io/:license-Apache%202.0-yellowgreen.svg)](https://opensource.org/licenses/Apache-2.0)
 [![license - bsd 3 clause](https://img.shields.io/:license-BSD%203--Clause-blue.svg)](https://opensource.org/licenses/BSD-3-Clause)
 
 [![support level: community](https://img.shields.io/badge/support%20level-community-lightgray.png)](http://rosindustrial.org/news/2016/10/7/better-supporting-a-growing-ros-industrial-software-platform)
-
 
 
 [ROS-Industrial][] Fanuc meta-package. See the [ROS wiki][] page for more information.

--- a/readme.md
+++ b/readme.md
@@ -1,6 +1,6 @@
 # Fanuc
 
-[![Build Status](http://build.ros.org/job/Idev__fanuc__ubuntu_trusty_amd64/badge/icon)](http://build.ros.org/job/Idev__fanuc__ubuntu_trusty_amd64)
+[![Build Status](http://build.ros.org/job/Kdev__fanuc__ubuntu_xenial_amd64/badge/icon)](http://build.ros.org/job/Kdev__fanuc__ubuntu_xenial_amd64)
 [![license - apache 2.0](https://img.shields.io/:license-Apache%202.0-yellowgreen.svg)](https://opensource.org/licenses/Apache-2.0)
 [![license - bsd 3 clause](https://img.shields.io/:license-BSD%203--Clause-blue.svg)](https://opensource.org/licenses/BSD-3-Clause)
 


### PR DESCRIPTION
As per subject.

The buildfarm status will not show a badge until ros/rosdistro#22328 is merged.
