### PR TITLE
Avoid CMake warnings on Noetic (bump min version)

### DIFF
--- a/fanuc/CMakeLists.txt
+++ b/fanuc/CMakeLists.txt
@@ -1,4 +1,4 @@
-cmake_minimum_required(VERSION 2.8.3)
+cmake_minimum_required(VERSION 3.0.2)
 project(fanuc)
 find_package(catkin REQUIRED)
 catkin_metapackage()

--- a/fanuc_cr35ia_support/CMakeLists.txt
+++ b/fanuc_cr35ia_support/CMakeLists.txt
@@ -1,4 +1,4 @@
-cmake_minimum_required(VERSION 2.8.3)
+cmake_minimum_required(VERSION 3.0.2)
 
 project(fanuc_cr35ia_support)
 

--- a/fanuc_cr7ia_moveit_config/CMakeLists.txt
+++ b/fanuc_cr7ia_moveit_config/CMakeLists.txt
@@ -1,4 +1,4 @@
-cmake_minimum_required(VERSION 2.8.3)
+cmake_minimum_required(VERSION 3.0.2)
 project(fanuc_cr7ia_moveit_config)
 
 find_package(catkin REQUIRED)

--- a/fanuc_cr7ia_support/CMakeLists.txt
+++ b/fanuc_cr7ia_support/CMakeLists.txt
@@ -1,4 +1,4 @@
-cmake_minimum_required(VERSION 2.8.3)
+cmake_minimum_required(VERSION 3.0.2)
 
 project(fanuc_cr7ia_support)
 

--- a/fanuc_cr7ial_moveit_config/CMakeLists.txt
+++ b/fanuc_cr7ial_moveit_config/CMakeLists.txt
@@ -1,4 +1,4 @@
-cmake_minimum_required(VERSION 2.8.3)
+cmake_minimum_required(VERSION 3.0.2)
 project(fanuc_cr7ial_moveit_config)
 
 find_package(catkin REQUIRED)

--- a/fanuc_driver/CMakeLists.txt
+++ b/fanuc_driver/CMakeLists.txt
@@ -1,4 +1,4 @@
-cmake_minimum_required(VERSION 2.8.3)
+cmake_minimum_required(VERSION 3.0.2)
 
 project(fanuc_driver)
 

--- a/fanuc_lrmate200i_moveit_config/CMakeLists.txt
+++ b/fanuc_lrmate200i_moveit_config/CMakeLists.txt
@@ -1,4 +1,4 @@
-cmake_minimum_required(VERSION 2.8.3)
+cmake_minimum_required(VERSION 3.0.2)
 project(fanuc_lrmate200i_moveit_config)
 
 find_package(catkin REQUIRED)

--- a/fanuc_lrmate200i_moveit_plugins/CMakeLists.txt
+++ b/fanuc_lrmate200i_moveit_plugins/CMakeLists.txt
@@ -1,4 +1,4 @@
-cmake_minimum_required(VERSION 2.8.3)
+cmake_minimum_required(VERSION 3.0.2)
 project(fanuc_lrmate200i_moveit_plugins)
 
 find_package(catkin REQUIRED COMPONENTS

--- a/fanuc_lrmate200i_support/CMakeLists.txt
+++ b/fanuc_lrmate200i_support/CMakeLists.txt
@@ -1,4 +1,4 @@
-cmake_minimum_required(VERSION 2.8.3)
+cmake_minimum_required(VERSION 3.0.2)
 
 project(fanuc_lrmate200i_support)
 

--- a/fanuc_lrmate200ib3l_moveit_config/CMakeLists.txt
+++ b/fanuc_lrmate200ib3l_moveit_config/CMakeLists.txt
@@ -1,4 +1,4 @@
-cmake_minimum_required(VERSION 2.8.3)
+cmake_minimum_required(VERSION 3.0.2)
 project(fanuc_lrmate200ib3l_moveit_config)
 
 find_package(catkin REQUIRED)

--- a/fanuc_lrmate200ib_moveit_config/CMakeLists.txt
+++ b/fanuc_lrmate200ib_moveit_config/CMakeLists.txt
@@ -1,4 +1,4 @@
-cmake_minimum_required(VERSION 2.8.3)
+cmake_minimum_required(VERSION 3.0.2)
 project(fanuc_lrmate200ib_moveit_config)
 
 find_package(catkin REQUIRED)

--- a/fanuc_lrmate200ib_moveit_plugins/CMakeLists.txt
+++ b/fanuc_lrmate200ib_moveit_plugins/CMakeLists.txt
@@ -1,4 +1,4 @@
-cmake_minimum_required(VERSION 2.8.3)
+cmake_minimum_required(VERSION 3.0.2)
 project(fanuc_lrmate200ib_moveit_plugins)
 
 find_package(catkin REQUIRED COMPONENTS

--- a/fanuc_lrmate200ib_support/CMakeLists.txt
+++ b/fanuc_lrmate200ib_support/CMakeLists.txt
@@ -1,4 +1,4 @@
-cmake_minimum_required(VERSION 2.8.3)
+cmake_minimum_required(VERSION 3.0.2)
 
 project(fanuc_lrmate200ib_support)
 

--- a/fanuc_lrmate200ic5h_moveit_config/CMakeLists.txt
+++ b/fanuc_lrmate200ic5h_moveit_config/CMakeLists.txt
@@ -1,4 +1,4 @@
-cmake_minimum_required(VERSION 2.8.3)
+cmake_minimum_required(VERSION 3.0.2)
 project(fanuc_lrmate200ic5h_moveit_config)
 
 find_package(catkin REQUIRED)

--- a/fanuc_lrmate200ic5l_moveit_config/CMakeLists.txt
+++ b/fanuc_lrmate200ic5l_moveit_config/CMakeLists.txt
@@ -1,4 +1,4 @@
-cmake_minimum_required(VERSION 2.8.3)
+cmake_minimum_required(VERSION 3.0.2)
 project(fanuc_lrmate200ic5l_moveit_config)
 
 find_package(catkin REQUIRED)

--- a/fanuc_lrmate200ic_moveit_config/CMakeLists.txt
+++ b/fanuc_lrmate200ic_moveit_config/CMakeLists.txt
@@ -1,4 +1,4 @@
-cmake_minimum_required(VERSION 2.8.3)
+cmake_minimum_required(VERSION 3.0.2)
 project(fanuc_lrmate200ic_moveit_config)
 
 find_package(catkin REQUIRED)

--- a/fanuc_lrmate200ic_moveit_plugins/CMakeLists.txt
+++ b/fanuc_lrmate200ic_moveit_plugins/CMakeLists.txt
@@ -1,4 +1,4 @@
-cmake_minimum_required(VERSION 2.8.3)
+cmake_minimum_required(VERSION 3.0.2)
 project(fanuc_lrmate200ic_moveit_plugins)
 
 find_package(catkin REQUIRED COMPONENTS

--- a/fanuc_lrmate200ic_support/CMakeLists.txt
+++ b/fanuc_lrmate200ic_support/CMakeLists.txt
@@ -1,4 +1,4 @@
-cmake_minimum_required(VERSION 2.8.3)
+cmake_minimum_required(VERSION 3.0.2)
 
 project(fanuc_lrmate200ic_support)
 

--- a/fanuc_m10ia_moveit_config/CMakeLists.txt
+++ b/fanuc_m10ia_moveit_config/CMakeLists.txt
@@ -1,4 +1,4 @@
-cmake_minimum_required(VERSION 2.8.3)
+cmake_minimum_required(VERSION 3.0.2)
 project(fanuc_m10ia_moveit_config)
 
 find_package(catkin REQUIRED)

--- a/fanuc_m10ia_moveit_plugins/CMakeLists.txt
+++ b/fanuc_m10ia_moveit_plugins/CMakeLists.txt
@@ -1,4 +1,4 @@
-cmake_minimum_required(VERSION 2.8.3)
+cmake_minimum_required(VERSION 3.0.2)
 project(fanuc_m10ia_moveit_plugins)
 
 find_package(catkin REQUIRED COMPONENTS

--- a/fanuc_m10ia_support/CMakeLists.txt
+++ b/fanuc_m10ia_support/CMakeLists.txt
@@ -1,4 +1,4 @@
-cmake_minimum_required(VERSION 2.8.3)
+cmake_minimum_required(VERSION 3.0.2)
 
 project(fanuc_m10ia_support)
 

--- a/fanuc_m16ib20_moveit_config/CMakeLists.txt
+++ b/fanuc_m16ib20_moveit_config/CMakeLists.txt
@@ -1,4 +1,4 @@
-cmake_minimum_required(VERSION 2.8.3)
+cmake_minimum_required(VERSION 3.0.2)
 project(fanuc_m16ib20_moveit_config)
 
 find_package(catkin REQUIRED)

--- a/fanuc_m16ib_moveit_plugins/CMakeLists.txt
+++ b/fanuc_m16ib_moveit_plugins/CMakeLists.txt
@@ -1,4 +1,4 @@
-cmake_minimum_required(VERSION 2.8.3)
+cmake_minimum_required(VERSION 3.0.2)
 project(fanuc_m16ib_moveit_plugins)
 
 find_package(catkin REQUIRED COMPONENTS

--- a/fanuc_m16ib_support/CMakeLists.txt
+++ b/fanuc_m16ib_support/CMakeLists.txt
@@ -1,4 +1,4 @@
-cmake_minimum_required(VERSION 2.8.3)
+cmake_minimum_required(VERSION 3.0.2)
 
 project(fanuc_m16ib_support)
 

--- a/fanuc_m20ia10l_moveit_config/CMakeLists.txt
+++ b/fanuc_m20ia10l_moveit_config/CMakeLists.txt
@@ -1,4 +1,4 @@
-cmake_minimum_required(VERSION 2.8.3)
+cmake_minimum_required(VERSION 3.0.2)
 project(fanuc_m20ia10l_moveit_config)
 
 find_package(catkin REQUIRED)

--- a/fanuc_m20ia_moveit_config/CMakeLists.txt
+++ b/fanuc_m20ia_moveit_config/CMakeLists.txt
@@ -1,4 +1,4 @@
-cmake_minimum_required(VERSION 2.8.3)
+cmake_minimum_required(VERSION 3.0.2)
 project(fanuc_m20ia_moveit_config)
 
 find_package(catkin REQUIRED)

--- a/fanuc_m20ia_moveit_plugins/CMakeLists.txt
+++ b/fanuc_m20ia_moveit_plugins/CMakeLists.txt
@@ -1,4 +1,4 @@
-cmake_minimum_required(VERSION 2.8.3)
+cmake_minimum_required(VERSION 3.0.2)
 project(fanuc_m20ia_moveit_plugins)
 
 find_package(catkin REQUIRED COMPONENTS

--- a/fanuc_m20ia_support/CMakeLists.txt
+++ b/fanuc_m20ia_support/CMakeLists.txt
@@ -1,4 +1,4 @@
-cmake_minimum_required(VERSION 2.8.3)
+cmake_minimum_required(VERSION 3.0.2)
 
 project(fanuc_m20ia_support)
 

--- a/fanuc_m20ib25_moveit_config/CMakeLists.txt
+++ b/fanuc_m20ib25_moveit_config/CMakeLists.txt
@@ -1,4 +1,4 @@
-cmake_minimum_required(VERSION 2.8.3)
+cmake_minimum_required(VERSION 3.0.2)
 project(fanuc_m20ib25_moveit_config)
 
 find_package(catkin REQUIRED)

--- a/fanuc_m20ib_support/CMakeLists.txt
+++ b/fanuc_m20ib_support/CMakeLists.txt
@@ -1,4 +1,4 @@
-cmake_minimum_required(VERSION 2.8.3)
+cmake_minimum_required(VERSION 3.0.2)
 
 project(fanuc_m20ib_support)
 

--- a/fanuc_m430ia2f_moveit_config/CMakeLists.txt
+++ b/fanuc_m430ia2f_moveit_config/CMakeLists.txt
@@ -1,4 +1,4 @@
-cmake_minimum_required(VERSION 2.8.3)
+cmake_minimum_required(VERSION 3.0.2)
 project(fanuc_m430ia2f_moveit_config)
 
 find_package(catkin REQUIRED)

--- a/fanuc_m430ia2p_moveit_config/CMakeLists.txt
+++ b/fanuc_m430ia2p_moveit_config/CMakeLists.txt
@@ -1,4 +1,4 @@
-cmake_minimum_required(VERSION 2.8.3)
+cmake_minimum_required(VERSION 3.0.2)
 project(fanuc_m430ia2p_moveit_config)
 
 find_package(catkin REQUIRED)

--- a/fanuc_m430ia_moveit_plugins/CMakeLists.txt
+++ b/fanuc_m430ia_moveit_plugins/CMakeLists.txt
@@ -1,4 +1,4 @@
-cmake_minimum_required(VERSION 2.8.3)
+cmake_minimum_required(VERSION 3.0.2)
 project(fanuc_m430ia_moveit_plugins)
 
 find_package(catkin REQUIRED COMPONENTS

--- a/fanuc_m430ia_support/CMakeLists.txt
+++ b/fanuc_m430ia_support/CMakeLists.txt
@@ -1,4 +1,4 @@
-cmake_minimum_required(VERSION 2.8.3)
+cmake_minimum_required(VERSION 3.0.2)
 
 project(fanuc_m430ia_support)
 

--- a/fanuc_m6ib6s_moveit_config/CMakeLists.txt
+++ b/fanuc_m6ib6s_moveit_config/CMakeLists.txt
@@ -1,4 +1,4 @@
-cmake_minimum_required(VERSION 2.8.3)
+cmake_minimum_required(VERSION 3.0.2)
 project(fanuc_m6ib6s_moveit_config)
 
 find_package(catkin REQUIRED)

--- a/fanuc_m6ib_moveit_config/CMakeLists.txt
+++ b/fanuc_m6ib_moveit_config/CMakeLists.txt
@@ -1,4 +1,4 @@
-cmake_minimum_required(VERSION 2.8.3)
+cmake_minimum_required(VERSION 3.0.2)
 project(fanuc_m6ib_moveit_config)
 
 find_package(catkin REQUIRED)

--- a/fanuc_m6ib_moveit_plugins/CMakeLists.txt
+++ b/fanuc_m6ib_moveit_plugins/CMakeLists.txt
@@ -1,4 +1,4 @@
-cmake_minimum_required(VERSION 2.8.3)
+cmake_minimum_required(VERSION 3.0.2)
 project(fanuc_m6ib_moveit_plugins)
 
 find_package(catkin REQUIRED COMPONENTS

--- a/fanuc_m6ib_support/CMakeLists.txt
+++ b/fanuc_m6ib_support/CMakeLists.txt
@@ -1,4 +1,4 @@
-cmake_minimum_required(VERSION 2.8.3)
+cmake_minimum_required(VERSION 3.0.2)
 
 project(fanuc_m6ib_support)
 

--- a/fanuc_m710ic_support/CMakeLists.txt
+++ b/fanuc_m710ic_support/CMakeLists.txt
@@ -1,4 +1,4 @@
-cmake_minimum_required(VERSION 2.8.3)
+cmake_minimum_required(VERSION 3.0.2)
 
 project(fanuc_m710ic_support)
 

--- a/fanuc_m900ia_support/CMakeLists.txt
+++ b/fanuc_m900ia_support/CMakeLists.txt
@@ -1,4 +1,4 @@
-cmake_minimum_required(VERSION 2.8.3)
+cmake_minimum_required(VERSION 3.0.2)
 
 project(fanuc_m900ia_support)
 

--- a/fanuc_m900ib_support/CMakeLists.txt
+++ b/fanuc_m900ib_support/CMakeLists.txt
@@ -1,4 +1,4 @@
-cmake_minimum_required(VERSION 2.8.3)
+cmake_minimum_required(VERSION 3.0.2)
 
 project(fanuc_m900ib_support)
 

--- a/fanuc_r1000ia80f_moveit_config/CMakeLists.txt
+++ b/fanuc_r1000ia80f_moveit_config/CMakeLists.txt
@@ -1,4 +1,4 @@
-cmake_minimum_required(VERSION 2.8.3)
+cmake_minimum_required(VERSION 3.0.2)
 project(fanuc_r1000ia80f_moveit_config)
 
 find_package(catkin REQUIRED)

--- a/fanuc_r1000ia_moveit_plugins/CMakeLists.txt
+++ b/fanuc_r1000ia_moveit_plugins/CMakeLists.txt
@@ -1,4 +1,4 @@
-cmake_minimum_required(VERSION 2.8.3)
+cmake_minimum_required(VERSION 3.0.2)
 project(fanuc_r1000ia_moveit_plugins)
 
 find_package(catkin REQUIRED COMPONENTS

--- a/fanuc_r1000ia_support/CMakeLists.txt
+++ b/fanuc_r1000ia_support/CMakeLists.txt
@@ -1,4 +1,4 @@
-cmake_minimum_required(VERSION 2.8.3)
+cmake_minimum_required(VERSION 3.0.2)
 
 project(fanuc_r1000ia_support)
 

--- a/fanuc_resources/CMakeLists.txt
+++ b/fanuc_resources/CMakeLists.txt
@@ -1,4 +1,4 @@
-cmake_minimum_required(VERSION 2.8.3)
+cmake_minimum_required(VERSION 3.0.2)
 
 project(fanuc_resources)
 


### PR DESCRIPTION
As per subject.

This isn't required for Kinetic nor Melodic, but is compatible with CMake on the OS supported by those versions of ROS _and_ prevents CMake on Focal (and other up-to-date OS) from complaining about `CMP0048` during build.
