### PR TITLE
ci: don't build `industrial_core` anymore

### DIFF
--- a/.github/workflows/ci_bionic.yml
+++ b/.github/workflows/ci_bionic.yml
@@ -24,7 +24,6 @@ jobs:
       CCACHE_DIR: "${{ github.workspace }}/.ccache"
       CATKIN_LINT: "true"
       CATKIN_LINT_ARGS: --ignore launch_depend
-      UPSTREAM_WORKSPACE: 'github:ros-industrial/industrial_core#melodic'
 
     steps:
       - name: Fetch repository


### PR DESCRIPTION
As per title.

Is available as a released package, so no need.
