### PR TITLE
driver: force Windows EOL on TP and KL sources.

### DIFF
--- a/fanuc_driver/.gitattributes
+++ b/fanuc_driver/.gitattributes
@@ -1,0 +1,3 @@
+# LS and Karel source files must have CRLF (ie: Windows) line-endings.
+*.kl text eol=crlf
+*.ls text eol=crlf


### PR DESCRIPTION
As per subject.

No functional changes.
