### PR TITLE
Mark all IKFast plugins as deprecated

### DIFF
--- a/fanuc_lrmate200i_moveit_plugins/package.xml
+++ b/fanuc_lrmate200i_moveit_plugins/package.xml
@@ -36,6 +36,11 @@
   <depend>tf_conversions</depend>
 
   <export>
+    <deprecated>
+      All IKFast MoveIt plugins are deprecated and will be removed from future
+      releases. Where possible, they will be replaced with OPW Kinematics-based
+      plugins.
+    </deprecated>
     <moveit_core plugin="${prefix}/lrmate200i_kinematics/fanuc_lrmate200i_manipulator_moveit_ikfast_plugin_description.xml"/>
     <rosindex>
       <tags>

--- a/fanuc_lrmate200ib_moveit_plugins/package.xml
+++ b/fanuc_lrmate200ib_moveit_plugins/package.xml
@@ -36,6 +36,11 @@
   <depend>tf_conversions</depend>
 
   <export>
+    <deprecated>
+      All IKFast MoveIt plugins are deprecated and will be removed from future
+      releases. Where possible, they will be replaced with OPW Kinematics-based
+      plugins.
+    </deprecated>
     <moveit_core plugin="${prefix}/lrmate200ib_kinematics/fanuc_lrmate200ib_manipulator_moveit_ikfast_plugin_description.xml"/>
     <moveit_core plugin="${prefix}/lrmate200ib3l_kinematics/fanuc_lrmate200ib3l_manipulator_moveit_ikfast_plugin_description.xml"/>
     <rosindex>

--- a/fanuc_lrmate200ic_moveit_plugins/package.xml
+++ b/fanuc_lrmate200ic_moveit_plugins/package.xml
@@ -38,6 +38,11 @@
   <depend>tf_conversions</depend>
 
   <export>
+    <deprecated>
+      All IKFast MoveIt plugins are deprecated and will be removed from future
+      releases. Where possible, they will be replaced with OPW Kinematics-based
+      plugins.
+    </deprecated>
     <moveit_core plugin="${prefix}/lrmate200ic_kinematics/fanuc_lrmate200ic_manipulator_moveit_ikfast_plugin_description.xml"/>
     <moveit_core plugin="${prefix}/lrmate200ic5f_kinematics/fanuc_lrmate200ic5f_manipulator_moveit_ikfast_plugin_description.xml"/>
     <moveit_core plugin="${prefix}/lrmate200ic5h_kinematics/fanuc_lrmate200ic5h_manipulator_moveit_ikfast_plugin_description.xml"/>

--- a/fanuc_m10ia_moveit_plugins/package.xml
+++ b/fanuc_m10ia_moveit_plugins/package.xml
@@ -36,6 +36,11 @@
   <depend>tf_conversions</depend>
 
   <export>
+    <deprecated>
+      All IKFast MoveIt plugins are deprecated and will be removed from future
+      releases. Where possible, they will be replaced with OPW Kinematics-based
+      plugins.
+    </deprecated>
     <moveit_core plugin="${prefix}/m10ia_kinematics/fanuc_m10ia_manipulator_moveit_ikfast_plugin_description.xml"/>
     <rosindex>
       <tags>

--- a/fanuc_m16ib_moveit_plugins/package.xml
+++ b/fanuc_m16ib_moveit_plugins/package.xml
@@ -36,6 +36,11 @@
   <depend>tf_conversions</depend>
 
   <export>
+    <deprecated>
+      All IKFast MoveIt plugins are deprecated and will be removed from future
+      releases. Where possible, they will be replaced with OPW Kinematics-based
+      plugins.
+    </deprecated>
     <moveit_core plugin="${prefix}/m16ib20_kinematics/fanuc_m16ib20_manipulator_moveit_ikfast_plugin_description.xml"/>
     <rosindex>
       <tags>

--- a/fanuc_m20ia_moveit_plugins/package.xml
+++ b/fanuc_m20ia_moveit_plugins/package.xml
@@ -40,6 +40,11 @@
   <depend>tf_conversions</depend>
 
   <export>
+    <deprecated>
+      All IKFast MoveIt plugins are deprecated and will be removed from future
+      releases. Where possible, they will be replaced with OPW Kinematics-based
+      plugins.
+    </deprecated>
     <moveit_core plugin="${prefix}/m20ia_kinematics/fanuc_m20ia_manipulator_moveit_ikfast_plugin_description.xml"/>
     <moveit_core plugin="${prefix}/m20ia10l_kinematics/fanuc_m20ia10l_manipulator_moveit_ikfast_plugin_description.xml"/>
     <rosindex>

--- a/fanuc_m20ib_moveit_plugins/package.xml
+++ b/fanuc_m20ib_moveit_plugins/package.xml
@@ -37,6 +37,11 @@
   <depend>tf_conversions</depend>
 
   <export>
+    <deprecated>
+      All IKFast MoveIt plugins are deprecated and will be removed from future
+      releases. Where possible, they will be replaced with OPW Kinematics-based
+      plugins.
+    </deprecated>
     <moveit_core plugin="${prefix}/m20ib25_kinematics/fanuc_m20ib25_manipulator_moveit_ikfast_plugin_description.xml"/>
     <rosindex>
       <tags>

--- a/fanuc_m430ia_moveit_plugins/package.xml
+++ b/fanuc_m430ia_moveit_plugins/package.xml
@@ -36,6 +36,11 @@
   <depend>tf_conversions</depend>
 
   <export>
+    <deprecated>
+      All IKFast MoveIt plugins are deprecated and will be removed from future
+      releases. Where possible, they will be replaced with OPW Kinematics-based
+      plugins.
+    </deprecated>
     <moveit_core plugin="${prefix}/m430ia2f_kinematics/fanuc_m430ia2f_manipulator_moveit_ikfast_plugin_description.xml"/>
     <moveit_core plugin="${prefix}/m430ia2p_kinematics/fanuc_m430ia2p_manipulator_moveit_ikfast_plugin_description.xml"/>
     <rosindex>

--- a/fanuc_m6ib_moveit_plugins/package.xml
+++ b/fanuc_m6ib_moveit_plugins/package.xml
@@ -36,6 +36,11 @@
   <depend>tf_conversions</depend>
 
   <export>
+    <deprecated>
+      All IKFast MoveIt plugins are deprecated and will be removed from future
+      releases. Where possible, they will be replaced with OPW Kinematics-based
+      plugins.
+    </deprecated>
     <moveit_core plugin="${prefix}/m6ib_kinematics/fanuc_m6ib_manipulator_moveit_ikfast_plugin_description.xml"/>
     <rosindex>
       <tags>

--- a/fanuc_r1000ia_moveit_plugins/package.xml
+++ b/fanuc_r1000ia_moveit_plugins/package.xml
@@ -36,6 +36,11 @@
   <depend>tf_conversions</depend>
 
   <export>
+    <deprecated>
+      All IKFast MoveIt plugins are deprecated and will be removed from future
+      releases. Where possible, they will be replaced with OPW Kinematics-based
+      plugins.
+    </deprecated>
     <moveit_core plugin="${prefix}/r1000ia80f_kinematics/fanuc_r1000ia80f_manipulator_moveit_ikfast_plugin_description.xml"/>
     <rosindex>
       <tags>


### PR DESCRIPTION
As per subject.

They will be removed from the repository.

Moveit packages depending on them will be migrated to use an OPW Kinematics-based plugin in future PRs.
