### PR TITLE
moveit_cfgs: use 'xacro' instead of 'xacro.py'

### DIFF
--- a/moveit_cfgs/fanuc_lrmate200i_moveit_config/launch/planning_context.launch
+++ b/moveit_cfgs/fanuc_lrmate200i_moveit_config/launch/planning_context.launch
@@ -6,7 +6,7 @@
   <arg name="robot_description" default="robot_description"/>
 
   <!-- Load universal robot description format (URDF) -->
-  <param if="$(arg load_robot_description)" name="$(arg robot_description)" command="$(find xacro)/xacro.py --inorder '$(find fanuc_lrmate200i_support)/urdf/lrmate200i.xacro'"/>
+  <param if="$(arg load_robot_description)" name="$(arg robot_description)" command="$(find xacro)/xacro --inorder '$(find fanuc_lrmate200i_support)/urdf/lrmate200i.xacro'"/>
 
   <!-- The semantic description that corresponds to the URDF -->
   <param name="$(arg robot_description)_semantic" textfile="$(find fanuc_lrmate200i_moveit_config)/config/fanuc_lrmate200i.srdf" />


### PR DESCRIPTION
This fixes a use of the deprecated xacro.py. See also https://github.com/ros-industrial/fanuc/issues/195.

This issue is causing "catkin test" to fail in recent ROS1 distros:

```
Invalid <param> tag: Cannot load command parameter [robot_description]: no such command [['/opt/ros/noetic/share/xacro/xacro.py', '--inorder', '/home/user/catkin_ws/src/fanuc/fanuc_lrmate200i_support/urdf/lrmate200i.xacro']]. 

Param xml is <param if="$(arg load_robot_description)" name="$(arg robot_description)" command="$(find xacro)/xacro.py --inorder '$(find fanuc_lrmate200i_support)/urdf/lrmate200i.xacro'"/
```