### PR TITLE
Point to manifest (ie: package.xml) for info on package contents

### DIFF
--- a/fanuc_cr35ia_support/readme.md
+++ b/fanuc_cr35ia_support/readme.md
@@ -5,6 +5,10 @@
 This package is part of the [ROS-Industrial][] program. See the main
 [fanuc][] page on the ROS wiki for more information on usage.
 
+## Contents
+
+See `package.xml` for information about the contents of this package.
+
 
 [ROS-Industrial]: http://wiki.ros.org/Industrial
 [fanuc]: http://wiki.ros.org/fanuc

--- a/fanuc_cr7ia_moveit_config/readme.md
+++ b/fanuc_cr7ia_moveit_config/readme.md
@@ -5,6 +5,10 @@
 This package is part of the [ROS-Industrial][] program. See the main
 [fanuc][] page on the ROS wiki for more information on usage.
 
+## Contents
+
+See `package.xml` for information about the contents of this package.
+
 ## Known issues
 
 Please see the [known issues][] page on the ROS wiki.

--- a/fanuc_cr7ia_support/readme.md
+++ b/fanuc_cr7ia_support/readme.md
@@ -5,6 +5,10 @@
 This package is part of the [ROS-Industrial][] program. See the main
 [fanuc][] page on the ROS wiki for more information on usage.
 
+## Contents
+
+See `package.xml` for information about the contents of this package.
+
 
 [ROS-Industrial]: http://wiki.ros.org/Industrial
 [fanuc]: http://wiki.ros.org/fanuc

--- a/fanuc_cr7ial_moveit_config/readme.md
+++ b/fanuc_cr7ial_moveit_config/readme.md
@@ -5,6 +5,10 @@
 This package is part of the [ROS-Industrial][] program. See the main
 [fanuc][] page on the ROS wiki for more information on usage.
 
+## Contents
+
+See `package.xml` for information about the contents of this package.
+
 ## Known issues
 
 Please see the [known issues][] page on the ROS wiki.

--- a/fanuc_lrmate200i_moveit_config/readme.md
+++ b/fanuc_lrmate200i_moveit_config/readme.md
@@ -5,6 +5,10 @@
 This package is part of the [ROS-Industrial][] program. See the main
 [fanuc][] page on the ROS wiki for more information on usage.
 
+## Contents
+
+See `package.xml` for information about the contents of this package.
+
 ## Known issues
 
 Please see the [known issues][] page on the ROS wiki.

--- a/fanuc_lrmate200i_moveit_plugins/readme.md
+++ b/fanuc_lrmate200i_moveit_plugins/readme.md
@@ -5,6 +5,10 @@
 This package is part of the [ROS-Industrial][] program. See the main
 [fanuc][] page on the ROS wiki for more information on usage.
 
+## Contents
+
+See `package.xml` for information about the contents of this package.
+
 
 [ROS-Industrial]: http://wiki.ros.org/Industrial
 [fanuc]: http://wiki.ros.org/fanuc

--- a/fanuc_lrmate200i_support/readme.md
+++ b/fanuc_lrmate200i_support/readme.md
@@ -5,6 +5,10 @@
 This package is part of the [ROS-Industrial][] program. See the main
 [fanuc][] page on the ROS wiki for more information on usage.
 
+## Contents
+
+See `package.xml` for information about the contents of this package.
+
 
 [ROS-Industrial]: http://wiki.ros.org/Industrial
 [fanuc]: http://wiki.ros.org/fanuc

--- a/fanuc_lrmate200ib3l_moveit_config/readme.md
+++ b/fanuc_lrmate200ib3l_moveit_config/readme.md
@@ -5,6 +5,10 @@
 This package is part of the [ROS-Industrial][] program. See the main
 [fanuc][] page on the ROS wiki for more information on usage.
 
+## Contents
+
+See `package.xml` for information about the contents of this package.
+
 ## Known issues
 
 Please see the [known issues][] page on the ROS wiki.

--- a/fanuc_lrmate200ib_moveit_config/readme.md
+++ b/fanuc_lrmate200ib_moveit_config/readme.md
@@ -5,6 +5,10 @@
 This package is part of the [ROS-Industrial][] program. See the main
 [fanuc][] page on the ROS wiki for more information on usage.
 
+## Contents
+
+See `package.xml` for information about the contents of this package.
+
 ## Known issues
 
 Please see the [known issues][] page on the ROS wiki.

--- a/fanuc_lrmate200ib_moveit_plugins/readme.md
+++ b/fanuc_lrmate200ib_moveit_plugins/readme.md
@@ -5,6 +5,10 @@
 This package is part of the [ROS-Industrial][] program. See the main
 [fanuc][] page on the ROS wiki for more information on usage.
 
+## Contents
+
+See `package.xml` for information about the contents of this package.
+
 
 [ROS-Industrial]: http://wiki.ros.org/Industrial
 [fanuc]: http://wiki.ros.org/fanuc

--- a/fanuc_lrmate200ib_support/readme.md
+++ b/fanuc_lrmate200ib_support/readme.md
@@ -5,6 +5,10 @@
 This package is part of the [ROS-Industrial][] program. See the main
 [fanuc][] page on the ROS wiki for more information on usage.
 
+## Contents
+
+See `package.xml` for information about the contents of this package.
+
 
 [ROS-Industrial]: http://wiki.ros.org/Industrial
 [fanuc]: http://wiki.ros.org/fanuc

--- a/fanuc_lrmate200ic5h_moveit_config/readme.md
+++ b/fanuc_lrmate200ic5h_moveit_config/readme.md
@@ -5,6 +5,10 @@
 This package is part of the [ROS-Industrial][] program. See the main [fanuc][]
 page on the ROS wiki for more information on usage.
 
+## Contents
+
+See `package.xml` for information about the contents of this package.
+
 ## Known issues
 
 Please see the [known issues][] page on the ROS wiki.

--- a/fanuc_lrmate200ic5l_moveit_config/readme.md
+++ b/fanuc_lrmate200ic5l_moveit_config/readme.md
@@ -5,6 +5,10 @@
 This package is part of the [ROS-Industrial][] program. See the main [fanuc][]
 page on the ROS wiki for more information on usage.
 
+## Contents
+
+See `package.xml` for information about the contents of this package.
+
 ## Known issues
 
 Please see the [known issues][] page on the ROS wiki.

--- a/fanuc_lrmate200ic_moveit_config/readme.md
+++ b/fanuc_lrmate200ic_moveit_config/readme.md
@@ -5,6 +5,10 @@
 This package is part of the [ROS-Industrial][] program. See the main [fanuc][]
 page on the ROS wiki for more information on usage.
 
+## Contents
+
+See `package.xml` for information about the contents of this package.
+
 ## Known issues
 
 Please see the [known issues][] page on the ROS wiki.

--- a/fanuc_lrmate200ic_moveit_plugins/readme.md
+++ b/fanuc_lrmate200ic_moveit_plugins/readme.md
@@ -5,6 +5,10 @@
 This package is part of the [ROS-Industrial][] program. See the main [fanuc][]
 page on the ROS wiki for more information on usage.
 
+## Contents
+
+See `package.xml` for information about the contents of this package.
+
 
 [ROS-Industrial]: http://wiki.ros.org/Industrial
 [fanuc]: http://wiki.ros.org/fanuc

--- a/fanuc_lrmate200ic_support/readme.md
+++ b/fanuc_lrmate200ic_support/readme.md
@@ -5,6 +5,10 @@
 This package is part of the [ROS-Industrial][] program. See the main [fanuc][]
 page on the ROS wiki for more information on usage.
 
+## Contents
+
+See `package.xml` for information about the contents of this package.
+
 
 [ROS-Industrial]: http://wiki.ros.org/Industrial
 [fanuc]: http://wiki.ros.org/fanuc

--- a/fanuc_m10ia_moveit_config/readme.md
+++ b/fanuc_m10ia_moveit_config/readme.md
@@ -5,6 +5,10 @@
 This package is part of the [ROS-Industrial][] program. See the main [fanuc][]
 page on the ROS wiki for more information on usage.
 
+## Contents
+
+See `package.xml` for information about the contents of this package.
+
 ## Known issues
 
 Please see the [known issues][] page on the ROS wiki.

--- a/fanuc_m10ia_moveit_plugins/readme.md
+++ b/fanuc_m10ia_moveit_plugins/readme.md
@@ -5,6 +5,10 @@
 This package is part of the [ROS-Industrial][] program. See the main [fanuc][]
 page on the ROS wiki for more information on usage.
 
+## Contents
+
+See `package.xml` for information about the contents of this package.
+
 
 [ROS-Industrial]: http://wiki.ros.org/Industrial
 [fanuc]: http://wiki.ros.org/fanuc

--- a/fanuc_m10ia_support/readme.md
+++ b/fanuc_m10ia_support/readme.md
@@ -5,6 +5,10 @@
 This package is part of the [ROS-Industrial][] program. See the main [fanuc][]
 page on the ROS wiki for more information on usage.
 
+## Contents
+
+See `package.xml` for information about the contents of this package.
+
 
 [ROS-Industrial]: http://wiki.ros.org/Industrial
 [fanuc]: http://wiki.ros.org/fanuc

--- a/fanuc_m16ib20_moveit_config/readme.md
+++ b/fanuc_m16ib20_moveit_config/readme.md
@@ -5,6 +5,10 @@
 This package is part of the [ROS-Industrial][] program. See the main [fanuc][]
 page on the ROS wiki for more information on usage.
 
+## Contents
+
+See `package.xml` for information about the contents of this package.
+
 ## Known issues
 
 Please see the [known issues][] page on the ROS wiki.

--- a/fanuc_m16ib_moveit_plugins/readme.md
+++ b/fanuc_m16ib_moveit_plugins/readme.md
@@ -5,6 +5,10 @@
 This package is part of the [ROS-Industrial][] program. See the main [fanuc][]
 page on the ROS wiki for more information on usage.
 
+## Contents
+
+See `package.xml` for information about the contents of this package.
+
 
 [ROS-Industrial]: http://wiki.ros.org/Industrial
 [fanuc]: http://wiki.ros.org/fanuc

--- a/fanuc_m16ib_support/readme.md
+++ b/fanuc_m16ib_support/readme.md
@@ -5,6 +5,10 @@
 This package is part of the [ROS-Industrial][] program. See the main [fanuc][]
 page on the ROS wiki for more information on usage.
 
+## Contents
+
+See `package.xml` for information about the contents of this package.
+
 
 [ROS-Industrial]: http://wiki.ros.org/Industrial
 [fanuc]: http://wiki.ros.org/fanuc

--- a/fanuc_m20ia10l_moveit_config/readme.md
+++ b/fanuc_m20ia10l_moveit_config/readme.md
@@ -5,6 +5,10 @@
 This package is part of the [ROS-Industrial][] program. See the main [fanuc][]
 page on the ROS wiki for more information on usage.
 
+## Contents
+
+See `package.xml` for information about the contents of this package.
+
 ## Known issues
 
 Please see the [known issues][] page on the ROS wiki.

--- a/fanuc_m20ia_moveit_config/readme.md
+++ b/fanuc_m20ia_moveit_config/readme.md
@@ -5,6 +5,10 @@
 This package is part of the [ROS-Industrial][] program. See the main [fanuc][]
 page on the ROS wiki for more information on usage.
 
+## Contents
+
+See `package.xml` for information about the contents of this package.
+
 ## Known issues
 
 Please see the [known issues][] page on the ROS wiki.

--- a/fanuc_m20ia_moveit_plugins/readme.md
+++ b/fanuc_m20ia_moveit_plugins/readme.md
@@ -5,6 +5,10 @@
 This package is part of the [ROS-Industrial][] program. See the main [fanuc][]
 page on the ROS wiki for more information on usage.
 
+## Contents
+
+See `package.xml` for information about the contents of this package.
+
 
 [ROS-Industrial]: http://wiki.ros.org/Industrial
 [fanuc]: http://wiki.ros.org/fanuc

--- a/fanuc_m20ia_support/readme.md
+++ b/fanuc_m20ia_support/readme.md
@@ -5,6 +5,10 @@
 This package is part of the [ROS-Industrial][] program. See the main [fanuc][]
 page on the ROS wiki for more information on usage.
 
+## Contents
+
+See `package.xml` for information about the contents of this package.
+
 
 [ROS-Industrial]: http://wiki.ros.org/Industrial
 [fanuc]: http://wiki.ros.org/fanuc

--- a/fanuc_m20ib25_moveit_config/readme.md
+++ b/fanuc_m20ib25_moveit_config/readme.md
@@ -5,6 +5,10 @@
 This package is part of the [ROS-Industrial][] program. See the main
 [fanuc][] page on the ROS wiki for more information on usage.
 
+## Contents
+
+See `package.xml` for information about the contents of this package.
+
 ## Known issues
 
 Please see the [known issues][] page on the ROS wiki.

--- a/fanuc_m20ib_moveit_plugins/readme.md
+++ b/fanuc_m20ib_moveit_plugins/readme.md
@@ -5,6 +5,10 @@
 This package is part of the [ROS-Industrial][] program. See the main
 [fanuc][] page on the ROS wiki for more information on usage.
 
+## Contents
+
+See `package.xml` for information about the contents of this package.
+
 
 [ROS-Industrial]: http://wiki.ros.org/Industrial
 [fanuc]: http://wiki.ros.org/fanuc

--- a/fanuc_m20ib_support/readme.md
+++ b/fanuc_m20ib_support/readme.md
@@ -5,6 +5,10 @@
 This package is part of the [ROS-Industrial][] program. See the main [fanuc][]
 page on the ROS wiki for more information on usage.
 
+## Contents
+
+See `package.xml` for information about the contents of this package.
+
 
 [ROS-Industrial]: http://wiki.ros.org/Industrial
 [fanuc]: http://wiki.ros.org/fanuc

--- a/fanuc_m430ia2f_moveit_config/readme.md
+++ b/fanuc_m430ia2f_moveit_config/readme.md
@@ -5,6 +5,10 @@
 This package is part of the [ROS-Industrial][] program. See the main [fanuc][]
 page on the ROS wiki for more information on usage.
 
+## Contents
+
+See `package.xml` for information about the contents of this package.
+
 ## Known issues
 
 Please see the [known issues][] page on the ROS wiki.

--- a/fanuc_m430ia2p_moveit_config/readme.md
+++ b/fanuc_m430ia2p_moveit_config/readme.md
@@ -5,6 +5,10 @@
 This package is part of the [ROS-Industrial][] program. See the main [fanuc][]
 page on the ROS wiki for more information on usage.
 
+## Contents
+
+See `package.xml` for information about the contents of this package.
+
 ## Known issues
 
 Please see the [known issues][] page on the ROS wiki.

--- a/fanuc_m430ia_moveit_plugins/readme.md
+++ b/fanuc_m430ia_moveit_plugins/readme.md
@@ -5,6 +5,10 @@
 This package is part of the [ROS-Industrial][] program. See the main [fanuc][]
 page on the ROS wiki for more information on usage.
 
+## Contents
+
+See `package.xml` for information about the contents of this package.
+
 
 [ROS-Industrial]: http://wiki.ros.org/Industrial
 [fanuc]: http://wiki.ros.org/fanuc

--- a/fanuc_m430ia_support/readme.md
+++ b/fanuc_m430ia_support/readme.md
@@ -5,6 +5,10 @@
 This package is part of the [ROS-Industrial][] program. See the main [fanuc][]
 page on the ROS wiki for more information on usage.
 
+## Contents
+
+See `package.xml` for information about the contents of this package.
+
 
 [ROS-Industrial]: http://wiki.ros.org/Industrial
 [fanuc]: http://wiki.ros.org/fanuc

--- a/fanuc_m6ib6s_moveit_config/readme.md
+++ b/fanuc_m6ib6s_moveit_config/readme.md
@@ -5,6 +5,10 @@
 This package is part of the [ROS-Industrial][] program. See the main
 [fanuc][] page on the ROS wiki for more information on usage.
 
+## Contents
+
+See `package.xml` for information about the contents of this package.
+
 ## Known issues
 
 Please see the [known issues][] page on the ROS wiki.

--- a/fanuc_m6ib_moveit_config/readme.md
+++ b/fanuc_m6ib_moveit_config/readme.md
@@ -5,6 +5,10 @@
 This package is part of the [ROS-Industrial][] program. See the main
 [fanuc][] page on the ROS wiki for more information on usage.
 
+## Contents
+
+See `package.xml` for information about the contents of this package.
+
 ## Known issues
 
 Please see the [known issues][] page on the ROS wiki.

--- a/fanuc_m6ib_moveit_plugins/readme.md
+++ b/fanuc_m6ib_moveit_plugins/readme.md
@@ -5,6 +5,10 @@
 This package is part of the [ROS-Industrial][] program. See the main
 [fanuc][] page on the ROS wiki for more information on usage.
 
+## Contents
+
+See `package.xml` for information about the contents of this package.
+
 
 [ROS-Industrial]: http://wiki.ros.org/Industrial
 [fanuc]: http://wiki.ros.org/fanuc

--- a/fanuc_m6ib_support/readme.md
+++ b/fanuc_m6ib_support/readme.md
@@ -5,6 +5,10 @@
 This package is part of the [ROS-Industrial][] program. See the main
 [fanuc][] page on the ROS wiki for more information on usage.
 
+## Contents
+
+See `package.xml` for information about the contents of this package.
+
 
 [ROS-Industrial]: http://wiki.ros.org/Industrial
 [fanuc]: http://wiki.ros.org/fanuc

--- a/fanuc_m710ic_support/readme.md
+++ b/fanuc_m710ic_support/readme.md
@@ -5,6 +5,10 @@
 This package is part of the [ROS-Industrial][] program. See the main
 [fanuc][] page on the ROS wiki for more information on usage.
 
+## Contents
+
+See `package.xml` for information about the contents of this package.
+
 
 [ROS-Industrial]: http://wiki.ros.org/Industrial
 [fanuc]: http://wiki.ros.org/fanuc

--- a/fanuc_m900ia_support/readme.md
+++ b/fanuc_m900ia_support/readme.md
@@ -5,6 +5,10 @@
 This package is part of the [ROS-Industrial][] program. See the main
 [fanuc][] page on the ROS wiki for more information on usage.
 
+## Contents
+
+See `package.xml` for information about the contents of this package.
+
 
 [ROS-Industrial]: http://wiki.ros.org/Industrial
 [fanuc]: http://wiki.ros.org/fanuc

--- a/fanuc_m900ib_support/readme.md
+++ b/fanuc_m900ib_support/readme.md
@@ -5,6 +5,10 @@
 This package is part of the [ROS-Industrial][] program. See the main
 [fanuc][] page on the ROS wiki for more information on usage.
 
+## Contents
+
+See `package.xml` for information about the contents of this package.
+
 
 [ROS-Industrial]: http://wiki.ros.org/Industrial
 [fanuc]: http://wiki.ros.org/fanuc

--- a/fanuc_r1000ia80f_moveit_config/readme.md
+++ b/fanuc_r1000ia80f_moveit_config/readme.md
@@ -5,6 +5,10 @@
 This package is part of the [ROS-Industrial][] program. See the main
 [fanuc][] page on the ROS wiki for more information on usage.
 
+## Contents
+
+See `package.xml` for information about the contents of this package.
+
 ## Known issues
 
 Please see the [known issues][] page on the ROS wiki.

--- a/fanuc_r1000ia_moveit_plugins/readme.md
+++ b/fanuc_r1000ia_moveit_plugins/readme.md
@@ -5,6 +5,10 @@
 This package is part of the [ROS-Industrial][] program. See the main
 [fanuc][] page on the ROS wiki for more information on usage.
 
+## Contents
+
+See `package.xml` for information about the contents of this package.
+
 
 [ROS-Industrial]: http://wiki.ros.org/Industrial
 [fanuc]: http://wiki.ros.org/fanuc

--- a/fanuc_r1000ia_support/readme.md
+++ b/fanuc_r1000ia_support/readme.md
@@ -5,6 +5,10 @@
 This package is part of the [ROS-Industrial][] program. See the main
 [fanuc][] page on the ROS wiki for more information on usage.
 
+## Contents
+
+See `package.xml` for information about the contents of this package.
+
 
 [ROS-Industrial]: http://wiki.ros.org/Industrial
 [fanuc]: http://wiki.ros.org/fanuc

--- a/fanuc_resources/readme.md
+++ b/fanuc_resources/readme.md
@@ -5,6 +5,10 @@
 This package is part of the [ROS-Industrial][] program. See the main [fanuc][]
 page on the ROS wiki for more information on usage.
 
+## Contents
+
+See `package.xml` for information about the contents of this package.
+
 
 [ROS-Industrial]: http://wiki.ros.org/Industrial
 [fanuc]: http://wiki.ros.org/fanuc


### PR DESCRIPTION
As per subject.

I actually get quite some questions as to which specific variants or models are supported by a package.

As the readme is the likely entry-point for someone looking for more information, but I don't want to duplicate the contents from the `description` section of the manifest, I'll just refer users to `package.xml` for now and see whether that works.
