### PR TITLE
all: remove roslaunch version requirements.

### DIFF
--- a/fanuc_driver/package.xml
+++ b/fanuc_driver/package.xml
@@ -25,7 +25,7 @@
 
   <depend>industrial_robot_client</depend>
 
-  <test_depend version_gte="1.9.55">roslaunch</test_depend>
+  <test_depend>roslaunch</test_depend>
 
   <export>
     <rosindex>

--- a/fanuc_lrmate200ib_support/package.xml
+++ b/fanuc_lrmate200ib_support/package.xml
@@ -39,7 +39,7 @@
 
   <buildtool_depend>catkin</buildtool_depend>
 
-  <test_depend version_gte="1.9.55">roslaunch</test_depend>
+  <test_depend>roslaunch</test_depend>
 
   <exec_depend>fanuc_driver</exec_depend>
   <exec_depend>fanuc_resources</exec_depend>

--- a/fanuc_lrmate200ic_support/package.xml
+++ b/fanuc_lrmate200ic_support/package.xml
@@ -43,7 +43,7 @@
 
   <buildtool_depend>catkin</buildtool_depend>
 
-  <test_depend version_gte="1.9.55">roslaunch</test_depend>
+  <test_depend>roslaunch</test_depend>
 
   <exec_depend>fanuc_driver</exec_depend>
   <exec_depend>fanuc_resources</exec_depend>

--- a/fanuc_m10ia_support/package.xml
+++ b/fanuc_m10ia_support/package.xml
@@ -40,7 +40,7 @@
 
   <buildtool_depend>catkin</buildtool_depend>
 
-  <test_depend version_gte="1.9.55">roslaunch</test_depend>
+  <test_depend>roslaunch</test_depend>
 
   <exec_depend>fanuc_driver</exec_depend>
   <exec_depend>fanuc_resources</exec_depend>

--- a/fanuc_m16ib_support/package.xml
+++ b/fanuc_m16ib_support/package.xml
@@ -40,7 +40,7 @@
 
   <buildtool_depend>catkin</buildtool_depend>
 
-  <test_depend version_gte="1.9.55">roslaunch</test_depend>
+  <test_depend>roslaunch</test_depend>
 
   <exec_depend>fanuc_driver</exec_depend>
   <exec_depend>fanuc_resources</exec_depend>

--- a/fanuc_m20ia_support/package.xml
+++ b/fanuc_m20ia_support/package.xml
@@ -45,7 +45,7 @@
 
   <buildtool_depend>catkin</buildtool_depend>
 
-  <test_depend version_gte="1.9.55">roslaunch</test_depend>
+  <test_depend>roslaunch</test_depend>
 
   <exec_depend>fanuc_driver</exec_depend>
   <exec_depend>fanuc_resources</exec_depend>

--- a/fanuc_m430ia_support/package.xml
+++ b/fanuc_m430ia_support/package.xml
@@ -39,7 +39,7 @@
 
   <buildtool_depend>catkin</buildtool_depend>
 
-  <test_depend version_gte="1.9.55">roslaunch</test_depend>
+  <test_depend>roslaunch</test_depend>
 
   <exec_depend>fanuc_driver</exec_depend>
   <exec_depend>fanuc_resources</exec_depend>

--- a/fanuc_m6ib_support/package.xml
+++ b/fanuc_m6ib_support/package.xml
@@ -41,7 +41,7 @@
 
   <buildtool_depend>catkin</buildtool_depend>
 
-  <test_depend version_gte="1.9.55">roslaunch</test_depend>
+  <test_depend>roslaunch</test_depend>
 
   <exec_depend>fanuc_driver</exec_depend>
   <exec_depend>fanuc_resources</exec_depend>

--- a/fanuc_m710ic_support/package.xml
+++ b/fanuc_m710ic_support/package.xml
@@ -35,7 +35,7 @@
 
   <buildtool_depend>catkin</buildtool_depend>
 
-  <test_depend version_gte="1.9.55">roslaunch</test_depend>
+  <test_depend>roslaunch</test_depend>
 
   <exec_depend>fanuc_driver</exec_depend>
   <exec_depend>fanuc_resources</exec_depend>

--- a/fanuc_m900ia_support/package.xml
+++ b/fanuc_m900ia_support/package.xml
@@ -39,7 +39,7 @@
 
   <buildtool_depend>catkin</buildtool_depend>
 
-  <test_depend version_gte="1.9.55">roslaunch</test_depend>
+  <test_depend>roslaunch</test_depend>
 
   <exec_depend>fanuc_driver</exec_depend>
   <exec_depend>fanuc_resources</exec_depend>

--- a/fanuc_r1000ia_support/package.xml
+++ b/fanuc_r1000ia_support/package.xml
@@ -38,7 +38,7 @@
 
   <buildtool_depend>catkin</buildtool_depend>
 
-  <test_depend version_gte="1.9.55">roslaunch</test_depend>
+  <test_depend>roslaunch</test_depend>
 
   <exec_depend>fanuc_driver</exec_depend>
   <exec_depend>fanuc_resources</exec_depend>


### PR DESCRIPTION
As per subject.

No functional changes.

This was introduced in <del>#162</del> #131 to ensure that the version of `roslaunch` would support the testing infrastructure we're using. As this is now supported in all versions of `roslaunch`, we no longer need the version specification.
