### PR TITLE
Fix issue #83: add comments to TP Ps, PRs and Fs

### DIFF
--- a/fanuc_driver/tpe/ros_movesm.ls
+++ b/fanuc_driver/tpe/ros_movesm.ls
@@ -1,10 +1,10 @@
 /PROG  ROS_MOVESM
 /ATTR
 OWNER		= MNEDITOR;
-COMMENT		= "r2";
+COMMENT		= "r3";
 PROG_SIZE	= 548;
 CREATE		= DATE 12-10-02  TIME 12:08:46;
-MODIFIED	= DATE 13-04-28  TIME 18:20:26;
+MODIFIED	= DATE 19-10-08  TIME 20:04:26;
 FILE_NAME	= ;
 VERSION		= 0;
 LINE_COUNT	= 25;
@@ -21,26 +21,26 @@ CONTROL_CODE	= 00000000 00000000;
 /MN
    1:   ;
    2:  !init: not rdy, no ack ;
-   3:  F[1]=(OFF) ;
-   4:  F[2]=(OFF) ;
+   3:  F[1:ROS-I rdy]=(OFF) ;
+   4:  F[2:ROS-I drdy]=(OFF) ;
    5:   ;
    6:  LBL[10] ;
    7:   ;
    8:  !we're ready for new point ;
-   9:  F[1]=(ON) ;
+   9:  F[1:ROS-I rdy]=(ON) ;
   10:   ;
   11:  !wait for relay ;
-  12:  WAIT (F[2])    ;
+  12:  WAIT (F[2:ROS-I drdy])    ;
   13:   ;
   14:  !cache in temp preg ;
-  15:  PR[2]=PR[1]    ;
+  15:  PR[2:ROS-I p cache]=PR[1:ROS-I pos]    ;
   16:   ;
   17:  !first rdy low, then ack copy ;
-  18:  F[1]=(OFF) ;
-  19:  F[2]=(OFF) ;
+  18:  F[1:ROS-I rdy]=(OFF) ;
+  19:  F[2:ROS-I drdy]=(OFF) ;
   20:   ;
   21:  !move to point ;
-  22:J PR[2] R[1]% CNT R[2]    ;
+  22:J PR[2:ROS-I p cache] R[1:ROS-I spd]% CNT R[2:ROS-I cnt]    ;
   23:   ;
   24:  !done, repeat ;
   25:  JMP LBL[10] ;


### PR DESCRIPTION
As per subject.

These will be applied to the actual Ps, PRs and Fs on the controller when the `.tp` is loaded.

No functional changes.

This is a draft for now, as I need to verify this on real hw.
