### PR TITLE
driver: disable attributes for now

### DIFF
--- a/fanuc_driver/.gitattributes
+++ b/fanuc_driver/.gitattributes
@@ -1,3 +1,3 @@
 # LS and Karel source files must have CRLF (ie: Windows) line-endings.
-*.kl text eol=crlf
-*.ls text eol=crlf
+#*.kl text eol=crlf
+#*.ls text eol=crlf


### PR DESCRIPTION
As per subject.

This will be re-enabled later in a follow-up PR.

No functional changes.
