### PR TITLE
support: specify OPW joint offsets in degrees.

### DIFF
--- a/fanuc_lrmate200ib_support/config/opw_parameters_lrmate200ib.yaml
+++ b/fanuc_lrmate200ib_support/config/opw_parameters_lrmate200ib.yaml
@@ -16,5 +16,5 @@ opw_kinematics_geometric_parameters:
   c2: 0.25
   c3: 0.290
   c4: 0.08
-opw_kinematics_joint_offsets: [0.0, 0.0, -1.5707963267948966, 0.0, 0.0, 3.14159265359]
+opw_kinematics_joint_offsets: [0.0, 0.0, deg(-90.0), 0.0, 0.0, deg(180.0)]
 opw_kinematics_joint_sign_corrections: [1, 1, -1, -1, -1, -1]

--- a/fanuc_lrmate200ib_support/config/opw_parameters_lrmate200ib3l.yaml
+++ b/fanuc_lrmate200ib_support/config/opw_parameters_lrmate200ib3l.yaml
@@ -16,5 +16,5 @@ opw_kinematics_geometric_parameters:
   c2: 0.25
   c3: 0.450
   c4: 0.080
-opw_kinematics_joint_offsets: [0.0, 0.0, -1.57079632679, 0.0, 0.0, 3.14159265359]
+opw_kinematics_joint_offsets: [0.0, 0.0, deg(-90.0), 0.0, 0.0, deg(180.0)]
 opw_kinematics_joint_sign_corrections: [1, 1, -1, -1, -1, -1]

--- a/fanuc_lrmate200ic_support/config/opw_parameters_lrmate200ic.yaml
+++ b/fanuc_lrmate200ic_support/config/opw_parameters_lrmate200ic.yaml
@@ -16,5 +16,5 @@ opw_kinematics_geometric_parameters:
   c2: 0.3
   c3: 0.32
   c4: 0.08
-opw_kinematics_joint_offsets: [0.0, 0.0, -1.57079632679, 0.0, 0.0, 3.14159265359]
+opw_kinematics_joint_offsets: [0.0, 0.0, deg(-90.0), 0.0, 0.0, deg(180.0)]
 opw_kinematics_joint_sign_corrections: [1, 1, -1, -1, -1, -1]

--- a/fanuc_lrmate200ic_support/config/opw_parameters_lrmate200ic5l.yaml
+++ b/fanuc_lrmate200ic_support/config/opw_parameters_lrmate200ic5l.yaml
@@ -16,5 +16,5 @@ opw_kinematics_geometric_parameters:
   c2: 0.40
   c3: 0.41
   c4: 0.08
-opw_kinematics_joint_offsets: [0.0, 0.0, -1.57079632679, 0.0, 0.0, 3.14159265359]
+opw_kinematics_joint_offsets: [0.0, 0.0, deg(-90.0), 0.0, 0.0, deg(180.0)]
 opw_kinematics_joint_sign_corrections: [1, 1, -1, -1, -1, -1]

--- a/fanuc_m10ia_support/config/opw_parameters_m10ia.yaml
+++ b/fanuc_m10ia_support/config/opw_parameters_m10ia.yaml
@@ -16,5 +16,5 @@ opw_kinematics_geometric_parameters:
   c2: 0.60
   c3: 0.64
   c4: 0.10
-opw_kinematics_joint_offsets: [0.0, 0.0, -1.57079632679, 0.0, 0.0, 3.14159265359]
+opw_kinematics_joint_offsets: [0.0, 0.0, deg(-90.0), 0.0, 0.0, deg(180.0)]
 opw_kinematics_joint_sign_corrections: [1, 1, -1, -1, -1, -1]

--- a/fanuc_m10ia_support/config/opw_parameters_m10ia7l.yaml
+++ b/fanuc_m10ia_support/config/opw_parameters_m10ia7l.yaml
@@ -16,5 +16,5 @@ opw_kinematics_geometric_parameters:
   c2: 0.60
   c3: 0.86
   c4: 0.10
-opw_kinematics_joint_offsets: [0.0, 0.0, -1.57079632679, 0.0, 0.0, 3.14159265359]
+opw_kinematics_joint_offsets: [0.0, 0.0, deg(-90.0), 0.0, 0.0, deg(180.0)]
 opw_kinematics_joint_sign_corrections: [1, 1, -1, -1, -1, -1]

--- a/fanuc_m16ib_support/config/opw_parameters_m16ib20.yaml
+++ b/fanuc_m16ib_support/config/opw_parameters_m16ib20.yaml
@@ -16,5 +16,5 @@ opw_kinematics_geometric_parameters:
   c2: 0.77
   c3: 0.74
   c4: 0.10
-opw_kinematics_joint_offsets: [0.0, 0.0, -1.57079632679, 0.0, 0.0, 3.14159265359]
+opw_kinematics_joint_offsets: [0.0, 0.0, deg(-90.0), 0.0, 0.0, deg(180.0)]
 opw_kinematics_joint_sign_corrections: [1, 1, -1, -1, -1, -1]

--- a/fanuc_m20ia_support/config/opw_parameters_m20ia.yaml
+++ b/fanuc_m20ia_support/config/opw_parameters_m20ia.yaml
@@ -16,5 +16,5 @@ opw_kinematics_geometric_parameters:
   c2: 0.79
   c3: 0.835
   c4: 0.10
-opw_kinematics_joint_offsets: [0.0, 0.0, -1.57079632679, 0.0, 0.0, 3.14159265359]
+opw_kinematics_joint_offsets: [0.0, 0.0, deg(-90.0), 0.0, 0.0, deg(180.0)]
 opw_kinematics_joint_sign_corrections: [1, 1, -1, -1, -1, -1]

--- a/fanuc_m20ia_support/config/opw_parameters_m20ia10l.yaml
+++ b/fanuc_m20ia_support/config/opw_parameters_m20ia10l.yaml
@@ -16,5 +16,5 @@ opw_kinematics_geometric_parameters:
   c2: 0.79
   c3: 1.04
   c4: 0.10
-opw_kinematics_joint_offsets: [0.0, 0.0, -1.57079632679, 0.0, 0.0, 3.14159265359]
+opw_kinematics_joint_offsets: [0.0, 0.0, deg(-90.0), 0.0, 0.0, deg(180.0)]
 opw_kinematics_joint_sign_corrections: [1, 1, -1, -1, -1, -1]

--- a/fanuc_m6ib_support/config/opw_parameters_m6ib.yaml
+++ b/fanuc_m6ib_support/config/opw_parameters_m6ib.yaml
@@ -16,5 +16,5 @@ opw_kinematics_geometric_parameters:
   c2: 0.600
   c3: 0.615
   c4: 0.10
-opw_kinematics_joint_offsets: [0.0, 0.0, -1.57079632679, 0.0, 0.0, 3.14159265359]
+opw_kinematics_joint_offsets: [0.0, 0.0, deg(-90.0), 0.0, 0.0, deg(180.0)]
 opw_kinematics_joint_sign_corrections: [1, 1, -1, -1, -1, -1]


### PR DESCRIPTION
As per subject.

`rosparam` supports a `deg(..)` conversion function which converts its argument to radians, even in `.yaml` files.

We can use this to spec OPW's joint offsets in degrees instead of radians.

For context, see JeroenDM/moveit_opw_kinematics_plugin#67.

`rosparam` documentation: [wiki/rosparam: YAML Format](http://wiki.ros.org/rosparam#YAML_Format).
